### PR TITLE
fixed invalid JSON example in the 'Getting Started' page

### DIFF
--- a/src/docs/asciidoc/start/index.adoc
+++ b/src/docs/asciidoc/start/index.adoc
@@ -335,12 +335,12 @@ The card content is :
 	        "start" : 1553186770681
         },
         {
-            "start" : 1553186780681
+            "start" : 1553186780681,
             "end" : 1553186790681
         },
         {
-            "start" : 1553186800681
-            "end" : 1553186810681
+            "start" : 1553186800681,
+            "end" : 1553186810681,
             "display" : "BUBBLE"
         }
 	]
@@ -435,7 +435,7 @@ As in the card, we define several keys, one for the title: `defaultProcess.title
 
 ==== Template
 
-In the `template` folder, as we have two `i18n` we need to create two folders, `en` and `fr`. 
+In the `template` folder, as we have two `i18n` we need to create two folders, `en` and `fr`.
 In each folder we create a file named `template.handlebars` containing:
 
 - `en/template.handlebars`


### PR DESCRIPTION
Signed-off-by: Damien JEANDEMANGE <damien.jeandemange@rte-france.com>

*Please check if the PR fulfills these requirements* _(please use `&#39;[x]&#39;` to check the boxes, or submit the PR and then click the checkboxes)_

* [x] The commit message follows our guidelines
* [x] Docs have been added / updated (for bug fixes / features)

*Does this PR already have an issue describing the problem ?* _NO_

*What kind of change does this PR introduce?* _doc update_

*What is the current behavior?* _Cannot push card in the GettingStarted tutorial_

*What is the new behavior (if this is a feature change)?* _Card JSON example is now usable in the GettingStarted tutorial_

*Does this PR introduce a breaking change?* _NO_
