### PR TITLE
[OC-474] Hide and display action buttons

### DIFF
--- a/ui/main/src/app/modules/cards/components/card/card.component.html
+++ b/ui/main/src/app/modules/cards/components/card/card.component.html
@@ -15,15 +15,17 @@
             <p *ngIf="this.dateToDisplay" class="card-subtitle">({{this.dateToDisplay}})</p>
         </div>
     </div>
-    <div class="d-flex card-body p-0 border-0" *ngIf="open">
-        <div class="badge-border rounded-bottom-left bg-sev-{{lightCard.severity.toString()|lowercase}} col-1"></div>
-        <div class="card-text p-1" translate [translateParams]="lightCard.summary.parameters">
-            {{i18nPrefix + lightCard.summary.key}}
-            <div>
-                <of-action *ngFor="let action of getActions()" [action]="action" [i18nPrefix]="i18nPrefix"
-                           [actionUrlPath]="actionsUrlPath"
-                [lightCardId]="lightCard.id"
-                ></of-action>
+    <div class="d-flex card-body p-0 border-0">
+        <div *ngIf="open" class="badge-border rounded-bottom-left bg-sev-{{lightCard.severity.toString()|lowercase}} col-1"></div>
+        <div class="card-text p-1" *ngIf="open || actionsAppear">
+            <div *ngIf="open" translate [translateParams]="lightCard.summary.parameters">{{i18nPrefix + lightCard.summary.key}}</div>
+            <div *ngIf="actionsAppear">
+                <of-action *ngFor="let action of getActions()"
+                    [action]="action"
+                    [i18nPrefix]="i18nPrefix"
+                    [actionUrlPath]="actionsUrlPath"
+                    [lightCardId]="lightCard.id">
+                </of-action>
             </div>
         </div>
     </div>

--- a/ui/main/src/app/modules/cards/components/card/card.component.spec.ts
+++ b/ui/main/src/app/modules/cards/components/card/card.component.spec.ts
@@ -10,21 +10,22 @@ import {async, ComponentFixture, getTestBed, TestBed} from '@angular/core/testin
 
 import {CardComponent} from './card.component';
 import {getOneRandomLigthCard, getRandomAlphanumericValue} from '@tests/helpers';
-import {RouterTestingModule} from "@angular/router/testing";
-import {TranslateLoader, TranslateModule, TranslateService} from "@ngx-translate/core";
-import {Store, StoreModule} from "@ngrx/store";
-import {appReducer, AppState} from "@ofStore/index";
-import {HttpClientTestingModule} from "@angular/common/http/testing";
-import {ThirdsI18nLoaderFactory, ThirdsService} from "@ofServices/thirds.service";
-import {ServicesModule} from "@ofServices/services.module";
-import {Router} from "@angular/router";
+import {RouterTestingModule} from '@angular/router/testing';
+import {TranslateLoader, TranslateModule, TranslateService} from '@ngx-translate/core';
+import {Store, StoreModule} from '@ngrx/store';
+import {appReducer, AppState} from '@ofStore/index';
+import {HttpClientTestingModule} from '@angular/common/http/testing';
+import {ThirdsI18nLoaderFactory, ThirdsService} from '@ofServices/thirds.service';
+import {ServicesModule} from '@ofServices/services.module';
+import {Router} from '@angular/router';
 import 'moment/locale/fr';
-import {TimeService} from "@ofServices/time.service";
-import {I18nService} from "@ofServices/i18n.service";
-import {ActionComponent} from "../action/action.component";
-import {NgbModule} from "@ng-bootstrap/ng-bootstrap";
+import {TimeService} from '@ofServices/time.service';
+import {I18nService} from '@ofServices/i18n.service';
+import {ActionComponent} from '../action/action.component';
+import {NgbModule} from '@ng-bootstrap/ng-bootstrap';
 import SpyObj = jasmine.SpyObj;
 import createSpyObj = jasmine.createSpyObj;
+import { AddActionsAppear } from '@ofStore/actions/card.actions';
 
 describe('CardComponent', () => {
     let lightCardDetailsComp: CardComponent;
@@ -52,27 +53,26 @@ describe('CardComponent', () => {
                     },
                     useDefaultLang: false
                 }),
-            NgbModule],
-            declarations: [CardComponent,ActionComponent],
-            providers: [{provide: store, useClass: Store},
+                NgbModule
+            ],
+            declarations: [CardComponent, ActionComponent],
+            providers: [
+                {provide: store, useClass: Store},
                 {provide: Router, useValue: routerSpy},
                 ThirdsService,
-                {provide:'TimeEventSource',useValue:null},
-                TimeService,I18nService]
-        })
-            .compileComponents();
+                {provide: 'TimeEventSource', useValue: null},
+                TimeService, I18nService
+            ]}).compileComponents();
         store = TestBed.get(Store);
         spyOn(store, 'dispatch').and.callThrough();
         // avoid exceptions during construction and init of the component
-
-
-        injector=getTestBed();
+        injector = getTestBed();
         translateService = injector.get(TranslateService);
-        translateService.addLangs(["en", "fr"]);
-        translateService.setDefaultLang("en");
+        translateService.addLangs(['en', 'fr']);
+        translateService.setDefaultLang('en');
         // translateService.use("en");
         i18nService = injector.get(I18nService);
-        i18nService.changeLocale('en',"Europe/Paris");
+        i18nService.changeLocale('en', 'Europe/Paris');
 
     }));
 
@@ -81,10 +81,8 @@ describe('CardComponent', () => {
         lightCardDetailsComp = fixture.debugElement.componentInstance;
         router = TestBed.get(Router);
     });
-
     it('should create and display minimal light card information', () => {
         const lightCard = getOneRandomLigthCard();
-
         // extract expected data
         const id = lightCard.id;
         const uid = lightCard.uid;
@@ -97,10 +95,8 @@ describe('CardComponent', () => {
 
         fixture.detectChanges();
 
-        expect(fixture.nativeElement.querySelector('.card-title').innerText)
-            .toEqual(publisher+'.'+version+'.'+title);
-        expect(fixture.nativeElement.querySelector('.card-body > p'))
-            .toBeFalsy();
+        expect(fixture.nativeElement.querySelector('.card-title').innerText).toEqual(publisher + '.' + version + '.' + title);
+        expect(fixture.nativeElement.querySelector('.card-body > p')).toBeFalsy();
     });
     it('should select card', () => {
         const lightCard = getOneRandomLigthCard();
@@ -108,12 +104,23 @@ describe('CardComponent', () => {
         router.navigate.and.callThrough();
 
         lightCardDetailsComp.lightCard = lightCard;
-        lightCardDetailsComp.ngOnInit()
+        lightCardDetailsComp.ngOnInit();
         fixture.detectChanges();
 
         expect(lightCardDetailsComp.open).toBeFalsy();
         lightCardDetailsComp.select();
-        expect(router.navigate).toHaveBeenCalledWith(['/'+lightCardDetailsComp.currentPath,'cards',lightCard.id]);
+        expect(router.navigate).toHaveBeenCalledWith(['/' + lightCardDetailsComp.currentPath, 'cards', lightCard.id]);
+    });
+    it('should select card and set the appear array', () => {
+        const lightCard = getOneRandomLigthCard();
+        lightCardDetailsComp.lightCard = lightCard;
+        lightCardDetailsComp.ngOnInit();
+        fixture.detectChanges();
+
+        expect(lightCardDetailsComp.open).toBeFalsy();
+        lightCardDetailsComp.select();
+        expect(store.dispatch).toHaveBeenCalled();
+        expect(store.dispatch).toHaveBeenCalledWith(new AddActionsAppear(lightCard.id));
     });
 
     it('should handle non existent timestamp with an empty string', () => {
@@ -122,27 +129,27 @@ describe('CardComponent', () => {
     });
 
     it( 'should handle timestamp in English', () => {
-        i18nService.changeLocale('en',"Europe/Paris");
+        i18nService.changeLocale('en', 'Europe/Paris');
         const timeStampFor5June2019at10AM = 1559721600000;
         const FiveJune2019at10AMDateString = lightCardDetailsComp.handleDate(timeStampFor5June2019at10AM);
         expect(FiveJune2019at10AMDateString).toEqual('06/05/2019 10:00 AM');
         });
 
     it( 'should handle timestamp in French', () => {
-        i18nService.changeLocale('fr',"Europe/Paris");
+        i18nService.changeLocale('fr', 'Europe/Paris');
         const timeStampFor5June2019at10AM = 1559721600000;
         const FiveJune2019at10AMDateString = lightCardDetailsComp.handleDate(timeStampFor5June2019at10AM);
         expect(FiveJune2019at10AMDateString).toEqual('05/06/2019 10:00');
         });
 
-    it('should return an empty string if NONE is configured', () =>{
+    it('should return an empty string if NONE is configured', () => {
         const lightCard = getOneRandomLigthCard();
-        const expectedEmptyDisplayedDate = lightCardDetailsComp.computeDisplayedDates('NONE',lightCard);
+        const expectedEmptyDisplayedDate = lightCardDetailsComp.computeDisplayedDates('NONE', lightCard);
         expect(expectedEmptyDisplayedDate).toEqual('');
         });
-    it('should return interval if BUSINESS is configured', () =>{
+    it('should return interval if BUSINESS is configured', () => {
         const lightCard = getOneRandomLigthCard();
-        const expectedBuisnessInterval = lightCardDetailsComp.computeDisplayedDates('BUSINESS',lightCard);
+        const expectedBuisnessInterval = lightCardDetailsComp.computeDisplayedDates('BUSINESS', lightCard);
         verifyCorrectInterval(expectedBuisnessInterval);
     });
 
@@ -160,32 +167,31 @@ describe('CardComponent', () => {
         expect(testedLength).toBeLessThanOrEqual(max);
     }
 
-    it('should return interval if there is no configuration', () =>{
+    it('should return interval if there is no configuration', () => {
         const lightCard = getOneRandomLigthCard();
-        const expectedBusinessInterVal = lightCardDetailsComp.computeDisplayedDates(undefined,lightCard);
+        const expectedBusinessInterVal = lightCardDetailsComp.computeDisplayedDates(undefined, lightCard);
         verifyCorrectInterval(expectedBusinessInterVal);
     });
 
-    it('should return interval with unexpected configuration', () =>{
+    it('should return interval with unexpected configuration', () => {
         const lightCard = getOneRandomLigthCard();
-        const expectedBusinessInterVal = lightCardDetailsComp.computeDisplayedDates(getRandomAlphanumericValue(12)
-            ,lightCard);
+        const expectedBusinessInterVal = lightCardDetailsComp.computeDisplayedDates(getRandomAlphanumericValue(12), lightCard);
         verifyCorrectInterval(expectedBusinessInterVal);
     });
 
     it( 'should return a single date with LTTD configuration', () => {
-       const expectDate = lightCardDetailsComp.computeDisplayedDates('LTTD',getOneRandomLigthCard());
-       verifyCorrectString(expectDate,18,20);
+       const expectDate = lightCardDetailsComp.computeDisplayedDates('LTTD', getOneRandomLigthCard());
+       verifyCorrectString(expectDate, 18, 20);
     });
 
     it( 'should return a single date with BUSINESS_START configuration', () => {
-        const expectDate = lightCardDetailsComp.computeDisplayedDates('BUSINESS_START',getOneRandomLigthCard());
-        verifyCorrectString(expectDate,18,20);
+        const expectDate = lightCardDetailsComp.computeDisplayedDates('BUSINESS_START', getOneRandomLigthCard());
+        verifyCorrectString(expectDate, 18, 20);
     });
 
     it( 'should return a single date with PUBLICATION configuration', () => {
-        const expectDate = lightCardDetailsComp.computeDisplayedDates('PUBLICATION',getOneRandomLigthCard());
-        verifyCorrectString(expectDate,18,20);
+        const expectDate = lightCardDetailsComp.computeDisplayedDates('PUBLICATION', getOneRandomLigthCard());
+        verifyCorrectString(expectDate, 18, 20);
     });
 
 });

--- a/ui/main/src/app/modules/cards/components/card/card.component.ts
+++ b/ui/main/src/app/modules/cards/components/card/card.component.ts
@@ -11,12 +11,14 @@ import {Router} from '@angular/router';
 import {selectCurrentUrl} from '@ofStore/selectors/router.selectors';
 import {Store} from '@ngrx/store';
 import {AppState} from '@ofStore/index';
-import {map, takeUntil} from "rxjs/operators";
-import {buildConfigSelector} from "@ofSelectors/config.selectors";
-import {TranslateService} from "@ngx-translate/core";
-import {TimeService} from "@ofServices/time.service";
-import {Action} from "@ofModel/thirds.model";
-import {Subject} from "rxjs";
+import {map, takeUntil} from 'rxjs/operators';
+import {buildConfigSelector} from '@ofSelectors/config.selectors';
+import {TranslateService} from '@ngx-translate/core';
+import {TimeService} from '@ofServices/time.service';
+import {Action} from '@ofModel/thirds.model';
+import {Subject} from 'rxjs';
+import { AddActionsAppear } from '@ofStore/actions/card.actions';
+import { selectCardActionsAppearState } from '@ofStore/selectors/card.selectors';
 
 @Component({
     selector: 'of-card',
@@ -32,6 +34,7 @@ export class CardComponent implements OnInit, OnDestroy {
     dateToDisplay: string;
     actionsUrlPath: string;
     private actions: Action[];
+    actionsAppear = false;
 
     private ngUnsubscribe: Subject<void> = new Subject<void>();
 
@@ -59,6 +62,13 @@ export class CardComponent implements OnInit, OnDestroy {
             .subscribe(computedDate => this.dateToDisplay = computedDate);
 
         this.actionsUrlPath = `/publisher/${card.publisher}/process/${card.processId}/states/${card.state}/actions`;
+        // check if the current card is in the store
+        this.store.select(selectCardActionsAppearState).subscribe(d => {
+            const currentSelected = card.id;
+            if (d.includes(currentSelected)) {
+                this.actionsAppear = true;
+            }
+        });
     }
 
     computeDisplayedDates(config: string, lightCard: LightCard): string {
@@ -81,6 +91,7 @@ export class CardComponent implements OnInit, OnDestroy {
     }
 
     public select() {
+        this.store.dispatch(new AddActionsAppear(this.lightCard.id));
         this.router.navigate(['/' + this.currentPath, 'cards', this.lightCard.id]);
     }
 

--- a/ui/main/src/app/modules/feed/components/card-list/card-list.component.ts
+++ b/ui/main/src/app/modules/feed/components/card-list/card-list.component.ts
@@ -5,23 +5,37 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import {Component, Input} from '@angular/core';
+import {Component, Input, OnInit} from '@angular/core';
 import {LightCard} from '@ofModel/light-card.model';
 import {Observable} from 'rxjs';
 import { ResizableComponent } from 'app/modules/utilities/components/resizable/resizable.component';
+import { Store } from '@ngrx/store';
+import { AppState } from '@ofStore/index';
+import { selectCurrentUrl } from '@ofStore/selectors/router.selectors';
+import { AddActionsAppear } from '@ofStore/actions/card.actions';
 
 @Component({
   selector: 'of-card-list',
   templateUrl: './card-list.component.html',
   styleUrls: ['./card-list.component.scss']
 })
-export class CardListComponent extends ResizableComponent {
+export class CardListComponent extends ResizableComponent implements OnInit {
 
   @Input() public lightCards: LightCard[];
   @Input() public selection: Observable<string>;
 
-  constructor() {
+  constructor(private store: Store<AppState>) {
     super();
   }
 
+  ngOnInit(): void {
+    this.store.select(selectCurrentUrl).subscribe(url => {
+      if (url) {
+          const urlParts = url.split('/');
+          if (urlParts[3]) {
+              this.store.dispatch(new AddActionsAppear(urlParts[3]));
+          }
+      }
+    });
+  }
 }

--- a/ui/main/src/app/store/actions/card.actions.ts
+++ b/ui/main/src/app/store/actions/card.actions.ts
@@ -16,7 +16,8 @@ export enum CardActionTypes {
     LoadArchivedCard = '[Card] Load Archived Card',
     LoadArchivedCardSuccess = '[Card] Load Archived Card Success',
     LoadArchivedCardFailure = '[Card] Load Archived Card Fail',
-    HandleUnexpectedError = '[Card] Handle unexpected error related to card issue'
+    HandleUnexpectedError = '[Card] Handle unexpected error related to card issue',
+    AddActionsAppear = '[Card] Add Actions Appear'
 }
 // needed by NGRX entities
 export class ClearCard implements Action {
@@ -70,12 +71,18 @@ export class HandleUnexpectedError implements Action {
     constructor(public payload: {error: Error}) {}
 }
 
-export type CardActions =
-    ClearCard
+export class AddActionsAppear implements Action {
+    readonly type = CardActionTypes.AddActionsAppear;
+    /* istanbul ignore next */
+    constructor(public payload: string) {}
+}
+
+export type CardActions = ClearCard
     | LoadCard
     | LoadCardSuccess
     | LoadCardFailure
     | LoadArchivedCard
     | LoadArchivedCardSuccess
     | LoadArchivedCardFailure
-    | HandleUnexpectedError;
+    | HandleUnexpectedError
+    | AddActionsAppear;

--- a/ui/main/src/app/store/effects/card-operation.effects.spec.ts
+++ b/ui/main/src/app/store/effects/card-operation.effects.spec.ts
@@ -7,16 +7,16 @@
 
 import {Actions} from '@ngrx/effects';
 import {hot} from 'jasmine-marbles';
-import {Store} from "@ngrx/store";
-import {AppState} from "@ofStore/index";
-import {CardOperationEffects} from "@ofEffects/card-operation.effects";
-import {LoadLightCardsSuccess} from "@ofActions/light-card.actions";
-import {getOneRandomLigthCard, getRandomIndex, getSeveralRandomLightCards} from "@tests/helpers";
-import {CardService} from "@ofServices/card.service";
-import {LoadCard} from "@ofActions/card.actions";
-import {MockStore, provideMockStore} from "@ngrx/store/testing";
-import {provideMockActions} from "@ngrx/effects/testing";
-import {Observable} from "rxjs";
+import {Store} from '@ngrx/store';
+import {AppState} from '@ofStore/index';
+import {CardOperationEffects} from '@ofEffects/card-operation.effects';
+import {LoadLightCardsSuccess} from '@ofActions/light-card.actions';
+import {getOneRandomLigthCard, getRandomIndex, getSeveralRandomLightCards} from '@tests/helpers';
+import {CardService} from '@ofServices/card.service';
+import {LoadCard} from '@ofActions/card.actions';
+import {MockStore, provideMockStore} from '@ngrx/store/testing';
+import {provideMockActions} from '@ngrx/effects/testing';
+import {Observable} from 'rxjs';
 import {async, TestBed} from '@angular/core/testing';
 import SpyObj = jasmine.SpyObj;
 
@@ -61,14 +61,15 @@ describe('CardOperationEffects', () => {
                 card: {
                     selected: selectedLightCard,
                     loading: false,
-                    error: null
+                    error: null,
+                    actionsAppear: []
                 }
-            })
+            });
 
             const localActions$ = new Actions(hot('-a-', {a: new LoadLightCardsSuccess({lightCards: severalRandomLightCards})}));
 
             const expectedAction = new LoadCard({id: selectedLightCard.id});
-            //const localExpected = hot('--b', {b: expectedAction});
+            // const localExpected = hot('--b', {b: expectedAction});
 
             const localExpected = hot('-b-', {b: expectedAction});
 
@@ -89,18 +90,19 @@ describe('CardOperationEffects', () => {
                 card: {
                     selected: selectedLightCard,
                     loading: false,
-                    error: null
+                    error: null,
+                    actionsAppear: []
                 }
-            })
+            });
 
             const localActions$ = new Actions(hot('-a-', {a: new LoadLightCardsSuccess({lightCards: severalRandomLightCards})}));
 
             effects = new CardOperationEffects(store, localActions$, cardServiceSpy);
 
             expect(effects).toBeTruthy();
-            effects.refreshIfSelectedCard.subscribe( x => fail("Unexpected action emitted."))
+            effects.refreshIfSelectedCard.subscribe( x => fail('Unexpected action emitted.'));
 
         });
 
-    })
+    });
 });

--- a/ui/main/src/app/store/reducers/card.reducer.spec.ts
+++ b/ui/main/src/app/store/reducers/card.reducer.spec.ts
@@ -5,10 +5,10 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import {reducer} from "@ofStore/reducers/card.reducer";
-import {cardInitialState, CardState} from "@ofStates/card.state";
-import {getOneRandomCard, getRandomAlphanumericValue} from "@tests/helpers";
-import {ClearCard, LoadCard, LoadCardFailure, LoadCardSuccess} from "@ofActions/card.actions";
+import {reducer} from '@ofStore/reducers/card.reducer';
+import {cardInitialState, CardState} from '@ofStates/card.state';
+import {getOneRandomCard, getRandomAlphanumericValue} from '@tests/helpers';
+import {ClearCard, LoadCard, LoadCardFailure, LoadCardSuccess, AddActionsAppear} from '@ofActions/card.actions';
 
 describe('Card Reducer', () => {
     describe('unknown action', () => {
@@ -23,8 +23,9 @@ describe('Card Reducer', () => {
             const previousState: CardState = {
                 selected: getOneRandomCard(),
                 loading: false,
-                error: getRandomAlphanumericValue(5, 12)
-            }
+                error: getRandomAlphanumericValue(5, 12),
+                actionsAppear: []
+            };
             const actualState = reducer(previousState, unknowAction);
             expect(actualState).toBe(previousState);
         });
@@ -41,7 +42,8 @@ describe('Card Reducer', () => {
             const previousState: CardState = {
                 selected: null,
                 loading: true,
-                error: null
+                error: null,
+                actionsAppear: []
             }
             const actualState = reducer(previousState,
                 new LoadCard({id: getRandomAlphanumericValue(5, 12)}));
@@ -55,7 +57,8 @@ describe('Card Reducer', () => {
             const previousState: CardState = {
                 selected: actualCard,
                 loading: true,
-                error: null
+                error: null,
+                actionsAppear: []
             };
             const actualState = reducer(previousState,
                 new LoadCardFailure({error: new Error(getRandomAlphanumericValue(5, 12))}));
@@ -72,7 +75,8 @@ describe('Card Reducer', () => {
             const previousState: CardState = {
                 selected: previousCard,
                 loading: true,
-                error: getRandomAlphanumericValue(5, 12)
+                error: getRandomAlphanumericValue(5, 12),
+                actionsAppear: []
             };
 
             const actualCard = getOneRandomCard();
@@ -91,7 +95,8 @@ describe('Card Reducer', () => {
             const previousState: CardState = {
                 selected: previousCard,
                 loading: true,
-                error: getRandomAlphanumericValue(5, 12)
+                error: getRandomAlphanumericValue(5, 12),
+                actionsAppear: []
             };
 
             const actualState = reducer(previousState, new ClearCard());
@@ -100,6 +105,23 @@ describe('Card Reducer', () => {
             expect(actualState.error).toBeNull();
             expect(actualState.loading).toBeFalsy();
             expect(actualState.selected).toBeNull();
+        });
+    });
+
+    describe('AddActionsAppear', () => {
+        it('should add action appear to array of one element', () => {
+            const previousCard = getOneRandomCard();
+            const previousState: CardState = {
+                selected: previousCard,
+                loading: true,
+                error: getRandomAlphanumericValue(5, 12),
+                actionsAppear: []
+            };
+            const actualState = reducer(previousState, new AddActionsAppear('RANDOMCARDID'));
+            expect(actualState).not.toBe(previousState);
+            expect(actualState).not.toEqual(previousState);
+            expect(actualState.actionsAppear).toEqual(['RANDOMCARDID']);
+            expect(actualState.actionsAppear.length).toBe(1);
         });
     });
 });

--- a/ui/main/src/app/store/reducers/card.reducer.ts
+++ b/ui/main/src/app/store/reducers/card.reducer.ts
@@ -6,8 +6,8 @@
  */
 
 import {CardFeedState} from '@ofStates/feed.state';
-import {cardInitialState, CardState} from "@ofStates/card.state";
-import {CardActions, CardActionTypes} from "@ofActions/card.actions";
+import {cardInitialState, CardState} from '@ofStates/card.state';
+import {CardActions, CardActionTypes} from '@ofActions/card.actions';
 
 export function reducer(
     state = cardInitialState,
@@ -33,7 +33,7 @@ export function reducer(
         case CardActionTypes.LoadCardFailure: {
             return {
                 ...state,
-                selected:null,
+                selected: null,
                 loading: false,
                 error: `error while loading a Card: '${action.payload.error}'`
             };
@@ -54,9 +54,21 @@ export function reducer(
         case CardActionTypes.LoadArchivedCardFailure: {
             return {
                 ...state,
-                selected:null,
+                selected: null,
                 loading: false,
                 error: `error while loading a Card: '${action.payload.error}'`
+            };
+        }
+        case CardActionTypes.AddActionsAppear: {
+            let actionsAppear = [];
+            if (state.actionsAppear.includes(action.payload)) {
+                actionsAppear = [...state.actionsAppear];
+            } else {
+                actionsAppear = [...state.actionsAppear, action.payload];
+            }
+            return {
+                ...state,
+                actionsAppear
             };
         }
 

--- a/ui/main/src/app/store/selectors/card.selectors.spec.ts
+++ b/ui/main/src/app/store/selectors/card.selectors.spec.ts
@@ -5,42 +5,40 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import {AppState} from "@ofStore/index";
-import {cardInitialState, CardState} from "@ofStates/card.state";
-import {emptyAppState4Test , getOneRandomCard} from "@tests/helpers";
+import {AppState} from '@ofStore/index';
+import {cardInitialState, CardState} from '@ofStates/card.state';
+import {emptyAppState4Test , getOneRandomCard} from '@tests/helpers';
 import {
     selectCardState,
     selectCardStateSelected,
     selectCardStateSelectedDetails,
-    selectCardStateSelectedId
-} from "@ofSelectors/card.selectors";
-
-
-
+    selectCardStateSelectedId,
+    selectCardActionsAppearState
+} from '@ofSelectors/card.selectors';
 
 describe('ConfigSelectors', () => {
-    let emptyAppState: AppState = emptyAppState4Test;
-
-    let selectedState: CardState = {
+    const emptyAppState: AppState = emptyAppState4Test;
+    const selectedState: CardState = {
         ...cardInitialState,
         selected: getOneRandomCard()
     };
 
-
     it('manage empty card state', () => {
-        let testAppState = {...emptyAppState, card: cardInitialState};
+        const testAppState = {...emptyAppState, card: cardInitialState};
         expect(selectCardState(testAppState)).toEqual(cardInitialState);
         expect(selectCardStateSelected(testAppState)).toBeNull();
         expect(selectCardStateSelectedDetails(testAppState)).toBeNull();
         expect(selectCardStateSelectedId(testAppState)).toBeNull();
     });
-
     it('manage slected card state', () => {
-        let testAppState = {...emptyAppState, card: selectedState};
+        const testAppState = {...emptyAppState, card: selectedState};
         expect(selectCardState(testAppState)).toEqual(selectedState);
         expect(selectCardStateSelected(testAppState)).toEqual(selectedState.selected);
         expect(selectCardStateSelectedDetails(testAppState)).toEqual(selectedState.selected.details);
         expect(selectCardStateSelectedId(testAppState)).toEqual(selectedState.selected.id);
     });
-
+    it('should select the card appear array', () => {
+        const testAppState = {...emptyAppState, card: selectedState};
+        expect(selectCardActionsAppearState(testAppState)).toEqual(selectedState.actionsAppear);
+    });
 });

--- a/ui/main/src/app/store/selectors/card.selectors.ts
+++ b/ui/main/src/app/store/selectors/card.selectors.ts
@@ -5,16 +5,18 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import {AppState} from "@ofStore/index";
-import {createSelector} from "@ngrx/store";
-import {CardState} from "@ofStates/card.state";
-import {Card} from "@ofModel/card.model";
+import {AppState} from '@ofStore/index';
+import {createSelector} from '@ngrx/store';
+import {CardState} from '@ofStates/card.state';
+import {Card} from '@ofModel/card.model';
 
-export const selectCardState = (state:AppState) => state.card;
-export const selectCardStateSelected =  createSelector(selectCardState, (cardState:CardState)=> cardState.selected)
-export const selectCardStateSelectedDetails =  createSelector(selectCardStateSelected, (card:Card)=> {
-    return card==null?null:card.details;
-})
-export const selectCardStateSelectedId =  createSelector(selectCardStateSelected, (card:Card)=> {
-    return card==null?null:card.id;
-})
+export const selectCardState = (state: AppState) => state.card;
+export const selectCardStateSelected =  createSelector(selectCardState, (cardState: CardState) => cardState.selected);
+export const selectCardStateSelectedDetails =  createSelector(selectCardStateSelected, (card: Card) => {
+    return card == null ? null : card.details;
+});
+export const selectCardStateSelectedId =  createSelector(selectCardStateSelected, (card: Card) => {
+    return card == null ? null : card.id;
+});
+
+export const selectCardActionsAppearState = createSelector(selectCardState, (cardState: CardState) => cardState.actionsAppear);

--- a/ui/main/src/app/store/states/card.state.ts
+++ b/ui/main/src/app/store/states/card.state.ts
@@ -5,16 +5,18 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import {Card} from "@ofModel/card.model";
+import {Card} from '@ofModel/card.model';
 
-export interface CardState{
-    selected: Card,
-    loading: boolean,
-    error: string
+export interface CardState {
+    selected: Card;
+    loading: boolean;
+    error: string;
+    actionsAppear: string[];
 }
 
 export const cardInitialState: CardState = {
     selected: null,
     loading: false,
-    error: null
-}
+    error: null,
+    actionsAppear: []
+};


### PR DESCRIPTION
For each card in the feed:
If the card has been consulted once then the action buttons should appear 
If the card hasn't been opened yet  then the actions buttons remain hidden

See ticket OC-474