### PR TITLE
[OC-495] #99 Amended docker-compose file to use src locations as volumes …

### DIFF
--- a/src/main/docker/deploy/docker-compose.yml
+++ b/src/main/docker/deploy/docker-compose.yml
@@ -42,7 +42,7 @@ services:
      - REGISTRY_HOST=registry
      - REGISTRY_PORT=8080
     volumes:
-     - "../../../../services/infra/config/build/docker-volume/docker-configurations:/service-config"
+     - "../../../../services/infra/config/src/main/docker/volume/docker-configurations:/service-config"
   registry:
     depends_on:
      - config
@@ -89,7 +89,7 @@ services:
     - REGISTRY_PORT=8080
     - DEPENDS_ON=CONFIG
     volumes:
-     - "../../../../services/core/thirds/build/docker-volume/thirds-storage:/thirds-storage"
+     - "../../../../services/core/thirds/src/main/docker/volume/thirds-storage:/thirds-storage"
   time:
     depends_on:
      - registry


### PR DESCRIPTION
The issue was that this docker-compose relied on 2 folders from build directories:

    services/infra/config/build/docker-volume/docker-configurations for the yml config files of all services, to be used by the config service

    services/core/thirds/build/docker-volume/thirds-storage that stores the bundles

These directories are created from the corresponding source files by the copyWorkingDir gradle task.

This is the case for all docker-compose but it is not appropriate for this particular docker-compose as it is meant to be used “out of the box” without building OpFab or even having Gradle installed.

So I edited the docker-compose to point directly to the src directories as it was the simplest fix I could think of, but the downside of this is that any bundle posted when using the deploy docker-compose will show up in the thirds-storage directory under src, which is version-controlled.

As a more refined solution, I thought of having a dedicated folder under the “deploy” folder to use as volume and copy the data there (and add it to .gitignore), but the issue is that the data would still have to be initialized in some way and that we would have to make sure to keep it up to date with any changes made to the src files.

Other options : dedicated image, .sh script

Opened task OC-497 as a reminder to find a more elegant solution if possible.