### PR TITLE
[OC-500] Updating Java version from 8.0.212-zulu to 8.0.222-zulu

### DIFF
--- a/bin/load_environment_light.sh
+++ b/bin/load_environment_light.sh
@@ -3,6 +3,6 @@
 . ${BASH_SOURCE%/*}/load_variables.sh
 
 sdk use gradle 5.4.1
-sdk use java 8.0.212-zulu
+sdk use java 8.0.222-zulu
 sdk use maven 3.5.3
 nvm use v10.10.0


### PR DESCRIPTION
Anyone who wants to clone for the first time the projet faces this java version not available by running the command “source ./bin/load_environment_light.sh”.

The java version needs to be updated. 
The version 8.0.212-zulu is not in the sdkman list anymore, the newest version is 8.0.222-zulu.