### PR TITLE
[OC-505] Replace browser lang by config lang + EN default

### DIFF
--- a/services/web/web-ui/src/docs/asciidoc/configuration.adoc
+++ b/services/web/web-ui/src/docs/asciidoc/configuration.adoc
@@ -49,7 +49,7 @@ Values should be taken from the link:https://en.wikipedia.org/wiki/List_of_tz_da
 |operatorfabric.settings.timeFormat|LT|no|Default user time format (moment)
 |operatorfabric.settings.dateFormat|LL|no|Default user date format (moment)
 |operatorfabric.settings.dateTimeFormat|LL LT|no|Default user date format (moment)
-|operatorfabric.settings.locale|LT|no|Default user locale (use browser if not set)
+|operatorfabric.settings.locale|en|no|Default user locale (use en if not set)
 |operatorfabric.settings.default-tags||no|Default user list of filtered in tags
 |operatorfabric.time.pulse|5000|no|Duration between two ticks of the internal state of the User Interface
 |operatorfabric.archive.filters.page.size||no|The page size of archive filters

--- a/ui/main/src/app/modules/cards/services/handlebars.service.spec.ts
+++ b/ui/main/src/app/modules/cards/services/handlebars.service.spec.ts
@@ -461,12 +461,12 @@ describe('Handlebars Services', () => {
                 call.flush('{{i18n card.data.i18n}}');
             });
         });
-        it('compile numberFormat', (done) => {
+        it('compile numberFormat using en locale fallback', (done) => {
             const templateName = Guid.create().toString();
             handlebarsService.executeTemplate(templateName, new DetailContext(card, userContext))
                 .subscribe((result) => {
                     expect(result)
-                        .toEqual(new Intl.NumberFormat(translate.getBrowserLang(), {style: "currency", currency: "EUR"})
+                        .toEqual(new Intl.NumberFormat('en', {style: "currency", currency: "EUR"})
                             .format(5));
                     done();
                 });
@@ -477,9 +477,9 @@ describe('Handlebars Services', () => {
                 call.flush('{{numberFormat card.data.numbers.[5] style="currency" currency="EUR"}}');
             });
         });
-        it('compile dateFormat now', (done) => {
+        it('compile dateFormat now (using en locale fallback)', (done) => {
             const nowMoment = moment(new Date(now));
-            nowMoment.locale(translate.getBrowserLang())
+            nowMoment.locale('en')
             const templateName = Guid.create().toString();
             handlebarsService.executeTemplate(templateName, new DetailContext(card, userContext))
                 .subscribe((result) => {

--- a/ui/main/src/app/services/i18n.service.ts
+++ b/ui/main/src/app/services/i18n.service.ts
@@ -31,7 +31,7 @@ export class I18nService {
         if(locale) {
             this._locale = locale;
         }else{
-            this._locale = this.translate.getBrowserLang();
+            this._locale = 'en';
         }
         moment.locale(this._locale);
         this.translate.use(this._locale);


### PR DESCRIPTION

* [ `&#39;[x]&#39;`] The commit message follows our guidelines
* [ `&#39;[x]&#39;`] Tests for the changes have been added (for bug fixes / features)
* [ `&#39;[x]&#39;`] Docs have been added / updated (for bug fixes / features)

This is a simple fix for urgent client project. See OC-480 for full handling of the language choice issue.