### PR TITLE
OC-632 Order feed with publishDate in desc order

### DIFF
--- a/ui/main/src/app/store/states/feed.state.spec.ts
+++ b/ui/main/src/app/store/states/feed.state.spec.ts
@@ -38,14 +38,14 @@ describe('FeedState', () => {
     });
     describe('#compareByPublishDate', () => {
         it('should sort', () => {
-            expect(compareByPublishDate(card1,card2)).toBeLessThan(0);
+            expect(compareByPublishDate(card1,card2)).toBeGreaterThan(0);
         });
     });
     describe('#compareBySeverityLttdPublishDate', () => {
         it('should sort', () => {
-            expect(compareBySeverityLttdPublishDate(card1,card3)).toBeLessThan(0);
+            expect(compareBySeverityLttdPublishDate(card1,card3)).toBeGreaterThan(0);
             expect(compareBySeverityLttdPublishDate(card2,card4)).toBeLessThan(0);
-            expect([card1,card2,card3,card4].sort(compareBySeverityLttdPublishDate)).toEqual([card2,card4,card1,card3])
+            expect([card1,card2,card3,card4].sort(compareBySeverityLttdPublishDate)).toEqual([card2,card4,card3,card1])
         });
     });
 });

--- a/ui/main/src/app/store/states/feed.state.ts
+++ b/ui/main/src/app/store/states/feed.state.ts
@@ -40,7 +40,7 @@ export function compareByLttd(card1: LightCard, card2: LightCard){
 }
 
 export function compareByPublishDate(card1: LightCard, card2: LightCard){
-    return card1.publishDate - card2.publishDate;
+    return card2.publishDate - card1.publishDate;
 }
 
 export function compareBySeverityLttdPublishDate(card1: LightCard, card2: LightCard){


### PR DESCRIPTION
Order cards in feed with publishDate in desc order instead of asc order (the first ordering is still severity) 