### PR TITLE
[OC-581] In user settings, all fields there should be maskable

### DIFF
--- a/services/infra/config/src/main/docker/volume/dev-configurations/web-ui.yml
+++ b/services/infra/config/src/main/docker/volume/dev-configurations/web-ui.yml
@@ -63,5 +63,7 @@ operatorfabric:
     - en
   settings:
     locale: en
+    infos:
+      description: true
   time:
     pulse: 5000

--- a/services/infra/config/src/main/docker/volume/docker-configurations/web-ui.yml
+++ b/services/infra/config/src/main/docker/volume/docker-configurations/web-ui.yml
@@ -46,3 +46,5 @@ operatorfabric:
   - en
   settings:
     locale: en
+    infos:
+      description: true

--- a/services/web/web-ui/src/docs/asciidoc/configuration.adoc
+++ b/services/web/web-ui/src/docs/asciidoc/configuration.adoc
@@ -79,6 +79,14 @@ while clicking the icon opens in a new tab.
 |operatorfabric.archive.filters.tags.list||no|List of tags to choose from in the corresponding filter in archives
 |operatorfabric.settings.tags.hide||no|Control if you want to show or hide the tags filter in settings and feed page
 |operatorfabric.settings.infos.disable||no|Control if we want to disable/enable editing user email, description in the settings page
+|operatorfabric.settings.infos.email|false|no|Control if we want to hide(true) or display(false or not specified) the user email in the settings page
+|operatorfabric.settings.infos.description|false|no|Control if we want to hide(true) or display(false or not specified) the user description in the settings page
+|operatorfabric.settings.infos.language|false|no|Control if we want to hide(true) or display(false or not specified) the language in the settings page
+|operatorfabric.settings.infos.timezone|false|no|Control if we want to hide(true) or display(false or not specified) the timezone in the settings page
+|operatorfabric.settings.infos.timeformat|false|no|Control if we want to hide(true) or display(false or not specified) the timeformat in the settings page
+|operatorfabric.settings.infos.dateformat|false|no|Control if we want to hide(true) or display(false or not specified) the dateformat in the settings page
+|operatorfabric.settings.infos.datetimeformat|false|no|Control if we want to hide(true) or display(false or not specified) the datetimeformat in the settings page
+|operatorfabric.settings.infos.tags|false|no|Control if we want to hide(true) or display(false or not specified) the tags in the settings page
 |operatorfabric.logo.base64|medium OperatorFabric icon|no|The encoding result of converting the svg logo to Base64, use this link:https://base64.guru/converter/encode/image/svg[online tool] to encode your svg. If it is not set, a medium (32px) OperatorFabric icon is displayed.
 |operatorfabric.logo.height|32|no|The height of the logo (in px) (only taken into account if operatorfabric.logo.base64 is set).
 |operatorfabric.logo.width|150|no|The width of the logo (in px) (only taken into account if operatorfabric.logo.base64 is set).

--- a/ui/main/src/app/modules/settings/components/settings/settings.component.html
+++ b/ui/main/src/app/modules/settings/components/settings/settings.component.html
@@ -6,28 +6,28 @@
 
 <div class="container-fluid">
   <div class="row">
-    <div class="col-md-6">
+    <div class="col-md-6" *ngIf="!dispalyInfos?.email">
       <of-email-setting settingPath="email" [disabled]="(disableInfos$|async)"></of-email-setting>
     </div>
-    <div class="col-md-6">
+    <div class="col-md-6" *ngIf="!dispalyInfos?.description">
       <of-text-setting settingPath="description" [disabled]="(disableInfos$|async)"></of-text-setting>
     </div>
-    <div class="col-md-6">
+    <div class="col-md-6" *ngIf="!dispalyInfos?.language">
       <of-list-setting settingPath="locale" [values]="locales$|async" ></of-list-setting>
     </div>
-    <div class="col-md-6">
+    <div class="col-md-6" *ngIf="!dispalyInfos?.timezone">
       <of-list-setting settingPath="timeZone" [values]="timeZones$|async" ></of-list-setting>
     </div>
-    <div class="col-md-6">
+    <div class="col-md-6" *ngIf="!dispalyInfos?.timeformat">
       <of-text-setting settingPath="timeFormat"></of-text-setting>
     </div>
-    <div class="col-md-6">
+    <div class="col-md-6" *ngIf="!dispalyInfos?.dateformat">
       <of-text-setting settingPath="dateFormat"></of-text-setting>
     </div>
-    <div class="col-md-6">
+    <div class="col-md-6" *ngIf="!dispalyInfos?.datetimeformat">
       <of-text-setting settingPath="dateTimeFormat"></of-text-setting>
     </div>
-    <div class="col-md-6" *ngIf="!(hideTags$|async)">
+    <div class="col-md-6" *ngIf="!dispalyInfos?.tags">
       <of-type-ahead-settings settingPath="defaultTags"></of-type-ahead-settings>
     </div>
   </div>

--- a/ui/main/src/app/modules/settings/components/settings/settings.component.ts
+++ b/ui/main/src/app/modules/settings/components/settings/settings.component.ts
@@ -20,6 +20,7 @@ export class SettingsComponent implements OnInit {
   timeZones$: Observable<string[]>;
   hideTags$: Observable<boolean>;
   disableInfos$: Observable<boolean>;
+  dispalyInfos: {};
 
   constructor(private store: Store<AppState>) { }
 
@@ -28,6 +29,9 @@ export class SettingsComponent implements OnInit {
     this.timeZones$ = this.store.select(buildConfigSelector('i10n.supported.time-zones'));
     this.hideTags$ = this.store.select(buildConfigSelector('settings.tags.hide'));
     this.disableInfos$ = this.store.select(buildConfigSelector('settings.infos.disable'));
+    this.store.select(buildConfigSelector('settings.infos')).subscribe(d => {
+      this.dispalyInfos = d
+    });
   }
 
 }


### PR DESCRIPTION
In user settings all fields there should be maskable.

In that case for eg, developer can choose which fields he wants to present to the user in its user settings.

For let's co the only two fields necessary to display are "Language" and "Timezone".
The rest should be hidden.

