### PR TITLE
Alex leger test pr - Do not merge ci_docker ci_documentation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,9 +45,9 @@ jobs:
 stages:
   - test-assemble
   - name: docker-images
-    if: (type = cron OR commit_message =~ ci_docker) AND (NOT type IN (pull_request)) AND (branch = master)
+    if: type = cron OR commit_message =~ ci_docker
   - name: doc
-    if: (type = cron OR commit_message =~ ci_documentation) AND (NOT type IN (pull_request)) AND (branch = master)
+    if: type = cron OR commit_message =~ ci_documentation
 # Note: The condition on type is necessary to exclude PRs because their base branch could be master
 #script:
 #  - docker-compose -f src/main/docker/test-environment/docker-compose.yml up -d

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 sudo: required
 dist: trusty
-addons:
-    sonarcloud:
-        organization: "opfab"
-        token:
-            secure: ${SONAR_TOKEN}
+#addons:
+#    sonarcloud:
+#        organization: "opfab"
+#       token:
+#           secure: ${SONAR_TOKEN}
 services:
   - docker
 env:
@@ -25,7 +25,7 @@ jobs:
 #      - ./gradlew --build-cache clean
       - docker-compose -f src/main/docker/test-environment/docker-compose.yml up -d
       - export GRADLE_OPTS="-XX:MaxMetaspaceSize=512m -Xmx1024m"
-      - ./gradlew --build-cache copyDependencies test jacocoTestReport && sonar-scanner
+      - ./gradlew --build-cache copyDependencies test jacocoTestReport # && sonar-scanner
       - docker-compose -f src/main/docker/test-environment/docker-compose.yml down
 #      - ./gradlew --build-cache assemble -x test
   - stage: docker-images


### PR DESCRIPTION
This is to test that external (malicious) PRs can't push images to dockerhub or push documentation