### PR TITLE
[OC-700] Skip sonar for external PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,12 @@ jobs:
 #      - ./gradlew --build-cache clean
       - docker-compose -f src/main/docker/test-environment/docker-compose.yml up -d
       - export GRADLE_OPTS="-XX:MaxMetaspaceSize=512m -Xmx1024m"
-      - ./gradlew --build-cache copyDependencies test jacocoTestReport && sonar-scanner
+      # If SONAR_TOKEN is not available (for external PRs for example), skip sonar
+      - if [ "${SONAR_TOKEN}" != "" ]; then
+        (./gradlew --build-cache copyDependencies test jacocoTestReport) && (sonar-scanner);
+        else
+        (./gradlew --build-cache copyDependencies test jacocoTestReport);
+        fi
       - docker-compose -f src/main/docker/test-environment/docker-compose.yml down
 #      - ./gradlew --build-cache assemble -x test
   - stage: docker-images


### PR DESCRIPTION
Tested on branch: Sonar is still run for branch