### PR TITLE
[OC-783] Fix settingsOrConfig selector behaviour for booleans

### DIFF
--- a/src/docs/asciidoc/release_notes/1.1.0.RELEASE.adoc
+++ b/src/docs/asciidoc/release_notes/1.1.0.RELEASE.adoc
@@ -15,8 +15,9 @@ _The OperatorFabric deployment no longer requires a Time microservice._
 _Builds with a documentation stage will now fail if the push to the website repository wasn't successful._
 
 === Bug 
-* [OC-730] Correct minors bugs in timeline and major refactoring 
-=======
+* [OC-730] Correct minors bugs in timeline and major refactoring
+* [OC-783] Fix settingsOrConfig selector behaviour for booleans
+
 === Issue
 * [OC-682] As a user I want sound to be played on cards arrival
 +

--- a/ui/main/src/app/store/selectors/settings.x.config.selectors.spec.ts
+++ b/ui/main/src/app/store/selectors/settings.x.config.selectors.spec.ts
@@ -9,7 +9,7 @@
 import {AppState} from "@ofStore/index";
 import {settingsInitialState, SettingsState} from "@ofStates/settings.state";
 import {configInitialState, ConfigState} from "@ofStates/config.state";
-import {buildSettingsOrConfigSelector, selectMergedSettings} from "@ofSelectors/settings.x.config.selectors";
+import {buildSettingsOrConfigSelector} from "@ofSelectors/settings.x.config.selectors";
 import {emptyAppState4Test} from "@tests/helpers";
 
 describe('SettingsXConfigSelectors', () => {
@@ -21,8 +21,11 @@ describe('SettingsXConfigSelectors', () => {
         settings: {
             test: {
                 path: {my: {settings: 'value'}}
-            }
+            },
+            booleanTest1: false,
+            booleanTest2: true
         }
+
     };
     let loadedConfigState: ConfigState = {
         ...configInitialState,
@@ -34,7 +37,10 @@ describe('SettingsXConfigSelectors', () => {
                     byDefault:{
                         value: 'default value'
                     }
-                }
+                },
+                booleanTest1: true,
+                booleanTest2: false,
+                booleanTest3: true
             }
         }
     };
@@ -43,27 +49,23 @@ describe('SettingsXConfigSelectors', () => {
 
     it('manage empty', () => {
         let testAppState = {...emptyAppState, settings: settingsInitialState, config: configInitialState};
-        expect(selectMergedSettings(testAppState)).toEqual({});
         expect(buildSettingsOrConfigSelector('test.path.my.settings')(testAppState)).toEqual(null);
         expect(buildSettingsOrConfigSelector('test.byDefault.value')(testAppState)).toEqual(null);
         expect(buildSettingsOrConfigSelector('test.byDefault.value','fallback')(testAppState)).toEqual('fallback');
+        expect(buildSettingsOrConfigSelector('booleanTest1')(testAppState)).toEqual(null);
+        expect(buildSettingsOrConfigSelector('booleanTest2')(testAppState)).toEqual(null);
+        expect(buildSettingsOrConfigSelector('booleanTest3')(testAppState)).toEqual(null);
     });
 
     it('manage loaded settings and config', () => {
         let testAppState = {...emptyAppState, settings: loadedSettingsState, config: loadedConfigState};
-        expect(selectMergedSettings(testAppState)).toEqual({
-            test: {
-                path: {my: {settings: 'value'}},
-                byDefault:{
-                    value: 'default value'
-                }
-            }
-        });
         expect(buildSettingsOrConfigSelector('test.path.my.settings')(testAppState)).toEqual('value');
         expect(buildSettingsOrConfigSelector('test.byDefault.value')(testAppState)).toEqual('default value');
         expect(buildSettingsOrConfigSelector('test.byDefault.value','fallback')(testAppState)).toEqual('default value');
+        expect(buildSettingsOrConfigSelector('booleanTest1')(testAppState)).toEqual(false);
+        expect(buildSettingsOrConfigSelector('booleanTest2')(testAppState)).toEqual(true);
+        expect(buildSettingsOrConfigSelector('booleanTest3')(testAppState)).toEqual(true);
     });
-
 
 })
 ;

--- a/ui/main/src/app/store/selectors/settings.x.config.selectors.ts
+++ b/ui/main/src/app/store/selectors/settings.x.config.selectors.ts
@@ -9,21 +9,15 @@
 import {AppState} from "@ofStore/index";
 import * as _ from 'lodash';
 
-export const selectMergedSettings =  (state:AppState) =>{
-    const settings = state.settings.settings;
-    const configSettings = _.get(state,`config.config.settings`,{});
-    return _.merge(configSettings,settings);
-};
-
 export function buildSettingsOrConfigSelector(path:string,fallback:any = null){
     return (state:AppState) => {
         const settings = state.settings.settings;
         const config = state.config.config;
         let result = _.get(settings,path,null);
-        if(!result){
+        if(result == null){
             result = _.get(config,`settings.${path}`,null);
         }
-        if(!result && fallback)
+        if(result == null && fallback)
             return fallback
         return result;
     }


### PR DESCRIPTION
This fixes the fact that in the case of a boolean property the settingOrConfig selector didn't discriminate between a "false" value for settings and no value at all.

So if the property was set to true in config and to false in the settings, it would return true instead of false as expected.
I added tests with a boolean property, no changes to documentation needed (just added it to the release notes).

PS: I deleted function selectMergedSettings as it wasn't used anywhere except in its own test.
