### PR TITLE
[OC-773] Making sound notifications manageable in settings

### DIFF
--- a/services/core/users/src/main/java/org/lfenergy/operatorfabric/users/model/UserSettingsData.java
+++ b/services/core/users/src/main/java/org/lfenergy/operatorfabric/users/model/UserSettingsData.java
@@ -20,6 +20,7 @@ import java.util.*;
 @AllArgsConstructor
 @Builder
 public class UserSettingsData implements UserSettings {
+
     @Id
     private String login;
     private String description;
@@ -32,8 +33,11 @@ public class UserSettingsData implements UserSettings {
     @JsonIgnore
     @Singular("defaultTag")
     private Set<String> defaultTagsSet;
-
     private TimeLineFormats timeLineDefaultClusteringFormats;
+    private Boolean playSoundForAlarm;
+    private Boolean playSoundForAction;
+    private Boolean playSoundForCompliant;
+    private Boolean playSoundForInformation;
 
     public UserSettingsData(UserSettings settings) {
         this.login = settings.getLogin();
@@ -50,6 +54,10 @@ public class UserSettingsData implements UserSettings {
         this.email = settings.getEmail();
         if(settings.getTimeLineDefaultClusteringFormats()!=null)
             this.timeLineDefaultClusteringFormats = ((TimeLineFormatsData)settings.getTimeLineDefaultClusteringFormats()).copy();
+        this.playSoundForAlarm = settings.getPlaySoundForAlarm();
+        this.playSoundForAction = settings.getPlaySoundForAction();
+        this.playSoundForCompliant = settings.getPlaySoundForCompliant();
+        this.playSoundForInformation = settings.getPlaySoundForInformation();
     }
 
     public Set<String> getDefaultTagsSet() {
@@ -79,10 +87,10 @@ public class UserSettingsData implements UserSettings {
     }
 
     /**
-     * Create a new patched settings using this as reference and overiding fields from other parameter when filed is not
+     * Create a new patched settings using this as reference and overriding fields from other parameter when field is not
      * null.
      * <br>
-     * NB: resulting field defaultTags is the addition of collectins from both sides
+     * NB: resulting field defaultTags is the addition of collections from both sides
      * NB2: login cannot be changed
      *
      * @param other
@@ -104,6 +112,10 @@ public class UserSettingsData implements UserSettings {
             result.defaultTagsSet = new HashSet<>(this.getDefaultTags());
         else
             result.defaultTagsSet = null;
+        result.playSoundForAlarm = other.getPlaySoundForAlarm() != null ? other.getPlaySoundForAlarm() : this.getPlaySoundForAlarm();
+        result.playSoundForAction = other.getPlaySoundForAction() != null ? other.getPlaySoundForAction() : this.getPlaySoundForAction();
+        result.playSoundForCompliant = other.getPlaySoundForCompliant() != null ? other.getPlaySoundForCompliant() : this.getPlaySoundForCompliant();
+        result.playSoundForInformation = other.getPlaySoundForInformation() != null ? other.getPlaySoundForInformation() : this.getPlaySoundForInformation();
         return result;
     }
 }

--- a/services/core/users/src/main/modeling/swagger.yaml
+++ b/services/core/users/src/main/modeling/swagger.yaml
@@ -158,6 +158,18 @@ definitions:
           uniqueItems: true
       timeLineDefaultClusteringFormats:
         $ref: '#/definitions/TimeLineFormats'
+      playSoundForAlarm:
+        type: boolean
+        description: If this is set to true, a sound will be played for incoming cards with ALARM severity.
+      playSoundForAction:
+        type: boolean
+        description: If this is set to true, a sound will be played for incoming cards with ACTION severity.
+      playSoundForCompliant:
+        type: boolean
+        description: If this is set to true, a sound will be played for incoming cards with COMPLIANT severity.
+      playSoundForInformation:
+        type: boolean
+        description: If this is set to true, a sound will be played for incoming cards with INFORMATION severity.
     required:
       - login
     example:

--- a/services/core/users/src/test/java/org/lfenergy/operatorfabric/users/model/UserSettingsDataShould.java
+++ b/services/core/users/src/test/java/org/lfenergy/operatorfabric/users/model/UserSettingsDataShould.java
@@ -15,6 +15,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class UserSettingsDataShould {
 
+    //TODO Add tests for new settings
+
     @Test
     public void encapsulateTagSet(){
         UserSettingsData userData = UserSettingsData.builder().defaultTag("test1").defaultTag("test2").build();
@@ -39,6 +41,9 @@ public class UserSettingsDataShould {
                 .email("test@test.tst")
                 .locale("fr")
                 .timeZone("Europe/Berlin")
+                .playSoundForAlarm(true)
+                .playSoundForAction(false)
+                //Not setting Compliant and Information to test patch on empty
                 .build();
         UserSettingsData patched = userData.patch(UserSettingsData.builder().timeFormat("LLT").build().clearTags());
         assertThat(patched).isEqualToIgnoringGivenFields(userData,"timeFormat");
@@ -66,5 +71,22 @@ public class UserSettingsDataShould {
         patched = userData.patch(UserSettingsData.builder().timeZone("patched-zone").build().clearTags());
         assertThat(patched).isEqualToIgnoringGivenFields(userData,"timeZone");
         assertThat(patched.getTimeZone()).isEqualTo("patched-zone");
+
+        patched = userData.patch(UserSettingsData.builder().playSoundForAlarm(false).build().clearTags());
+        assertThat(patched).isEqualToIgnoringGivenFields(userData,"playSoundForAlarm");
+        assertThat(patched.getPlaySoundForAlarm()).isEqualTo(false);
+
+        patched = userData.patch(UserSettingsData.builder().playSoundForAction(true).build().clearTags());
+        assertThat(patched).isEqualToIgnoringGivenFields(userData,"playSoundForAction");
+        assertThat(patched.getPlaySoundForAction()).isEqualTo(true);
+
+        patched = userData.patch(UserSettingsData.builder().playSoundForCompliant(false).build().clearTags());
+        assertThat(patched).isEqualToIgnoringGivenFields(userData,"playSoundForCompliant");
+        assertThat(patched.getPlaySoundForCompliant()).isEqualTo(false);
+
+        patched = userData.patch(UserSettingsData.builder().playSoundForInformation(true).build().clearTags());
+        assertThat(patched).isEqualToIgnoringGivenFields(userData,"playSoundForInformation");
+        assertThat(patched.getPlaySoundForInformation()).isEqualTo(true);
+
     }
 }

--- a/services/web/web-ui/src/docs/asciidoc/configuration.adoc
+++ b/services/web/web-ui/src/docs/asciidoc/configuration.adoc
@@ -61,10 +61,10 @@ a|card time display mode in the feed. Values :
 |operatorfabric.feed.timeFilter.followClockTick|false|no|If set to true, the time filter on the feed will shift
 to reflect elapsed time
 |operatorfabric.feed.notify|false|no|If set to true, new cards are notified in the OS through web-push notifications
-|operatorfabric.sounds.alarm|false|no|If set to true, a sound is played when Alarm cards are added or updated in the feed
-|operatorfabric.sounds.action|false|no|If set to true, a sound is played when Action cards are added or updated in the feed
-|operatorfabric.sounds.compliant|false|no|If set to true, a sound is played when Compliant cards are added or updated in the feed
-|operatorfabric.sounds.information|false|no|If set to true, a sound is played when Information cards are added or updated in the feed
+|operatorfabric.playSoundForAlarm|false|no|If set to true, a sound is played when Alarm cards are added or updated in the feed
+|operatorfabric.playSoundForAction|false|no|If set to true, a sound is played when Action cards are added or updated in the feed
+|operatorfabric.playSoundForCompliant|false|no|If set to true, a sound is played when Compliant cards are added or updated in the feed
+|operatorfabric.playSoundForInformation|false|no|If set to true, a sound is played when Information cards are added or updated in the feed
 |operatorfabric.i18n.supported.locales||no|List of supported locales (Only fr and en so far)
 |operatorfabric.i10n.supported.time-zones||no|List of supported time zones, for instance 'Europe/Paris'.
 Values should be taken from the link:https://en.wikipedia.org/wiki/List_of_tz_database_time_zones[TZ database].
@@ -93,6 +93,7 @@ while clicking the icon opens in a new tab.
 |operatorfabric.settings.infos.dateformat|false|no|Control if we want to hide(true) or display(false or not specified) the dateformat in the settings page
 |operatorfabric.settings.infos.datetimeformat|false|no|Control if we want to hide(true) or display(false or not specified) the datetimeformat in the settings page
 |operatorfabric.settings.infos.tags|false|no|Control if we want to hide(true) or display(false or not specified) the tags in the settings page
+|operatorfabric.settings.infos.sounds|false|no|Control if we want to hide(true) or display(false or not specified) the checkboxes for sound notifications in the settings page
 |operatorfabric.settings.about
 a|`operatorfabric: +
      name:  'OperatorFabric' +

--- a/src/docs/asciidoc/release_notes/1.1.0.RELEASE.adoc
+++ b/src/docs/asciidoc/release_notes/1.1.0.RELEASE.adoc
@@ -44,3 +44,11 @@ prevent malicious sites to autoplay unwanted content.
 +
 https://www.zapsplat.com[Sound effects obtained from zapsplat.com]
 
+* [OC-773] As a user I want sound notifications to be manageable in my settings
++
+_This feature allows the user to override the sound playing policy that has been defined in the configuration by the
+administrator (see OC-682) in the settings screen._
++
+IMPORTANT: To disable sounds for a given severity, you need to click the checkbox twice (check then uncheck) to set it
+to false, otherwise your settings for this severity will remain "undefined" an the instance-wide configuration value
+will be applied instead.

--- a/ui/main/src/app/modules/settings/components/settings/checkbox-setting/checkbox-setting.component.html
+++ b/ui/main/src/app/modules/settings/components/settings/checkbox-setting/checkbox-setting.component.html
@@ -1,0 +1,12 @@
+<!-- Copyright (c) 2020, RTE (http://www.rte-france.com)                 -->
+<!--                                                                     -->
+<!-- This Source Code Form is subject to the terms of the Mozilla Public -->
+<!-- License, v. 2.0. If a copy of the MPL was not distributed with this -->
+<!-- file, You can obtain one at http://mozilla.org/MPL/2.0/.            -->
+
+<form [formGroup]="form" class="form-check-inline" id="checkbox-setting-form">
+    <div class="form-group" >
+        <label class="form-check-label" for="setting" translate>settings.{{settingPath}}</label>
+        <input id="setting" type="checkbox" formControlName="setting" class="form-check-input"/>
+    </div>
+</form>

--- a/ui/main/src/app/modules/settings/components/settings/checkbox-setting/checkbox-setting.component.scss
+++ b/ui/main/src/app/modules/settings/components/settings/checkbox-setting/checkbox-setting.component.scss
@@ -1,0 +1,12 @@
+/* Copyright (c) 2020, RTE (http://www.rte-france.com)
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+label {
+  padding-right: 10px;
+  padding-left: 10px;
+}
+

--- a/ui/main/src/app/modules/settings/components/settings/checkbox-setting/checkbox-setting.component.spec.ts
+++ b/ui/main/src/app/modules/settings/components/settings/checkbox-setting/checkbox-setting.component.spec.ts
@@ -1,0 +1,41 @@
+/* Copyright (c) 2020, RTE (http://www.rte-france.com)
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { CheckboxSettingComponent } from './checkbox-setting.component';
+import {FormsModule, ReactiveFormsModule} from "@angular/forms";
+import {TranslateModule} from "@ngx-translate/core";
+import {StoreModule} from "@ngrx/store";
+import {appReducer, storeConfig} from "@ofStore/index";
+
+describe('CheckboxSettingComponent', () => {
+  let component: CheckboxSettingComponent;
+  let fixture: ComponentFixture<CheckboxSettingComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [FormsModule,
+        ReactiveFormsModule,
+        TranslateModule.forRoot(),
+        StoreModule.forRoot(appReducer, storeConfig)
+      ],
+      declarations: [ CheckboxSettingComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(CheckboxSettingComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/ui/main/src/app/modules/settings/components/settings/checkbox-setting/checkbox-setting.component.ts
+++ b/ui/main/src/app/modules/settings/components/settings/checkbox-setting/checkbox-setting.component.ts
@@ -1,0 +1,40 @@
+/* Copyright (c) 2020, RTE (http://www.rte-france.com)
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import {Component, OnDestroy, OnInit} from '@angular/core';
+import {BaseSettingComponent} from "../base-setting/base-setting.component";
+import {Store} from "@ngrx/store";
+import {AppState} from "@ofStore/index";
+import {FormControl, FormGroup} from "@angular/forms";
+
+@Component({
+  selector: 'of-checkbox-setting',
+  templateUrl: './checkbox-setting.component.html',
+  styleUrls: ['./checkbox-setting.component.scss']
+})
+export class CheckboxSettingComponent extends BaseSettingComponent implements OnInit, OnDestroy {
+
+  constructor(protected store: Store<AppState>) {
+    super(store);
+  }
+
+  ngOnInit() {
+    super.ngOnInit();
+  }
+
+  initFormGroup() {
+    return new FormGroup({
+      setting: new FormControl('')
+    }, {updateOn: 'change'});
+    //No need for validators are the checkbox input type can only create boolean values
+  }
+
+  updateValue(value) {
+    this.form.get('setting').setValue(value, {emitEvent: false});
+  }
+
+}

--- a/ui/main/src/app/modules/settings/components/settings/settings.component.html
+++ b/ui/main/src/app/modules/settings/components/settings/settings.component.html
@@ -31,5 +31,12 @@
     <div class="col-md-6" *ngIf="!displayInfo?.tags">
       <of-type-ahead-settings settingPath="defaultTags"></of-type-ahead-settings>
     </div>
+    <div class="col-md-6" *ngIf="!displayInfo?.sounds">
+      <div><label translate>settings.playSoundLabel</label></div>
+      <of-checkbox-setting settingPath="playSoundForAlarm"></of-checkbox-setting>
+      <of-checkbox-setting settingPath="playSoundForAction"></of-checkbox-setting>
+      <of-checkbox-setting settingPath="playSoundForCompliant"></of-checkbox-setting>
+      <of-checkbox-setting settingPath="playSoundForInformation"></of-checkbox-setting>
+    </div>
   </div>
 </div>

--- a/ui/main/src/app/modules/settings/components/settings/settings.component.spec.ts
+++ b/ui/main/src/app/modules/settings/components/settings/settings.component.spec.ts
@@ -33,8 +33,8 @@ describe('SettingsComponent', () => {
     fixture.detectChanges();
   });
 
-  it('should create', () => {
+  it('should create and have 9 elements', () => {
     expect(component).toBeTruthy();
-    expect(fixture.debugElement.queryAll(By.css('.col-md-6')).length).toEqual(8)
+    expect(fixture.debugElement.queryAll(By.css('.col-md-6')).length).toEqual(9)
   });
 });

--- a/ui/main/src/app/modules/settings/components/settings/settings.component.ts
+++ b/ui/main/src/app/modules/settings/components/settings/settings.component.ts
@@ -46,4 +46,5 @@ interface SettingsInputs {
   dateformat: boolean;
   datetimeformat: boolean;
   tags: boolean;
+  sounds: boolean;
 }

--- a/ui/main/src/app/modules/settings/settings.module.ts
+++ b/ui/main/src/app/modules/settings/settings.module.ts
@@ -19,6 +19,7 @@ import {ListSettingComponent} from './components/settings/list-setting/list-sett
 import {MultiSettingsComponent} from './components/settings/multi-settings/multi-settings.component';
 import {TypeAheadSettingsComponent} from './components/settings/type-ahead-settings/type-ahead-settings.component';
 import {TypeaheadModule} from 'ngx-type-ahead';
+import { CheckboxSettingComponent } from './components/settings/checkbox-setting/checkbox-setting.component';
 
 @NgModule({
     declarations: [SettingsComponent
@@ -27,7 +28,8 @@ import {TypeaheadModule} from 'ngx-type-ahead';
         , EmailSettingComponent
         , ListSettingComponent
         , MultiSettingsComponent
-        , TypeAheadSettingsComponent],
+        , TypeAheadSettingsComponent
+        , CheckboxSettingComponent],
     imports: [
         CommonModule,
         FormsModule,

--- a/ui/main/src/app/services/sound-notification.service.spec.ts
+++ b/ui/main/src/app/services/sound-notification.service.spec.ts
@@ -64,6 +64,8 @@ describe('SoundNotificationService', () => {
 
   it('should play appropriate sound only if card is visible and freshly published and its severity is on', () => {
 
+    //Handles 1 Action and 1 Information, should play 1 Action sound
+
     configOnlyActionOn();
 
     const today = new Date().getTime();
@@ -78,6 +80,8 @@ describe('SoundNotificationService', () => {
   });
 
   it('should play appropriate sound for all severities if card is visible and freshly published and all severities are on', () => {
+
+    //Handles 1 card of each severity, should play all four sounds
 
     configAllSeveritiesOn();
 

--- a/ui/main/src/app/services/sound-notification.service.ts
+++ b/ui/main/src/app/services/sound-notification.service.ts
@@ -52,15 +52,14 @@ export class SoundNotificationService {
     this.informationSoundPath = (baseHref?baseHref:'/')+'assets/sounds/information.mp3'
     this.informationSound = new Audio(this.informationSoundPath);
 
-    store.select(buildConfigSelector('sounds.alarm')).subscribe(x => { this.playSoundForAlarm = x;});
-    store.select(buildConfigSelector('sounds.action')).subscribe(x => { this.playSoundForAction = x;});
-    store.select(buildConfigSelector('sounds.compliant')).subscribe(x => { this.playSoundForCompliant = x;});
-    store.select(buildConfigSelector('sounds.information')).subscribe(x => { this.playSoundForInformation = x;});
+    store.select(buildSettingsOrConfigSelector('playSoundForAlarm')).subscribe(x => { this.playSoundForAlarm = x;});
+    store.select(buildSettingsOrConfigSelector('playSoundForAction')).subscribe(x => { this.playSoundForAction = x;});
+    store.select(buildSettingsOrConfigSelector('playSoundForCompliant')).subscribe(x => { this.playSoundForCompliant = x;});
+    store.select(buildSettingsOrConfigSelector('playSoundForInformation')).subscribe(x => { this.playSoundForInformation = x;});
 
   }
 
   handleCards(lightCards : LightCard[], currentlyVisibleIds : string[]) {
-
     from(lightCards).subscribe( //There is no need to unsubscribe because this is by essence a finite observable
         // TODO Possible improvement: all cards in an operation have the same publishDate (to be checked) so we could do this check only once by operation and either handle all cards or dismiss the batch entirely
         (card : LightCard) => {

--- a/ui/main/src/assets/i18n/en.json
+++ b/ui/main/src/assets/i18n/en.json
@@ -64,7 +64,12 @@
     "timeFormat": "Time format",
     "dateFormat": "Date format",
     "dateTimeFormat": "Date Time format",
-    "defaultTags": "Default tags"
+    "defaultTags": "Default tags",
+    "playSoundLabel": "Play sounds for cards with severity",
+    "playSoundForAlarm": "Alarm",
+    "playSoundForAction": "Action",
+    "playSoundForCompliant": "Compliant",
+    "playSoundForInformation": "Information"
   },
   "archive": {
     "filters": {

--- a/ui/main/src/assets/i18n/fr.json
+++ b/ui/main/src/assets/i18n/fr.json
@@ -64,7 +64,12 @@
     "timeFormat": "Format heure/minute",
     "dateFormat": "Format de date",
     "dateTimeFormat": "Format date et heure/minute",
-    "defaultTags": "Tags par défaut"
+    "defaultTags": "Tags par défaut",
+    "playSoundLabel": "Jouer des sons pour les cartes de type",
+    "playSoundForAlarm": "Alarme",
+    "playSoundForAction": "Action",
+    "playSoundForCompliant": "Conforme",
+    "playSoundForInformation": "Information"
   },
   "archive": {
     "filters": {


### PR DESCRIPTION
I decided to have four separate settings rather than a list because it made the checkbox component more reusable.
Note: I had to change the names of the configuration properties due to settings constraints.