### PR TITLE
[OC-814] removing bootstrap file copy in Action Dockerfile

### DIFF
--- a/services/core/actions/src/main/docker/Dockerfile
+++ b/services/core/actions/src/main/docker/Dockerfile
@@ -16,5 +16,4 @@ RUN env
 COPY add-certificates.sh /add-certificates.sh
 COPY java-config-dependent-docker-entrypoint.sh /docker-entrypoint.sh
 COPY ${JAR_FILE} app.jar
-COPY bootstrap-docker.yml /config/bootstrap.yml
 ENTRYPOINT ["/docker-entrypoint.sh"]


### PR DESCRIPTION
The bootstrap.yml file is no longer needed for Actions since it doesn't rely on the Config service anymore, so it should be removed from the Dockerfile otherwise the image can't be built.