### PR TITLE
[OC-814] Fixing deploy docker

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,8 @@ ext {
             securityOauthResource   : "org.springframework.security:spring-security-oauth2-resource-server:${versions['spring.security']}",
             securityOauthJose       : "org.springframework.security:spring-security-oauth2-jose:${versions['spring.security']}",
             securityTest            : "org.springframework.security:spring-security-test:${versions['spring.security']}",
-            webflux                 : "org.springframework:spring-webflux:${versions['spring']}"
+            webflux                 : "org.springframework:spring-webflux:${versions['spring']}",
+            retry                   : "org.springframework.retry:spring-retry:1.2.2.RELEASE"
     ]
 
     cloud = [

--- a/services/core/actions/src/main/docker/Dockerfile
+++ b/services/core/actions/src/main/docker/Dockerfile
@@ -16,4 +16,5 @@ RUN env
 COPY add-certificates.sh /add-certificates.sh
 COPY java-config-dependent-docker-entrypoint.sh /docker-entrypoint.sh
 COPY ${JAR_FILE} app.jar
+COPY application-docker.yml /config/application.yml
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/services/core/actions/src/main/resources/application-docker.yml
+++ b/services/core/actions/src/main/resources/application-docker.yml
@@ -1,0 +1,17 @@
+server:
+  port: 2105
+spring:
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          jwk-set-uri: http://keycloak:8080/auth/realms/dev/protocol/openid-connect/certs
+  data:
+    mongodb:
+      database: operator-fabric
+operatorfabric:
+  services:
+    base-url:
+      cards: http://cards-consultation:8080
+      thirds: http://thirds:8080
+      users: http://users:8080

--- a/services/infra/client-gateway/src/main/resources/bootstrap.yml
+++ b/services/infra/client-gateway/src/main/resources/bootstrap.yml
@@ -11,4 +11,5 @@ spring:
         service-id: config
         enabled: true
 logging:
-  level: debug
+  level:
+    root: debug

--- a/services/infra/registry/build.gradle
+++ b/services/infra/registry/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-    compile cloud.eurekaServer, boot.starterAop
+    compile cloud.eurekaServer, boot.starterAop, spring.retry
 }
 
 bootJar {

--- a/services/services.gradle
+++ b/services/services.gradle
@@ -112,7 +112,7 @@ subprojects {
             name "lfeoperatorfabric/of-${project.name.toLowerCase()}"
             tags 'latest', dockerVersionTag
             labels (['project':"${project.group}"])
-            files jar.archivePath, 'src/main/resources/bootstrap-docker.yml', '../../../src/main/docker/java-config-dependent-docker-entrypoint.sh', '../../../src/main/docker/java-config-docker-entrypoint.sh', '../../../src/main/docker/java-registry-docker-entrypoint.sh','../../../src/main/docker/add-certificates.sh'
+            files jar.archivePath, 'src/main/resources/bootstrap-docker.yml', 'src/main/resources/application-docker.yml', '../../../src/main/docker/java-config-dependent-docker-entrypoint.sh', '../../../src/main/docker/java-config-docker-entrypoint.sh', '../../../src/main/docker/java-registry-docker-entrypoint.sh','../../../src/main/docker/add-certificates.sh'
             buildArgs(['JAR_FILE'       : "${jar.archiveName}",
                        'http_proxy'     : apk.proxy.uri,
                        'https_proxy'    : apk.proxy.uri,

--- a/src/main/docker/deploy/docker-compose.yml
+++ b/src/main/docker/deploy/docker-compose.yml
@@ -1,6 +1,7 @@
 version: '2.1'
 services:
   mongodb:
+    container_name: mongodb
     image: mongo:4.1.1-xenial
     ports:
       - "27017:27017"
@@ -8,12 +9,14 @@ services:
       MONGO_INITDB_ROOT_USERNAME: root
       MONGO_INITDB_ROOT_PASSWORD: password
   rabbitmq:
+    container_name: rabbitmq
     image: rabbitmq:3-management
     ports:
       - "5672:5672"
       - "15672:15672"
 #      - "15674:15674"
   keycloak:
+    container_name: keycloak
     image: jboss/keycloak:6.0.1
     command: -Dkeycloak.migration.action=import -Dkeycloak.migration.provider=dir -Dkeycloak.migration.dir=/realms/export
     environment:
@@ -26,6 +29,7 @@ services:
     - "89:8080"
     - "90:9990"
   config:
+    container_name: config
     depends_on:
      - rabbitmq
     image: "lfeoperatorfabric/of-configuration-cloud-service:1.1.0.RELEASE"
@@ -46,6 +50,7 @@ services:
      - "../../../../src/main/docker/certificates:/certificates_to_add"
      - "../../../../services/infra/config/src/main/docker/volume/docker-configurations:/service-config"
   registry:
+    container_name: registry
     depends_on:
      - config
     image: "lfeoperatorfabric/of-registry-cloud-service:1.1.0.RELEASE"
@@ -61,6 +66,7 @@ services:
     volumes:
       - "../../../../src/main/docker/certificates:/certificates_to_add"
   client_gateway:
+    container_name: client_gateway
     depends_on:
      - registry
     image: "lfeoperatorfabric/of-client-gateway-cloud-service:1.1.0.RELEASE"
@@ -75,6 +81,7 @@ services:
     volumes:
       - "../../../../src/main/docker/certificates:/certificates_to_add"
   users:
+    container_name: users
     depends_on:
      - registry
     image: "lfeoperatorfabric/of-users-business-service:1.1.0.RELEASE"
@@ -89,6 +96,7 @@ services:
     volumes:
       - "../../../../src/main/docker/certificates:/certificates_to_add"
   thirds:
+    container_name: thirds
     depends_on:
      - registry
     image: "lfeoperatorfabric/of-thirds-business-service:1.1.0.RELEASE"
@@ -104,6 +112,7 @@ services:
      - "../../../../src/main/docker/certificates:/certificates_to_add"
      - "../../../../services/core/thirds/src/main/docker/volume/thirds-storage:/thirds-storage"
   cards-publication:
+    container_name: cards-publication
     depends_on:
      - registry
     image: "lfeoperatorfabric/of-cards-publication-business-service:1.1.0.RELEASE"
@@ -118,6 +127,7 @@ services:
     volumes:
       - "../../../../src/main/docker/certificates:/certificates_to_add"
   cards-consultation:
+    container_name: cards-consultation
     depends_on:
      - registry
     image: "lfeoperatorfabric/of-cards-consultation-business-service:1.1.0.RELEASE"
@@ -132,6 +142,7 @@ services:
     volumes:
       - "../../../../src/main/docker/certificates:/certificates_to_add"
   actions:
+    container_name: actions
     depends_on:
     - registry
     image: "lfeoperatorfabric/of-actions-business-service:1.1.0.RELEASE"
@@ -146,6 +157,7 @@ services:
     volumes:
       - "../../../../src/main/docker/certificates:/certificates_to_add"
   web-ui:
+    container_name: web-ui
     depends_on:
     - registry
     image: "lfeoperatorfabric/of-web-ui:1.1.0.RELEASE"


### PR DESCRIPTION
- Specifying container names in deploy docker-compose so Actions service can refer to the containers in its properties defining where to reach other services (users etc.)
- Adding Spring Cloud Retry dependency back for registry (without it, registry startup fails) -> created OC-833 to investigate
- Adding application-docker.yml file for action service defining config when running in docker mode

Tested that everything worked ok for actions by using the fake third server (launched from modified deploy docker compose so it was on the same network as the other containers).

Other issues created to investigate weird logs / inconsistent behaviour between run_all mode and docker mode: 
- OC-823
- OC-827
- OC-829
- OC-833
