### PR TITLE
configures cors for all routes for docker run-time

### DIFF
--- a/services/infra/config/src/main/docker/volume/docker-configurations/client-gateway.yml
+++ b/services/infra/config/src/main/docker/volume/docker-configurations/client-gateway.yml
@@ -1,6 +1,13 @@
 spring:
   cloud:
     gateway:
+      globalcors:
+        # WARNING : THIS CORS CONFIGURATION SHOULD NOT BE USED IN PRODUCTION
+        corsConfigurations:
+          '[/**]':
+            allowedOrigins: "*"
+            allowedMethods: "*"
+            allowedHeaders: "Authorization, Content-Type"
       routes:
       - id: auth
         uri: http://keycloak:8080
@@ -23,12 +30,5 @@ spring:
           - Path=/ui/**
         filters:
           - RewritePath=/ui/(?<path>.*), /$\{path}
-        # WARNING : THIS CORS CONFIGURATION SHOULD NOT BE USED IN PRODUCTION
-        globalcors:
-         corsConfigurations:
-          '[/**]':
-            allowedOrigins: "*"
-            allowedMethods: "*"
-            allowedHeaders: "Authorization, Content-Type"
 operatorfabric.gateway.configs:
   - web-ui.json


### PR DESCRIPTION
Enables usage of `ng serve` with docker deploy configuration.

Signed-off-by: LE-GALL Ronan Ext <43667786+rlg-rte@users.noreply.github.com>
