### PR TITLE
OC-910 Updating copyright headers in files

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -1,0 +1,22 @@
+Authors (GitHub usernames) in alphabetical order
+
+We decided against emails and first/last names in order not to make that information easily available to robots.
+
+agigox
+AlexGuironnetRTE
+bendaoudmba
+davidbinderRTE
+freddidierRTE
+HanaeSafiRTE
+jeandemanded
+JeroenGommans
+JulienBapt
+rlg-rte
+rte-amal
+samichehade
+taoufikbermaki
+vitorg
+vlo-rte
+youhou1515
+
+

--- a/PULL_REQUEST_TEMPLATE.adoc
+++ b/PULL_REQUEST_TEMPLATE.adoc
@@ -30,4 +30,6 @@ to be on the release notes).
 * Build and run OpFab locally to see the new feature or bug fix at work. In the case of a new feature, it's also a way
 of making sure that the configuration documentation is correct and easily understandable.
 * Depending on the scope of the PR , build docker images and test in docker mode
+* Check that the copyright header has been updated on the changed files if need be, and in the case of a first-time
+    contributor, make sure they're added to the AUTHORS.txt file.
 // end::review_checklist[]

--- a/PULL_REQUEST_TEMPLATE.adoc
+++ b/PULL_REQUEST_TEMPLATE.adoc
@@ -1,3 +1,10 @@
+// Copyright (c) 2018-2020 RTE (http://www.rte-france.com)
+// See AUTHORS.txt
+// This document is subject to the terms of the Creative Commons Attribution 4.0 International license.
+// If a copy of the license was not distributed with this
+// file, You can obtain one at https://creativecommons.org/licenses/by/4.0/.
+// SPDX-License-Identifier: CC-BY-4.0
+
 Please read through the checklist below to make sure that you haven't forgotten anything before submitting your PR.
 Then, remove the text and replace it with your PR comment.
 

--- a/README.adoc
+++ b/README.adoc
@@ -1,8 +1,10 @@
-// Copyright (c) 2020, RTE (http://www.rte-france.com)
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// Copyright (c) 2018-2020 RTE (http://www.rte-france.com)
+// See AUTHORS.txt
+// This document is subject to the terms of the Creative Commons Attribution 4.0 International license.
+// If a copy of the license was not distributed with this
+// file, You can obtain one at https://creativecommons.org/licenses/by/4.0/.
+// SPDX-License-Identifier: CC-BY-4.0
+
 
 :imagesdir: src/docs/asciidoc/images
 

--- a/bin/add_header.sh
+++ b/bin/add_header.sh
@@ -90,6 +90,7 @@ echo -e "\n"
 findCommand+="! -path \"$OF_HOME/services/core/thirds/src/test/data/bundles/*\" "
 findCommand+="-and ! -path \"$OF_HOME/services/core/thirds/src/main/docker/volume/thirds-storage/*\" "
 findCommand+="-and ! -path \"$OF_HOME/services/core/thirds/src/test/docker/volume/thirds-storage/*\" "
+findCommand+="-and ! -path \"$OF_HOME/src/test/utils/karate/thirds/resources/*\" "
 
 #Exclude generated folders from ui
 findCommand+="-and ! -path \"$OF_HOME/ui/main/build/*\" "

--- a/client/actions/src/main/java/org/lfenergy/operatorfabric/actions/model/ActionEnum.java
+++ b/client/actions/src/main/java/org/lfenergy/operatorfabric/actions/model/ActionEnum.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.actions.model;

--- a/client/actions/src/main/java/org/lfenergy/operatorfabric/actions/model/InputEnum.java
+++ b/client/actions/src/main/java/org/lfenergy/operatorfabric/actions/model/InputEnum.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.actions.model;

--- a/client/cards/src/main/java/org/lfenergy/operatorfabric/cards/model/CardOperationTypeEnum.java
+++ b/client/cards/src/main/java/org/lfenergy/operatorfabric/cards/model/CardOperationTypeEnum.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.cards.model;

--- a/client/cards/src/main/java/org/lfenergy/operatorfabric/cards/model/InputEnum.java
+++ b/client/cards/src/main/java/org/lfenergy/operatorfabric/cards/model/InputEnum.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.cards.model;

--- a/client/cards/src/main/java/org/lfenergy/operatorfabric/cards/model/RecipientEnum.java
+++ b/client/cards/src/main/java/org/lfenergy/operatorfabric/cards/model/RecipientEnum.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.cards.model;

--- a/client/cards/src/main/java/org/lfenergy/operatorfabric/cards/model/SeverityEnum.java
+++ b/client/cards/src/main/java/org/lfenergy/operatorfabric/cards/model/SeverityEnum.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.cards.model;

--- a/client/cards/src/main/java/org/lfenergy/operatorfabric/cards/model/TimeSpanDisplayModeEnum.java
+++ b/client/cards/src/main/java/org/lfenergy/operatorfabric/cards/model/TimeSpanDisplayModeEnum.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 package org.lfenergy.operatorfabric.cards.model;
 

--- a/client/cards/src/main/java/org/lfenergy/operatorfabric/cards/model/TitlePositionEnum.java
+++ b/client/cards/src/main/java/org/lfenergy/operatorfabric/cards/model/TitlePositionEnum.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.cards.model;

--- a/client/thirds/src/main/java/org/lfenergy/operatorfabric/thirds/model/ActionEnum.java
+++ b/client/thirds/src/main/java/org/lfenergy/operatorfabric/thirds/model/ActionEnum.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.thirds.model;

--- a/client/thirds/src/main/java/org/lfenergy/operatorfabric/thirds/model/InputEnum.java
+++ b/client/thirds/src/main/java/org/lfenergy/operatorfabric/thirds/model/InputEnum.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.thirds.model;

--- a/client/users/src/main/java/org/lfenergy/operatorfabric/users/model/RightsEnum.java
+++ b/client/users/src/main/java/org/lfenergy/operatorfabric/users/model/RightsEnum.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 package org.lfenergy.operatorfabric.users.model;
 

--- a/services/core/actions/src/main/java/org/lfenergy/operatorfabric/actions/ActionsApplication.java
+++ b/services/core/actions/src/main/java/org/lfenergy/operatorfabric/actions/ActionsApplication.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.actions;

--- a/services/core/actions/src/main/java/org/lfenergy/operatorfabric/actions/configuration/Common.java
+++ b/services/core/actions/src/main/java/org/lfenergy/operatorfabric/actions/configuration/Common.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 package org.lfenergy.operatorfabric.actions.configuration;
 

--- a/services/core/actions/src/main/java/org/lfenergy/operatorfabric/actions/configuration/json/ActionsModule.java
+++ b/services/core/actions/src/main/java/org/lfenergy/operatorfabric/actions/configuration/json/ActionsModule.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.actions.configuration.json;

--- a/services/core/actions/src/main/java/org/lfenergy/operatorfabric/actions/configuration/json/JacksonConfig.java
+++ b/services/core/actions/src/main/java/org/lfenergy/operatorfabric/actions/configuration/json/JacksonConfig.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.actions.configuration.json;

--- a/services/core/actions/src/main/java/org/lfenergy/operatorfabric/actions/configuration/webflux/ActionRoutesConfig.java
+++ b/services/core/actions/src/main/java/org/lfenergy/operatorfabric/actions/configuration/webflux/ActionRoutesConfig.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.actions.configuration.webflux;

--- a/services/core/actions/src/main/java/org/lfenergy/operatorfabric/actions/configuration/webflux/GlobalErrorAttributes.java
+++ b/services/core/actions/src/main/java/org/lfenergy/operatorfabric/actions/configuration/webflux/GlobalErrorAttributes.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.actions.configuration.webflux;

--- a/services/core/actions/src/main/java/org/lfenergy/operatorfabric/actions/configuration/webflux/GlobalErrorWebExceptionHandler.java
+++ b/services/core/actions/src/main/java/org/lfenergy/operatorfabric/actions/configuration/webflux/GlobalErrorWebExceptionHandler.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.actions.configuration.webflux;

--- a/services/core/actions/src/main/java/org/lfenergy/operatorfabric/actions/configuration/webflux/WebSecurityConfiguration.java
+++ b/services/core/actions/src/main/java/org/lfenergy/operatorfabric/actions/configuration/webflux/WebSecurityConfiguration.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.actions.configuration.webflux;

--- a/services/core/actions/src/main/java/org/lfenergy/operatorfabric/actions/model/ActionData.java
+++ b/services/core/actions/src/main/java/org/lfenergy/operatorfabric/actions/model/ActionData.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 package org.lfenergy.operatorfabric.actions.model;
 

--- a/services/core/actions/src/main/java/org/lfenergy/operatorfabric/actions/model/ActionStatusData.java
+++ b/services/core/actions/src/main/java/org/lfenergy/operatorfabric/actions/model/ActionStatusData.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 package org.lfenergy.operatorfabric.actions.model;
 

--- a/services/core/actions/src/main/java/org/lfenergy/operatorfabric/actions/model/I18nData.java
+++ b/services/core/actions/src/main/java/org/lfenergy/operatorfabric/actions/model/I18nData.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 package org.lfenergy.operatorfabric.actions.model;
 

--- a/services/core/actions/src/main/java/org/lfenergy/operatorfabric/actions/services/ActionService.java
+++ b/services/core/actions/src/main/java/org/lfenergy/operatorfabric/actions/services/ActionService.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 package org.lfenergy.operatorfabric.actions.services;
 

--- a/services/core/actions/src/main/java/org/lfenergy/operatorfabric/actions/services/clients/CardConsultationClient.java
+++ b/services/core/actions/src/main/java/org/lfenergy/operatorfabric/actions/services/clients/CardConsultationClient.java
@@ -1,3 +1,12 @@
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
+ */
+
 package org.lfenergy.operatorfabric.actions.services.clients;
 
 import lombok.extern.slf4j.Slf4j;

--- a/services/core/actions/src/main/java/org/lfenergy/operatorfabric/actions/services/clients/ThirdClient.java
+++ b/services/core/actions/src/main/java/org/lfenergy/operatorfabric/actions/services/clients/ThirdClient.java
@@ -1,3 +1,12 @@
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
+ */
+
 package org.lfenergy.operatorfabric.actions.services.clients;
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/services/core/actions/src/main/java/org/lfenergy/operatorfabric/actions/services/clients/UserClient.java
+++ b/services/core/actions/src/main/java/org/lfenergy/operatorfabric/actions/services/clients/UserClient.java
@@ -1,3 +1,12 @@
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
+ */
+
 package org.lfenergy.operatorfabric.actions.services.clients;
 
 import lombok.extern.slf4j.Slf4j;

--- a/services/core/actions/src/test/java/org/lfenergy/operatorfabric/actions/application/IntegrationTestApplication.java
+++ b/services/core/actions/src/test/java/org/lfenergy/operatorfabric/actions/application/IntegrationTestApplication.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.actions.application;

--- a/services/core/actions/src/test/java/org/lfenergy/operatorfabric/actions/application/configuration/WebSecurityConfiguration.java
+++ b/services/core/actions/src/test/java/org/lfenergy/operatorfabric/actions/application/configuration/WebSecurityConfiguration.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.actions.application.configuration;

--- a/services/core/actions/src/test/java/org/lfenergy/operatorfabric/actions/model/ActionStatusDataShould.java
+++ b/services/core/actions/src/test/java/org/lfenergy/operatorfabric/actions/model/ActionStatusDataShould.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 package org.lfenergy.operatorfabric.actions.model;
 

--- a/services/core/actions/src/test/java/org/lfenergy/operatorfabric/actions/services/ActionServiceShould.java
+++ b/services/core/actions/src/test/java/org/lfenergy/operatorfabric/actions/services/ActionServiceShould.java
@@ -1,3 +1,12 @@
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
+ */
+
 package org.lfenergy.operatorfabric.actions.services;
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/services/core/cards-consultation/src/main/java/org/lfenergy/operatorfabric/cards/consultation/CardConsultationApplication.java
+++ b/services/core/cards-consultation/src/main/java/org/lfenergy/operatorfabric/cards/consultation/CardConsultationApplication.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.cards.consultation;

--- a/services/core/cards-consultation/src/main/java/org/lfenergy/operatorfabric/cards/consultation/configuration/json/CardsModule.java
+++ b/services/core/cards-consultation/src/main/java/org/lfenergy/operatorfabric/cards/consultation/configuration/json/CardsModule.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.cards.consultation.configuration.json;

--- a/services/core/cards-consultation/src/main/java/org/lfenergy/operatorfabric/cards/consultation/configuration/json/JacksonConfig.java
+++ b/services/core/cards-consultation/src/main/java/org/lfenergy/operatorfabric/cards/consultation/configuration/json/JacksonConfig.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.cards.consultation.configuration.json;

--- a/services/core/cards-consultation/src/main/java/org/lfenergy/operatorfabric/cards/consultation/configuration/json/PageImplSerializer.java
+++ b/services/core/cards-consultation/src/main/java/org/lfenergy/operatorfabric/cards/consultation/configuration/json/PageImplSerializer.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.cards.consultation.configuration.json;

--- a/services/core/cards-consultation/src/main/java/org/lfenergy/operatorfabric/cards/consultation/configuration/json/PagedResultsModule.java
+++ b/services/core/cards-consultation/src/main/java/org/lfenergy/operatorfabric/cards/consultation/configuration/json/PagedResultsModule.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.cards.consultation.configuration.json;

--- a/services/core/cards-consultation/src/main/java/org/lfenergy/operatorfabric/cards/consultation/configuration/mongo/CardOperationReadConverter.java
+++ b/services/core/cards-consultation/src/main/java/org/lfenergy/operatorfabric/cards/consultation/configuration/mongo/CardOperationReadConverter.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.cards.consultation.configuration.mongo;

--- a/services/core/cards-consultation/src/main/java/org/lfenergy/operatorfabric/cards/consultation/configuration/mongo/DetailReadConverter.java
+++ b/services/core/cards-consultation/src/main/java/org/lfenergy/operatorfabric/cards/consultation/configuration/mongo/DetailReadConverter.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.cards.consultation.configuration.mongo;

--- a/services/core/cards-consultation/src/main/java/org/lfenergy/operatorfabric/cards/consultation/configuration/mongo/I18nReadConverter.java
+++ b/services/core/cards-consultation/src/main/java/org/lfenergy/operatorfabric/cards/consultation/configuration/mongo/I18nReadConverter.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.cards.consultation.configuration.mongo;

--- a/services/core/cards-consultation/src/main/java/org/lfenergy/operatorfabric/cards/consultation/configuration/mongo/LightCardReadConverter.java
+++ b/services/core/cards-consultation/src/main/java/org/lfenergy/operatorfabric/cards/consultation/configuration/mongo/LightCardReadConverter.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.cards.consultation.configuration.mongo;

--- a/services/core/cards-consultation/src/main/java/org/lfenergy/operatorfabric/cards/consultation/configuration/mongo/LocalMongoConfiguration.java
+++ b/services/core/cards-consultation/src/main/java/org/lfenergy/operatorfabric/cards/consultation/configuration/mongo/LocalMongoConfiguration.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.cards.consultation.configuration.mongo;

--- a/services/core/cards-consultation/src/main/java/org/lfenergy/operatorfabric/cards/consultation/configuration/mongo/RecipientReadConverter.java
+++ b/services/core/cards-consultation/src/main/java/org/lfenergy/operatorfabric/cards/consultation/configuration/mongo/RecipientReadConverter.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.cards.consultation.configuration.mongo;

--- a/services/core/cards-consultation/src/main/java/org/lfenergy/operatorfabric/cards/consultation/configuration/mongo/TimeSpanReadConverter.java
+++ b/services/core/cards-consultation/src/main/java/org/lfenergy/operatorfabric/cards/consultation/configuration/mongo/TimeSpanReadConverter.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.cards.consultation.configuration.mongo;

--- a/services/core/cards-consultation/src/main/java/org/lfenergy/operatorfabric/cards/consultation/configuration/webflux/ArchivedCardRoutesConfig.java
+++ b/services/core/cards-consultation/src/main/java/org/lfenergy/operatorfabric/cards/consultation/configuration/webflux/ArchivedCardRoutesConfig.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 package org.lfenergy.operatorfabric.cards.consultation.configuration.webflux;
 

--- a/services/core/cards-consultation/src/main/java/org/lfenergy/operatorfabric/cards/consultation/configuration/webflux/CardRoutesConfig.java
+++ b/services/core/cards-consultation/src/main/java/org/lfenergy/operatorfabric/cards/consultation/configuration/webflux/CardRoutesConfig.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.cards.consultation.configuration.webflux;

--- a/services/core/cards-consultation/src/main/java/org/lfenergy/operatorfabric/cards/consultation/configuration/webflux/CardSubscriptionRoutesConfig.java
+++ b/services/core/cards-consultation/src/main/java/org/lfenergy/operatorfabric/cards/consultation/configuration/webflux/CardSubscriptionRoutesConfig.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.cards.consultation.configuration.webflux;

--- a/services/core/cards-consultation/src/main/java/org/lfenergy/operatorfabric/cards/consultation/configuration/webflux/GlobalErrorAttributes.java
+++ b/services/core/cards-consultation/src/main/java/org/lfenergy/operatorfabric/cards/consultation/configuration/webflux/GlobalErrorAttributes.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.cards.consultation.configuration.webflux;

--- a/services/core/cards-consultation/src/main/java/org/lfenergy/operatorfabric/cards/consultation/configuration/webflux/GlobalErrorWebExceptionHandler.java
+++ b/services/core/cards-consultation/src/main/java/org/lfenergy/operatorfabric/cards/consultation/configuration/webflux/GlobalErrorWebExceptionHandler.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.cards.consultation.configuration.webflux;

--- a/services/core/cards-consultation/src/main/java/org/lfenergy/operatorfabric/cards/consultation/configuration/webflux/UserExtractor.java
+++ b/services/core/cards-consultation/src/main/java/org/lfenergy/operatorfabric/cards/consultation/configuration/webflux/UserExtractor.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 package org.lfenergy.operatorfabric.cards.consultation.configuration.webflux;
 

--- a/services/core/cards-consultation/src/main/java/org/lfenergy/operatorfabric/cards/consultation/configuration/webflux/WebSecurityConfiguration.java
+++ b/services/core/cards-consultation/src/main/java/org/lfenergy/operatorfabric/cards/consultation/configuration/webflux/WebSecurityConfiguration.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.cards.consultation.configuration.webflux;

--- a/services/core/cards-consultation/src/main/java/org/lfenergy/operatorfabric/cards/consultation/controllers/CardOperationsController.java
+++ b/services/core/cards-consultation/src/main/java/org/lfenergy/operatorfabric/cards/consultation/controllers/CardOperationsController.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.cards.consultation.controllers;

--- a/services/core/cards-consultation/src/main/java/org/lfenergy/operatorfabric/cards/consultation/controllers/CardOperationsGetParameters.java
+++ b/services/core/cards-consultation/src/main/java/org/lfenergy/operatorfabric/cards/consultation/controllers/CardOperationsGetParameters.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.cards.consultation.controllers;

--- a/services/core/cards-consultation/src/main/java/org/lfenergy/operatorfabric/cards/consultation/model/ArchivedCardConsultationData.java
+++ b/services/core/cards-consultation/src/main/java/org/lfenergy/operatorfabric/cards/consultation/model/ArchivedCardConsultationData.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.cards.consultation.model;

--- a/services/core/cards-consultation/src/main/java/org/lfenergy/operatorfabric/cards/consultation/model/CardConsultationData.java
+++ b/services/core/cards-consultation/src/main/java/org/lfenergy/operatorfabric/cards/consultation/model/CardConsultationData.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.cards.consultation.model;

--- a/services/core/cards-consultation/src/main/java/org/lfenergy/operatorfabric/cards/consultation/model/CardConsultationMessage.java
+++ b/services/core/cards-consultation/src/main/java/org/lfenergy/operatorfabric/cards/consultation/model/CardConsultationMessage.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.cards.consultation.model;

--- a/services/core/cards-consultation/src/main/java/org/lfenergy/operatorfabric/cards/consultation/model/CardOperationConsultationData.java
+++ b/services/core/cards-consultation/src/main/java/org/lfenergy/operatorfabric/cards/consultation/model/CardOperationConsultationData.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.cards.consultation.model;

--- a/services/core/cards-consultation/src/main/java/org/lfenergy/operatorfabric/cards/consultation/model/CardSubscriptionDto.java
+++ b/services/core/cards-consultation/src/main/java/org/lfenergy/operatorfabric/cards/consultation/model/CardSubscriptionDto.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 package org.lfenergy.operatorfabric.cards.consultation.model;
 

--- a/services/core/cards-consultation/src/main/java/org/lfenergy/operatorfabric/cards/consultation/model/DetailConsultationData.java
+++ b/services/core/cards-consultation/src/main/java/org/lfenergy/operatorfabric/cards/consultation/model/DetailConsultationData.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.cards.consultation.model;

--- a/services/core/cards-consultation/src/main/java/org/lfenergy/operatorfabric/cards/consultation/model/I18nConsultationData.java
+++ b/services/core/cards-consultation/src/main/java/org/lfenergy/operatorfabric/cards/consultation/model/I18nConsultationData.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.cards.consultation.model;

--- a/services/core/cards-consultation/src/main/java/org/lfenergy/operatorfabric/cards/consultation/model/LightCardConsultationData.java
+++ b/services/core/cards-consultation/src/main/java/org/lfenergy/operatorfabric/cards/consultation/model/LightCardConsultationData.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.cards.consultation.model;

--- a/services/core/cards-consultation/src/main/java/org/lfenergy/operatorfabric/cards/consultation/model/RecipientConsultationData.java
+++ b/services/core/cards-consultation/src/main/java/org/lfenergy/operatorfabric/cards/consultation/model/RecipientConsultationData.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.cards.consultation.model;

--- a/services/core/cards-consultation/src/main/java/org/lfenergy/operatorfabric/cards/consultation/model/TimeSpanConsultationData.java
+++ b/services/core/cards-consultation/src/main/java/org/lfenergy/operatorfabric/cards/consultation/model/TimeSpanConsultationData.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 package org.lfenergy.operatorfabric.cards.consultation.model;
 

--- a/services/core/cards-consultation/src/main/java/org/lfenergy/operatorfabric/cards/consultation/repositories/ArchivedCardCustomRepository.java
+++ b/services/core/cards-consultation/src/main/java/org/lfenergy/operatorfabric/cards/consultation/repositories/ArchivedCardCustomRepository.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 package org.lfenergy.operatorfabric.cards.consultation.repositories;
 

--- a/services/core/cards-consultation/src/main/java/org/lfenergy/operatorfabric/cards/consultation/repositories/ArchivedCardCustomRepositoryImpl.java
+++ b/services/core/cards-consultation/src/main/java/org/lfenergy/operatorfabric/cards/consultation/repositories/ArchivedCardCustomRepositoryImpl.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 package org.lfenergy.operatorfabric.cards.consultation.repositories;
 

--- a/services/core/cards-consultation/src/main/java/org/lfenergy/operatorfabric/cards/consultation/repositories/ArchivedCardRepository.java
+++ b/services/core/cards-consultation/src/main/java/org/lfenergy/operatorfabric/cards/consultation/repositories/ArchivedCardRepository.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.cards.consultation.repositories;

--- a/services/core/cards-consultation/src/main/java/org/lfenergy/operatorfabric/cards/consultation/repositories/CardCustomRepository.java
+++ b/services/core/cards-consultation/src/main/java/org/lfenergy/operatorfabric/cards/consultation/repositories/CardCustomRepository.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 package org.lfenergy.operatorfabric.cards.consultation.repositories;
 

--- a/services/core/cards-consultation/src/main/java/org/lfenergy/operatorfabric/cards/consultation/repositories/CardCustomRepositoryImpl.java
+++ b/services/core/cards-consultation/src/main/java/org/lfenergy/operatorfabric/cards/consultation/repositories/CardCustomRepositoryImpl.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 package org.lfenergy.operatorfabric.cards.consultation.repositories;
 

--- a/services/core/cards-consultation/src/main/java/org/lfenergy/operatorfabric/cards/consultation/repositories/CardOperationRepository.java
+++ b/services/core/cards-consultation/src/main/java/org/lfenergy/operatorfabric/cards/consultation/repositories/CardOperationRepository.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.cards.consultation.repositories;

--- a/services/core/cards-consultation/src/main/java/org/lfenergy/operatorfabric/cards/consultation/repositories/CardOperationRepositoryImpl.java
+++ b/services/core/cards-consultation/src/main/java/org/lfenergy/operatorfabric/cards/consultation/repositories/CardOperationRepositoryImpl.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.cards.consultation.repositories;

--- a/services/core/cards-consultation/src/main/java/org/lfenergy/operatorfabric/cards/consultation/repositories/CardRepository.java
+++ b/services/core/cards-consultation/src/main/java/org/lfenergy/operatorfabric/cards/consultation/repositories/CardRepository.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.cards.consultation.repositories;

--- a/services/core/cards-consultation/src/main/java/org/lfenergy/operatorfabric/cards/consultation/repositories/UserUtilitiesCommonToCardRepository.java
+++ b/services/core/cards-consultation/src/main/java/org/lfenergy/operatorfabric/cards/consultation/repositories/UserUtilitiesCommonToCardRepository.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 package org.lfenergy.operatorfabric.cards.consultation.repositories;
 

--- a/services/core/cards-consultation/src/main/java/org/lfenergy/operatorfabric/cards/consultation/services/CardSubscription.java
+++ b/services/core/cards-consultation/src/main/java/org/lfenergy/operatorfabric/cards/consultation/services/CardSubscription.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.cards.consultation.services;

--- a/services/core/cards-consultation/src/main/java/org/lfenergy/operatorfabric/cards/consultation/services/CardSubscriptionService.java
+++ b/services/core/cards-consultation/src/main/java/org/lfenergy/operatorfabric/cards/consultation/services/CardSubscriptionService.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.cards.consultation.services;

--- a/services/core/cards-consultation/src/test/java/org/lfenergy/operatorfabric/cards/consultation/TestUtilities.java
+++ b/services/core/cards-consultation/src/test/java/org/lfenergy/operatorfabric/cards/consultation/TestUtilities.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.cards.consultation;

--- a/services/core/cards-consultation/src/test/java/org/lfenergy/operatorfabric/cards/consultation/application/IntegrationTestApplication.java
+++ b/services/core/cards-consultation/src/test/java/org/lfenergy/operatorfabric/cards/consultation/application/IntegrationTestApplication.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.cards.consultation.application;

--- a/services/core/cards-consultation/src/test/java/org/lfenergy/operatorfabric/cards/consultation/application/configuration/WebSecurityConfiguration.java
+++ b/services/core/cards-consultation/src/test/java/org/lfenergy/operatorfabric/cards/consultation/application/configuration/WebSecurityConfiguration.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.cards.consultation.application.configuration;

--- a/services/core/cards-consultation/src/test/java/org/lfenergy/operatorfabric/cards/consultation/controllers/CardOperationsControllerShould.java
+++ b/services/core/cards-consultation/src/test/java/org/lfenergy/operatorfabric/cards/consultation/controllers/CardOperationsControllerShould.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.cards.consultation.controllers;

--- a/services/core/cards-consultation/src/test/java/org/lfenergy/operatorfabric/cards/consultation/repositories/ArchivedCardRepositoryShould.java
+++ b/services/core/cards-consultation/src/test/java/org/lfenergy/operatorfabric/cards/consultation/repositories/ArchivedCardRepositoryShould.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.cards.consultation.repositories;

--- a/services/core/cards-consultation/src/test/java/org/lfenergy/operatorfabric/cards/consultation/repositories/CardRepositoryShould.java
+++ b/services/core/cards-consultation/src/test/java/org/lfenergy/operatorfabric/cards/consultation/repositories/CardRepositoryShould.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.cards.consultation.repositories;

--- a/services/core/cards-consultation/src/test/java/org/lfenergy/operatorfabric/cards/consultation/routes/ArchivedCardRoutesShould.java
+++ b/services/core/cards-consultation/src/test/java/org/lfenergy/operatorfabric/cards/consultation/routes/ArchivedCardRoutesShould.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.cards.consultation.routes;

--- a/services/core/cards-consultation/src/test/java/org/lfenergy/operatorfabric/cards/consultation/routes/CardRoutesShould.java
+++ b/services/core/cards-consultation/src/test/java/org/lfenergy/operatorfabric/cards/consultation/routes/CardRoutesShould.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.cards.consultation.routes;

--- a/services/core/cards-consultation/src/test/java/org/lfenergy/operatorfabric/cards/consultation/services/CardSubscriptionServiceShould.java
+++ b/services/core/cards-consultation/src/test/java/org/lfenergy/operatorfabric/cards/consultation/services/CardSubscriptionServiceShould.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.cards.consultation.services;

--- a/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/CardPublicationApplication.java
+++ b/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/CardPublicationApplication.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.cards.publication;

--- a/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/configuration/WebFluxConfig.java
+++ b/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/configuration/WebFluxConfig.java
@@ -1,3 +1,12 @@
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
+ */
+
 /* Copyright (c) 2018, RTE (http://www.rte-france.com)
  *
  * This Source Code Form is subject to the terms of the Mozilla Public

--- a/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/configuration/json/CardsModule.java
+++ b/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/configuration/json/CardsModule.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.cards.publication.configuration.json;

--- a/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/configuration/json/JacksonConfig.java
+++ b/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/configuration/json/JacksonConfig.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.cards.publication.configuration.json;

--- a/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/configuration/mongo/DetailReadConverter.java
+++ b/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/configuration/mongo/DetailReadConverter.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.cards.publication.configuration.mongo;

--- a/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/configuration/mongo/DetailWriterConverter.java
+++ b/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/configuration/mongo/DetailWriterConverter.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.cards.publication.configuration.mongo;

--- a/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/configuration/mongo/I18nReadConverter.java
+++ b/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/configuration/mongo/I18nReadConverter.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.cards.publication.configuration.mongo;

--- a/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/configuration/mongo/I18nWriterConverter.java
+++ b/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/configuration/mongo/I18nWriterConverter.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 package org.lfenergy.operatorfabric.cards.publication.configuration.mongo;
 

--- a/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/configuration/mongo/LocalMongoConfiguration.java
+++ b/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/configuration/mongo/LocalMongoConfiguration.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.cards.publication.configuration.mongo;

--- a/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/configuration/mongo/RecipientReadConverter.java
+++ b/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/configuration/mongo/RecipientReadConverter.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.cards.publication.configuration.mongo;

--- a/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/configuration/mongo/RecipientWriterConverter.java
+++ b/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/configuration/mongo/RecipientWriterConverter.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.cards.publication.configuration.mongo;

--- a/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/configuration/mongo/TimeSpanReadConverter.java
+++ b/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/configuration/mongo/TimeSpanReadConverter.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.cards.publication.configuration.mongo;

--- a/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/configuration/mongo/TimeSpanWriterConverter.java
+++ b/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/configuration/mongo/TimeSpanWriterConverter.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.cards.publication.configuration.mongo;

--- a/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/controllers/AsyncCardController.java
+++ b/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/controllers/AsyncCardController.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.cards.publication.controllers;

--- a/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/controllers/CardController.java
+++ b/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/controllers/CardController.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.cards.publication.controllers;

--- a/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/model/ArchivedCardPublicationData.java
+++ b/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/model/ArchivedCardPublicationData.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.cards.publication.model;

--- a/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/model/CardCreationReportData.java
+++ b/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/model/CardCreationReportData.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.cards.publication.model;

--- a/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/model/CardOperationData.java
+++ b/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/model/CardOperationData.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.cards.publication.model;

--- a/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/model/CardPublicationData.java
+++ b/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/model/CardPublicationData.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.cards.publication.model;

--- a/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/model/DetailPublicationData.java
+++ b/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/model/DetailPublicationData.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.cards.publication.model;

--- a/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/model/I18nPublicationData.java
+++ b/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/model/I18nPublicationData.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.cards.publication.model;

--- a/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/model/LightCardPublicationData.java
+++ b/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/model/LightCardPublicationData.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.cards.publication.model;

--- a/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/model/RecipientPublicationData.java
+++ b/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/model/RecipientPublicationData.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.cards.publication.model;

--- a/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/model/TimeSpanPublicationData.java
+++ b/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/model/TimeSpanPublicationData.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 package org.lfenergy.operatorfabric.cards.publication.model;
 

--- a/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/services/CardNotificationService.java
+++ b/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/services/CardNotificationService.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.cards.publication.services;

--- a/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/services/CardProcessingService.java
+++ b/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/services/CardProcessingService.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 package org.lfenergy.operatorfabric.cards.publication.services;
 

--- a/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/services/CardRepositoryService.java
+++ b/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/services/CardRepositoryService.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 package org.lfenergy.operatorfabric.cards.publication.services;
 

--- a/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/services/ComputedRecipient.java
+++ b/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/services/ComputedRecipient.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.cards.publication.services;

--- a/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/services/RecipientProcessor.java
+++ b/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/services/RecipientProcessor.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.cards.publication.services;

--- a/services/core/cards-publication/src/test/java/org/lfenergy/operatorfabric/cards/publication/application/UnitTestApplication.java
+++ b/services/core/cards-publication/src/test/java/org/lfenergy/operatorfabric/cards/publication/application/UnitTestApplication.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.cards.publication.application;

--- a/services/core/cards-publication/src/test/java/org/lfenergy/operatorfabric/cards/publication/configuration/ObjectMapperShould.java
+++ b/services/core/cards-publication/src/test/java/org/lfenergy/operatorfabric/cards/publication/configuration/ObjectMapperShould.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.cards.publication.configuration;

--- a/services/core/cards-publication/src/test/java/org/lfenergy/operatorfabric/cards/publication/configuration/TestCardReceiver.java
+++ b/services/core/cards-publication/src/test/java/org/lfenergy/operatorfabric/cards/publication/configuration/TestCardReceiver.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.cards.publication.configuration;

--- a/services/core/cards-publication/src/test/java/org/lfenergy/operatorfabric/cards/publication/configuration/TestConsumerConfig.java
+++ b/services/core/cards-publication/src/test/java/org/lfenergy/operatorfabric/cards/publication/configuration/TestConsumerConfig.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.cards.publication.configuration;

--- a/services/core/cards-publication/src/test/java/org/lfenergy/operatorfabric/cards/publication/controllers/AsyncCardControllerShould.java
+++ b/services/core/cards-publication/src/test/java/org/lfenergy/operatorfabric/cards/publication/controllers/AsyncCardControllerShould.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.cards.publication.controllers;

--- a/services/core/cards-publication/src/test/java/org/lfenergy/operatorfabric/cards/publication/controllers/CardControllerShould.java
+++ b/services/core/cards-publication/src/test/java/org/lfenergy/operatorfabric/cards/publication/controllers/CardControllerShould.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.cards.publication.controllers;

--- a/services/core/cards-publication/src/test/java/org/lfenergy/operatorfabric/cards/publication/repositories/ArchivedCardRepositoryForTest.java
+++ b/services/core/cards-publication/src/test/java/org/lfenergy/operatorfabric/cards/publication/repositories/ArchivedCardRepositoryForTest.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.cards.publication.repositories;

--- a/services/core/cards-publication/src/test/java/org/lfenergy/operatorfabric/cards/publication/repositories/CardRepositoryForTest.java
+++ b/services/core/cards-publication/src/test/java/org/lfenergy/operatorfabric/cards/publication/repositories/CardRepositoryForTest.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.cards.publication.repositories;

--- a/services/core/cards-publication/src/test/java/org/lfenergy/operatorfabric/cards/publication/services/CardNotificationServiceShould.java
+++ b/services/core/cards-publication/src/test/java/org/lfenergy/operatorfabric/cards/publication/services/CardNotificationServiceShould.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.cards.publication.services;

--- a/services/core/cards-publication/src/test/java/org/lfenergy/operatorfabric/cards/publication/services/CardProcessServiceShould.java
+++ b/services/core/cards-publication/src/test/java/org/lfenergy/operatorfabric/cards/publication/services/CardProcessServiceShould.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 package org.lfenergy.operatorfabric.cards.publication.services;
 

--- a/services/core/cards-publication/src/test/java/org/lfenergy/operatorfabric/cards/publication/services/RecipientProcessorShould.java
+++ b/services/core/cards-publication/src/test/java/org/lfenergy/operatorfabric/cards/publication/services/RecipientProcessorShould.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.cards.publication.services;

--- a/services/core/thirds/src/main/java/org/lfenergy/operatorfabric/thirds/ThirdsApplication.java
+++ b/services/core/thirds/src/main/java/org/lfenergy/operatorfabric/thirds/ThirdsApplication.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.thirds;

--- a/services/core/thirds/src/main/java/org/lfenergy/operatorfabric/thirds/configuration/json/JacksonConfig.java
+++ b/services/core/thirds/src/main/java/org/lfenergy/operatorfabric/thirds/configuration/json/JacksonConfig.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.thirds.configuration.json;

--- a/services/core/thirds/src/main/java/org/lfenergy/operatorfabric/thirds/configuration/json/ThirdsModule.java
+++ b/services/core/thirds/src/main/java/org/lfenergy/operatorfabric/thirds/configuration/json/ThirdsModule.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.thirds.configuration.json;

--- a/services/core/thirds/src/main/java/org/lfenergy/operatorfabric/thirds/configuration/oauth2/WebSecurityConfiguration.java
+++ b/services/core/thirds/src/main/java/org/lfenergy/operatorfabric/thirds/configuration/oauth2/WebSecurityConfiguration.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.thirds.configuration.oauth2;

--- a/services/core/thirds/src/main/java/org/lfenergy/operatorfabric/thirds/controllers/CustomExceptionHandler.java
+++ b/services/core/thirds/src/main/java/org/lfenergy/operatorfabric/thirds/controllers/CustomExceptionHandler.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.thirds.controllers;

--- a/services/core/thirds/src/main/java/org/lfenergy/operatorfabric/thirds/controllers/ThirdsController.java
+++ b/services/core/thirds/src/main/java/org/lfenergy/operatorfabric/thirds/controllers/ThirdsController.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.thirds.controllers;

--- a/services/core/thirds/src/main/java/org/lfenergy/operatorfabric/thirds/model/ActionData.java
+++ b/services/core/thirds/src/main/java/org/lfenergy/operatorfabric/thirds/model/ActionData.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.thirds.model;

--- a/services/core/thirds/src/main/java/org/lfenergy/operatorfabric/thirds/model/DetailData.java
+++ b/services/core/thirds/src/main/java/org/lfenergy/operatorfabric/thirds/model/DetailData.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.thirds.model;

--- a/services/core/thirds/src/main/java/org/lfenergy/operatorfabric/thirds/model/I18nData.java
+++ b/services/core/thirds/src/main/java/org/lfenergy/operatorfabric/thirds/model/I18nData.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.thirds.model;

--- a/services/core/thirds/src/main/java/org/lfenergy/operatorfabric/thirds/model/ResourceTypeEnum.java
+++ b/services/core/thirds/src/main/java/org/lfenergy/operatorfabric/thirds/model/ResourceTypeEnum.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.thirds.model;

--- a/services/core/thirds/src/main/java/org/lfenergy/operatorfabric/thirds/model/ThirdData.java
+++ b/services/core/thirds/src/main/java/org/lfenergy/operatorfabric/thirds/model/ThirdData.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.thirds.model;

--- a/services/core/thirds/src/main/java/org/lfenergy/operatorfabric/thirds/model/ThirdMenuEntryData.java
+++ b/services/core/thirds/src/main/java/org/lfenergy/operatorfabric/thirds/model/ThirdMenuEntryData.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 package org.lfenergy.operatorfabric.thirds.model;
 

--- a/services/core/thirds/src/main/java/org/lfenergy/operatorfabric/thirds/model/ThirdProcessesData.java
+++ b/services/core/thirds/src/main/java/org/lfenergy/operatorfabric/thirds/model/ThirdProcessesData.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 package org.lfenergy.operatorfabric.thirds.model;
 

--- a/services/core/thirds/src/main/java/org/lfenergy/operatorfabric/thirds/model/ThirdStatesData.java
+++ b/services/core/thirds/src/main/java/org/lfenergy/operatorfabric/thirds/model/ThirdStatesData.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 package org.lfenergy.operatorfabric.thirds.model;
 

--- a/services/core/thirds/src/main/java/org/lfenergy/operatorfabric/thirds/services/ThirdsService.java
+++ b/services/core/thirds/src/main/java/org/lfenergy/operatorfabric/thirds/services/ThirdsService.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.thirds.services;

--- a/services/core/thirds/src/test/java/org/lfenergy/operatorfabric/thirds/application/IntegrationTestApplication.java
+++ b/services/core/thirds/src/test/java/org/lfenergy/operatorfabric/thirds/application/IntegrationTestApplication.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.thirds.application;

--- a/services/core/thirds/src/test/java/org/lfenergy/operatorfabric/thirds/application/WebSecurityConfiguration.java
+++ b/services/core/thirds/src/test/java/org/lfenergy/operatorfabric/thirds/application/WebSecurityConfiguration.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.thirds.application;

--- a/services/core/thirds/src/test/java/org/lfenergy/operatorfabric/thirds/controllers/CustomExceptionHandlerShould.java
+++ b/services/core/thirds/src/test/java/org/lfenergy/operatorfabric/thirds/controllers/CustomExceptionHandlerShould.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.thirds.controllers;

--- a/services/core/thirds/src/test/java/org/lfenergy/operatorfabric/thirds/controllers/GivenAdminUserThirdControllerShould.java
+++ b/services/core/thirds/src/test/java/org/lfenergy/operatorfabric/thirds/controllers/GivenAdminUserThirdControllerShould.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.thirds.controllers;

--- a/services/core/thirds/src/test/java/org/lfenergy/operatorfabric/thirds/controllers/GivenNonAdminUserThirdControllerShould.java
+++ b/services/core/thirds/src/test/java/org/lfenergy/operatorfabric/thirds/controllers/GivenNonAdminUserThirdControllerShould.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.thirds.controllers;

--- a/services/core/thirds/src/test/java/org/lfenergy/operatorfabric/thirds/controllers/ThirdsServiceWithWrongConfigurationShould.java
+++ b/services/core/thirds/src/test/java/org/lfenergy/operatorfabric/thirds/controllers/ThirdsServiceWithWrongConfigurationShould.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.thirds.controllers;

--- a/services/core/thirds/src/test/java/org/lfenergy/operatorfabric/thirds/services/ThirdsServiceShould.java
+++ b/services/core/thirds/src/test/java/org/lfenergy/operatorfabric/thirds/services/ThirdsServiceShould.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.thirds.services;

--- a/services/core/thirds/src/test/java/org/lfenergy/operatorfabric/thirds/services/ThirdsServiceWithWrongConfigurationShould.java
+++ b/services/core/thirds/src/test/java/org/lfenergy/operatorfabric/thirds/services/ThirdsServiceWithWrongConfigurationShould.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.thirds.services;

--- a/services/core/users/src/main/java/org/lfenergy/operatorfabric/users/UsersApplication.java
+++ b/services/core/users/src/main/java/org/lfenergy/operatorfabric/users/UsersApplication.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.users;

--- a/services/core/users/src/main/java/org/lfenergy/operatorfabric/users/configuration/DataInitComponent.java
+++ b/services/core/users/src/main/java/org/lfenergy/operatorfabric/users/configuration/DataInitComponent.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.users.configuration;

--- a/services/core/users/src/main/java/org/lfenergy/operatorfabric/users/configuration/json/JacksonConfig.java
+++ b/services/core/users/src/main/java/org/lfenergy/operatorfabric/users/configuration/json/JacksonConfig.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.users.configuration.json;

--- a/services/core/users/src/main/java/org/lfenergy/operatorfabric/users/configuration/json/UsersModule.java
+++ b/services/core/users/src/main/java/org/lfenergy/operatorfabric/users/configuration/json/UsersModule.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.users.configuration.json;

--- a/services/core/users/src/main/java/org/lfenergy/operatorfabric/users/configuration/mongo/LocalMongoConfiguration.java
+++ b/services/core/users/src/main/java/org/lfenergy/operatorfabric/users/configuration/mongo/LocalMongoConfiguration.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.users.configuration.mongo;

--- a/services/core/users/src/main/java/org/lfenergy/operatorfabric/users/configuration/mongo/StateRightReadConverter.java
+++ b/services/core/users/src/main/java/org/lfenergy/operatorfabric/users/configuration/mongo/StateRightReadConverter.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 package org.lfenergy.operatorfabric.users.configuration.mongo;
 

--- a/services/core/users/src/main/java/org/lfenergy/operatorfabric/users/configuration/mongo/StateRightWriteConverter.java
+++ b/services/core/users/src/main/java/org/lfenergy/operatorfabric/users/configuration/mongo/StateRightWriteConverter.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 package org.lfenergy.operatorfabric.users.configuration.mongo;
 

--- a/services/core/users/src/main/java/org/lfenergy/operatorfabric/users/configuration/oauth2/OAuth2UsersConfiguration.java
+++ b/services/core/users/src/main/java/org/lfenergy/operatorfabric/users/configuration/oauth2/OAuth2UsersConfiguration.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.users.configuration.oauth2;

--- a/services/core/users/src/main/java/org/lfenergy/operatorfabric/users/configuration/oauth2/UserExtractor.java
+++ b/services/core/users/src/main/java/org/lfenergy/operatorfabric/users/configuration/oauth2/UserExtractor.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 package org.lfenergy.operatorfabric.users.configuration.oauth2;
 

--- a/services/core/users/src/main/java/org/lfenergy/operatorfabric/users/configuration/oauth2/WebSecurityChecks.java
+++ b/services/core/users/src/main/java/org/lfenergy/operatorfabric/users/configuration/oauth2/WebSecurityChecks.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.users.configuration.oauth2;

--- a/services/core/users/src/main/java/org/lfenergy/operatorfabric/users/configuration/oauth2/WebSecurityConfiguration.java
+++ b/services/core/users/src/main/java/org/lfenergy/operatorfabric/users/configuration/oauth2/WebSecurityConfiguration.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.users.configuration.oauth2;

--- a/services/core/users/src/main/java/org/lfenergy/operatorfabric/users/configuration/users/UsersProperties.java
+++ b/services/core/users/src/main/java/org/lfenergy/operatorfabric/users/configuration/users/UsersProperties.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.users.configuration.users;

--- a/services/core/users/src/main/java/org/lfenergy/operatorfabric/users/controllers/CurrentUserWithPerimetersController.java
+++ b/services/core/users/src/main/java/org/lfenergy/operatorfabric/users/controllers/CurrentUserWithPerimetersController.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.users.controllers;

--- a/services/core/users/src/main/java/org/lfenergy/operatorfabric/users/controllers/CustomExceptionHandler.java
+++ b/services/core/users/src/main/java/org/lfenergy/operatorfabric/users/controllers/CustomExceptionHandler.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.users.controllers;

--- a/services/core/users/src/main/java/org/lfenergy/operatorfabric/users/controllers/EntitiesController.java
+++ b/services/core/users/src/main/java/org/lfenergy/operatorfabric/users/controllers/EntitiesController.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.users.controllers;

--- a/services/core/users/src/main/java/org/lfenergy/operatorfabric/users/controllers/GroupsController.java
+++ b/services/core/users/src/main/java/org/lfenergy/operatorfabric/users/controllers/GroupsController.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.users.controllers;

--- a/services/core/users/src/main/java/org/lfenergy/operatorfabric/users/controllers/PerimetersController.java
+++ b/services/core/users/src/main/java/org/lfenergy/operatorfabric/users/controllers/PerimetersController.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 package org.lfenergy.operatorfabric.users.controllers;
 

--- a/services/core/users/src/main/java/org/lfenergy/operatorfabric/users/controllers/UsersController.java
+++ b/services/core/users/src/main/java/org/lfenergy/operatorfabric/users/controllers/UsersController.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.users.controllers;

--- a/services/core/users/src/main/java/org/lfenergy/operatorfabric/users/model/ComputedPerimeterData.java
+++ b/services/core/users/src/main/java/org/lfenergy/operatorfabric/users/model/ComputedPerimeterData.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 package org.lfenergy.operatorfabric.users.model;
 

--- a/services/core/users/src/main/java/org/lfenergy/operatorfabric/users/model/CurrentUserWithPerimetersData.java
+++ b/services/core/users/src/main/java/org/lfenergy/operatorfabric/users/model/CurrentUserWithPerimetersData.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.users.model;

--- a/services/core/users/src/main/java/org/lfenergy/operatorfabric/users/model/EntityData.java
+++ b/services/core/users/src/main/java/org/lfenergy/operatorfabric/users/model/EntityData.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.users.model;

--- a/services/core/users/src/main/java/org/lfenergy/operatorfabric/users/model/GroupData.java
+++ b/services/core/users/src/main/java/org/lfenergy/operatorfabric/users/model/GroupData.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.users.model;

--- a/services/core/users/src/main/java/org/lfenergy/operatorfabric/users/model/PerimeterData.java
+++ b/services/core/users/src/main/java/org/lfenergy/operatorfabric/users/model/PerimeterData.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 package org.lfenergy.operatorfabric.users.model;
 

--- a/services/core/users/src/main/java/org/lfenergy/operatorfabric/users/model/SimpleUserData.java
+++ b/services/core/users/src/main/java/org/lfenergy/operatorfabric/users/model/SimpleUserData.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.users.model;

--- a/services/core/users/src/main/java/org/lfenergy/operatorfabric/users/model/StateRightData.java
+++ b/services/core/users/src/main/java/org/lfenergy/operatorfabric/users/model/StateRightData.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.users.model;

--- a/services/core/users/src/main/java/org/lfenergy/operatorfabric/users/model/UserData.java
+++ b/services/core/users/src/main/java/org/lfenergy/operatorfabric/users/model/UserData.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.users.model;

--- a/services/core/users/src/main/java/org/lfenergy/operatorfabric/users/model/UserSettingsData.java
+++ b/services/core/users/src/main/java/org/lfenergy/operatorfabric/users/model/UserSettingsData.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 package org.lfenergy.operatorfabric.users.model;
 

--- a/services/core/users/src/main/java/org/lfenergy/operatorfabric/users/repositories/EntityRepository.java
+++ b/services/core/users/src/main/java/org/lfenergy/operatorfabric/users/repositories/EntityRepository.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.users.repositories;

--- a/services/core/users/src/main/java/org/lfenergy/operatorfabric/users/repositories/GroupRepository.java
+++ b/services/core/users/src/main/java/org/lfenergy/operatorfabric/users/repositories/GroupRepository.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.users.repositories;

--- a/services/core/users/src/main/java/org/lfenergy/operatorfabric/users/repositories/PerimeterRepository.java
+++ b/services/core/users/src/main/java/org/lfenergy/operatorfabric/users/repositories/PerimeterRepository.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 package org.lfenergy.operatorfabric.users.repositories;
 

--- a/services/core/users/src/main/java/org/lfenergy/operatorfabric/users/repositories/UserRepository.java
+++ b/services/core/users/src/main/java/org/lfenergy/operatorfabric/users/repositories/UserRepository.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.users.repositories;

--- a/services/core/users/src/main/java/org/lfenergy/operatorfabric/users/repositories/UserSettingsRepository.java
+++ b/services/core/users/src/main/java/org/lfenergy/operatorfabric/users/repositories/UserSettingsRepository.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.users.repositories;

--- a/services/core/users/src/main/java/org/lfenergy/operatorfabric/users/services/UserService.java
+++ b/services/core/users/src/main/java/org/lfenergy/operatorfabric/users/services/UserService.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 package org.lfenergy.operatorfabric.users.services;
 

--- a/services/core/users/src/test/java/org/lfenergy/operatorfabric/users/ApplicationShould.java
+++ b/services/core/users/src/test/java/org/lfenergy/operatorfabric/users/ApplicationShould.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.users;

--- a/services/core/users/src/test/java/org/lfenergy/operatorfabric/users/application/UnitTestApplication.java
+++ b/services/core/users/src/test/java/org/lfenergy/operatorfabric/users/application/UnitTestApplication.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.users.application;

--- a/services/core/users/src/test/java/org/lfenergy/operatorfabric/users/application/configuration/OpFabUserDetails.java
+++ b/services/core/users/src/test/java/org/lfenergy/operatorfabric/users/application/configuration/OpFabUserDetails.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.users.application.configuration;

--- a/services/core/users/src/test/java/org/lfenergy/operatorfabric/users/application/configuration/WebSecurityConfiguration.java
+++ b/services/core/users/src/test/java/org/lfenergy/operatorfabric/users/application/configuration/WebSecurityConfiguration.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.users.application.configuration;

--- a/services/core/users/src/test/java/org/lfenergy/operatorfabric/users/application/configuration/WithMockOpFabUser.java
+++ b/services/core/users/src/test/java/org/lfenergy/operatorfabric/users/application/configuration/WithMockOpFabUser.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.users.application.configuration;

--- a/services/core/users/src/test/java/org/lfenergy/operatorfabric/users/application/configuration/WithMockOpFabUserSecurityContextFactory.java
+++ b/services/core/users/src/test/java/org/lfenergy/operatorfabric/users/application/configuration/WithMockOpFabUserSecurityContextFactory.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.users.application.configuration;

--- a/services/core/users/src/test/java/org/lfenergy/operatorfabric/users/configuration/ObjectMapperShould.java
+++ b/services/core/users/src/test/java/org/lfenergy/operatorfabric/users/configuration/ObjectMapperShould.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.users.configuration;

--- a/services/core/users/src/test/java/org/lfenergy/operatorfabric/users/controllers/EntitiesControllerShould.java
+++ b/services/core/users/src/test/java/org/lfenergy/operatorfabric/users/controllers/EntitiesControllerShould.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.users.controllers;

--- a/services/core/users/src/test/java/org/lfenergy/operatorfabric/users/controllers/GroupsControllerShould.java
+++ b/services/core/users/src/test/java/org/lfenergy/operatorfabric/users/controllers/GroupsControllerShould.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.users.controllers;

--- a/services/core/users/src/test/java/org/lfenergy/operatorfabric/users/controllers/PerimetersControllerShould.java
+++ b/services/core/users/src/test/java/org/lfenergy/operatorfabric/users/controllers/PerimetersControllerShould.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.users.controllers;

--- a/services/core/users/src/test/java/org/lfenergy/operatorfabric/users/controllers/UsersControllerShould.java
+++ b/services/core/users/src/test/java/org/lfenergy/operatorfabric/users/controllers/UsersControllerShould.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.users.controllers;

--- a/services/core/users/src/test/java/org/lfenergy/operatorfabric/users/model/CurrentUserWithPerimetersDataShould.java
+++ b/services/core/users/src/test/java/org/lfenergy/operatorfabric/users/model/CurrentUserWithPerimetersDataShould.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 package org.lfenergy.operatorfabric.users.model;
 

--- a/services/core/users/src/test/java/org/lfenergy/operatorfabric/users/model/UserSettingsDataShould.java
+++ b/services/core/users/src/test/java/org/lfenergy/operatorfabric/users/model/UserSettingsDataShould.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 package org.lfenergy.operatorfabric.users.model;
 

--- a/services/core/users/src/test/java/org/lfenergy/operatorfabric/users/repositories/UserRepositoryShould.java
+++ b/services/core/users/src/test/java/org/lfenergy/operatorfabric/users/repositories/UserRepositoryShould.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.users.repositories;

--- a/services/core/users/src/test/java/org/lfenergy/operatorfabric/users/services/UserServiceShould.java
+++ b/services/core/users/src/test/java/org/lfenergy/operatorfabric/users/services/UserServiceShould.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.users.services;

--- a/services/infra/client-gateway/src/main/java/org/lfenergy/operatorfabric/gateway/GatewayApplication.java
+++ b/services/infra/client-gateway/src/main/java/org/lfenergy/operatorfabric/gateway/GatewayApplication.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.gateway;

--- a/services/infra/client-gateway/src/main/java/org/lfenergy/operatorfabric/gateway/configuration/GatewayConfig.java
+++ b/services/infra/client-gateway/src/main/java/org/lfenergy/operatorfabric/gateway/configuration/GatewayConfig.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.gateway.configuration;

--- a/services/infra/client-gateway/src/main/java/org/lfenergy/operatorfabric/gateway/configuration/OperatorFabricGatewayConf.java
+++ b/services/infra/client-gateway/src/main/java/org/lfenergy/operatorfabric/gateway/configuration/OperatorFabricGatewayConf.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 package org.lfenergy.operatorfabric.gateway.configuration;
 

--- a/services/infra/client-gateway/src/main/java/org/lfenergy/operatorfabric/gateway/controller/ClientAppController.java
+++ b/services/infra/client-gateway/src/main/java/org/lfenergy/operatorfabric/gateway/controller/ClientAppController.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.gateway.controller;

--- a/services/infra/config/src/main/java/org/lfenergy/operatorfabric/config/ConfigurationApplication.java
+++ b/services/infra/config/src/main/java/org/lfenergy/operatorfabric/config/ConfigurationApplication.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.config;

--- a/services/infra/config/src/main/java/org/lfenergy/operatorfabric/config/CustomEnvironmentRepository.java
+++ b/services/infra/config/src/main/java/org/lfenergy/operatorfabric/config/CustomEnvironmentRepository.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.config;

--- a/services/infra/registry/src/main/java/org/lfenergy/operatorfabric/registry/RegistryApplication.java
+++ b/services/infra/registry/src/main/java/org/lfenergy/operatorfabric/registry/RegistryApplication.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.registry;

--- a/src/docs/asciidoc/CICD/index.adoc
+++ b/src/docs/asciidoc/CICD/index.adoc
@@ -1,8 +1,10 @@
-// Copyright (c) 2020, RTE (http://www.rte-france.com)
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// Copyright (c) 2018-2020 RTE (http://www.rte-france.com)
+// See AUTHORS.txt
+// This document is subject to the terms of the Creative Commons Attribution 4.0 International license.
+// If a copy of the license was not distributed with this
+// file, You can obtain one at https://creativecommons.org/licenses/by/4.0/.
+// SPDX-License-Identifier: CC-BY-4.0
+
 
 
 

--- a/src/docs/asciidoc/CICD/pipeline_conf.adoc
+++ b/src/docs/asciidoc/CICD/pipeline_conf.adoc
@@ -1,8 +1,10 @@
-// Copyright (c) 2020, RTE (http://www.rte-france.com)
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// Copyright (c) 2018-2020 RTE (http://www.rte-france.com)
+// See AUTHORS.txt
+// This document is subject to the terms of the Creative Commons Attribution 4.0 International license.
+// If a copy of the license was not distributed with this
+// file, You can obtain one at https://creativecommons.org/licenses/by/4.0/.
+// SPDX-License-Identifier: CC-BY-4.0
+
 
 
 

--- a/src/docs/asciidoc/CICD/release_process.adoc
+++ b/src/docs/asciidoc/CICD/release_process.adoc
@@ -1,8 +1,10 @@
-// Copyright (c) 2020, RTE (http://www.rte-france.com)
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// Copyright (c) 2018-2020 RTE (http://www.rte-france.com)
+// See AUTHORS.txt
+// This document is subject to the terms of the Creative Commons Attribution 4.0 International license.
+// If a copy of the license was not distributed with this
+// file, You can obtain one at https://creativecommons.org/licenses/by/4.0/.
+// SPDX-License-Identifier: CC-BY-4.0
+
 
 [[release_process]]
 = Release process

--- a/src/docs/asciidoc/TODO_WIP.adoc
+++ b/src/docs/asciidoc/TODO_WIP.adoc
@@ -1,8 +1,10 @@
-// Copyright (c) 2020, RTE (http://www.rte-france.com)
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// Copyright (c) 2018-2020 RTE (http://www.rte-france.com)
+// See AUTHORS.txt
+// This document is subject to the terms of the Creative Commons Attribution 4.0 International license.
+// If a copy of the license was not distributed with this
+// file, You can obtain one at https://creativecommons.org/licenses/by/4.0/.
+// SPDX-License-Identifier: CC-BY-4.0
+
 
 // After moving
 //TODO Remove unnecessary custom id anchors (script it?)

--- a/src/docs/asciidoc/architecture/index.adoc
+++ b/src/docs/asciidoc/architecture/index.adoc
@@ -1,8 +1,10 @@
-// Copyright (c) 2020, RTE (http://www.rte-france.com)
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// Copyright (c) 2018-2020 RTE (http://www.rte-france.com)
+// See AUTHORS.txt
+// This document is subject to the terms of the Creative Commons Attribution 4.0 International license.
+// If a copy of the license was not distributed with this
+// file, You can obtain one at https://creativecommons.org/licenses/by/4.0/.
+// SPDX-License-Identifier: CC-BY-4.0
+
 
 
 

--- a/src/docs/asciidoc/business_description.adoc
+++ b/src/docs/asciidoc/business_description.adoc
@@ -1,8 +1,10 @@
-// Copyright (c) 2020, RTE (http://www.rte-france.com)
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// Copyright (c) 2018-2020 RTE (http://www.rte-france.com)
+// See AUTHORS.txt
+// This document is subject to the terms of the Creative Commons Attribution 4.0 International license.
+// If a copy of the license was not distributed with this
+// file, You can obtain one at https://creativecommons.org/licenses/by/4.0/.
+// SPDX-License-Identifier: CC-BY-4.0
+
 
 
 

--- a/src/docs/asciidoc/community/CODE_OF_CONDUCT.adoc
+++ b/src/docs/asciidoc/community/CODE_OF_CONDUCT.adoc
@@ -1,8 +1,10 @@
-// Copyright (c) 2020, RTE (http://www.rte-france.com)
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// Copyright (c) 2018-2020 RTE (http://www.rte-france.com)
+// See AUTHORS.txt
+// This document is subject to the terms of the Creative Commons Attribution 4.0 International license.
+// If a copy of the license was not distributed with this
+// file, You can obtain one at https://creativecommons.org/licenses/by/4.0/.
+// SPDX-License-Identifier: CC-BY-4.0
+
 
 
 

--- a/src/docs/asciidoc/community/copyright.adoc
+++ b/src/docs/asciidoc/community/copyright.adoc
@@ -1,0 +1,130 @@
+// Copyright (c) 2018-2020 RTE (http://www.rte-france.com)
+// See AUTHORS.txt
+// This document is subject to the terms of the Creative Commons Attribution 4.0 International license.
+// If a copy of the license was not distributed with this
+// file, You can obtain one at https://creativecommons.org/licenses/by/4.0/.
+// SPDX-License-Identifier: CC-BY-4.0
+
+= Copyright Headers
+
+All source files and documentation files for the project should bear copyright headers.
+
+== Header templates
+
+In the case of source files (*.java, *.css or *.scss, *.html, *.ts, etc.), we are working with the
+link:http://mozilla.org/MPL/2.0/[Mozilla Public License, v. 2.0], so the header should be something like this:
+
+```
+Copyright (c) YYYY-YYYY, Entity Name (website or contact info)
+See AUTHORS.txt
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at http://mozilla.org/MPL/2.0/.
+SPDX-License-Identifier: MPL-2.0
+This file is part of the OperatorFabric project.
+```
+
+In the case of documentation files (*.adoc), we use the
+link:https://creativecommons.org/licenses/by/4.0/[Creative Commons Attribution 4.0 International license], so the
+header should be:
+
+```
+Copyright (c) YYYY-YYYY, Entity Name (website or contact info)
+See AUTHORS.txt
+This document is subject to the terms of the Creative Commons Attribution 4.0 International license.
+If a copy of the license was not distributed with this
+file, You can obtain one at https://creativecommons.org/licenses/by/4.0/.
+SPDX-License-Identifier: CC-BY-4.0
+```
+
+These templates should of course be converted to comments depending on the file type. See src/main/headers for examples.
+
+Please make sure to include the appropriate header when creating new files and to update the existing one when
+making changes to a file.
+
+In the case of a first time contribution, the GitHub username of the person making the contribution should also be
+added to the AUTHORS file.
+
+== Examples
+
+=== Creating a new file
+
+Let's say a developer from entity Entity X creates a new java file in 2020. The header should read:
+
+```
+Copyright (c) 2020, Entity X (http://www.entityX.org)
+See AUTHORS.txt
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at http://mozilla.org/MPL/2.0/.
+SPDX-License-Identifier: MPL-2.0
+This file is part of the OperatorFabric project.
+```
+
+=== Updating a file
+
+Given an existing java file with the following header:
+
+```
+Copyright (c) 2020, Entity X (http://www.entityX.org)
+See AUTHORS.txt
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at http://mozilla.org/MPL/2.0/.
+SPDX-License-Identifier: MPL-2.0
+This file is part of the OperatorFabric project.
+```
+
+If a developer from entity Entity X edits it in 2021, the header should now read:
+
+```
+Copyright (c) 2020-2021, Entity X (http://www.entityX.org)
+See AUTHORS.txt
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at http://mozilla.org/MPL/2.0/.
+SPDX-License-Identifier: MPL-2.0
+This file is part of the OperatorFabric project.
+```
+
+However, if a developer from entity Entity X edits it in 2022, but no one from Entity X had touched it in 2021,
+the header should now read:
+
+```
+Copyright (c) 2020 Entity X (http://www.entityX.org)
+Copyright (c) 2022 Entity X (http://www.entityX.org)
+See AUTHORS.txt
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at http://mozilla.org/MPL/2.0/.
+SPDX-License-Identifier: MPL-2.0
+This file is part of the OperatorFabric project.
+```
+
+=== Multiple contributors
+
+Given an existing java file with the following header:
+
+```
+Copyright (c) 2020-2021, Entity X (http://www.entityX.org)
+See AUTHORS.txt
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at http://mozilla.org/MPL/2.0/.
+SPDX-License-Identifier: MPL-2.0
+This file is part of the OperatorFabric project.
+```
+
+If a developer from entity Entity Y edits it in 2021, the header should now read:
+
+```
+Copyright (c) 2020-2021, Entity X (http://www.entityX.org)
+Copyright (c) 2021, Entity Y (http://www.entityY.org)
+See AUTHORS.txt
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at http://mozilla.org/MPL/2.0/.
+SPDX-License-Identifier: MPL-2.0
+This file is part of the OperatorFabric project.
+```
+

--- a/src/docs/asciidoc/community/documentation.adoc
+++ b/src/docs/asciidoc/community/documentation.adoc
@@ -1,8 +1,10 @@
-// Copyright (c) 2020, RTE (http://www.rte-france.com)
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// Copyright (c) 2018-2020 RTE (http://www.rte-france.com)
+// See AUTHORS.txt
+// This document is subject to the terms of the Creative Commons Attribution 4.0 International license.
+// If a copy of the license was not distributed with this
+// file, You can obtain one at https://creativecommons.org/licenses/by/4.0/.
+// SPDX-License-Identifier: CC-BY-4.0
+
 
 
 

--- a/src/docs/asciidoc/community/documentation.adoc
+++ b/src/docs/asciidoc/community/documentation.adoc
@@ -6,8 +6,6 @@
 // SPDX-License-Identifier: CC-BY-4.0
 
 
-
-
 = Documentation Guidelines
 
 The aim of this section is to explain how the documentation is currently organized and to give a few guidelines on how

--- a/src/docs/asciidoc/community/index.adoc
+++ b/src/docs/asciidoc/community/index.adoc
@@ -5,9 +5,6 @@
 // file, You can obtain one at https://creativecommons.org/licenses/by/4.0/.
 // SPDX-License-Identifier: CC-BY-4.0
 
-
-
-
 = OperatorFabric Community
 
 The aim of this document is to present the OperatorFabric community, its code of conduct and to welcome contributors!
@@ -75,6 +72,8 @@ include::workflow.adoc[leveloffset=+2]
 to have to maintain these mentions (since this information is tracked by git anyway).
 
 include::documentation.adoc[leveloffset=+2]
+
+include::copyright.adoc[leveloffset=+2]
 
 == Project Governance
 

--- a/src/docs/asciidoc/community/index.adoc
+++ b/src/docs/asciidoc/community/index.adoc
@@ -1,8 +1,10 @@
-// Copyright (c) 2020, RTE (http://www.rte-france.com)
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// Copyright (c) 2018-2020 RTE (http://www.rte-france.com)
+// See AUTHORS.txt
+// This document is subject to the terms of the Creative Commons Attribution 4.0 International license.
+// If a copy of the license was not distributed with this
+// file, You can obtain one at https://creativecommons.org/licenses/by/4.0/.
+// SPDX-License-Identifier: CC-BY-4.0
+
 
 
 

--- a/src/docs/asciidoc/community/workflow.adoc
+++ b/src/docs/asciidoc/community/workflow.adoc
@@ -1,8 +1,10 @@
-// Copyright (c) 2020, RTE (http://www.rte-france.com)
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// Copyright (c) 2018-2020 RTE (http://www.rte-france.com)
+// See AUTHORS.txt
+// This document is subject to the terms of the Creative Commons Attribution 4.0 International license.
+// If a copy of the license was not distributed with this
+// file, You can obtain one at https://creativecommons.org/licenses/by/4.0/.
+// SPDX-License-Identifier: CC-BY-4.0
+
 
 
 

--- a/src/docs/asciidoc/deployment/RABBITMQ.adoc
+++ b/src/docs/asciidoc/deployment/RABBITMQ.adoc
@@ -1,8 +1,10 @@
-// Copyright (c) 2020, RTE (http://www.rte-france.com)
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// Copyright (c) 2018-2020 RTE (http://www.rte-france.com)
+// See AUTHORS.txt
+// This document is subject to the terms of the Creative Commons Attribution 4.0 International license.
+// If a copy of the license was not distributed with this
+// file, You can obtain one at https://creativecommons.org/licenses/by/4.0/.
+// SPDX-License-Identifier: CC-BY-4.0
+
 
 
 

--- a/src/docs/asciidoc/deployment/certificates.adoc
+++ b/src/docs/asciidoc/deployment/certificates.adoc
@@ -1,8 +1,10 @@
-// Copyright (c) 2020, RTE (http://www.rte-france.com)
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// Copyright (c) 2018-2020 RTE (http://www.rte-france.com)
+// See AUTHORS.txt
+// This document is subject to the terms of the Creative Commons Attribution 4.0 International license.
+// If a copy of the license was not distributed with this
+// file, You can obtain one at https://creativecommons.org/licenses/by/4.0/.
+// SPDX-License-Identifier: CC-BY-4.0
+
 
 
 

--- a/src/docs/asciidoc/deployment/configuration/actions_configuration.adoc
+++ b/src/docs/asciidoc/deployment/configuration/actions_configuration.adoc
@@ -1,8 +1,10 @@
-// Copyright (c) 2020, RTE (http://www.rte-france.com)
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// Copyright (c) 2018-2020 RTE (http://www.rte-france.com)
+// See AUTHORS.txt
+// This document is subject to the terms of the Creative Commons Attribution 4.0 International license.
+// If a copy of the license was not distributed with this
+// file, You can obtain one at https://creativecommons.org/licenses/by/4.0/.
+// SPDX-License-Identifier: CC-BY-4.0
+
 
 
 

--- a/src/docs/asciidoc/deployment/configuration/cards-consultation_configuration.adoc
+++ b/src/docs/asciidoc/deployment/configuration/cards-consultation_configuration.adoc
@@ -1,8 +1,10 @@
-// Copyright (c) 2020, RTE (http://www.rte-france.com)
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// Copyright (c) 2018-2020 RTE (http://www.rte-france.com)
+// See AUTHORS.txt
+// This document is subject to the terms of the Creative Commons Attribution 4.0 International license.
+// If a copy of the license was not distributed with this
+// file, You can obtain one at https://creativecommons.org/licenses/by/4.0/.
+// SPDX-License-Identifier: CC-BY-4.0
+
 
 
 

--- a/src/docs/asciidoc/deployment/configuration/cards-publication_configuration.adoc
+++ b/src/docs/asciidoc/deployment/configuration/cards-publication_configuration.adoc
@@ -1,8 +1,10 @@
-// Copyright (c) 2020, RTE (http://www.rte-france.com)
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// Copyright (c) 2018-2020 RTE (http://www.rte-france.com)
+// See AUTHORS.txt
+// This document is subject to the terms of the Creative Commons Attribution 4.0 International license.
+// If a copy of the license was not distributed with this
+// file, You can obtain one at https://creativecommons.org/licenses/by/4.0/.
+// SPDX-License-Identifier: CC-BY-4.0
+
 
 
 

--- a/src/docs/asciidoc/deployment/configuration/client-gateway_configuration.adoc
+++ b/src/docs/asciidoc/deployment/configuration/client-gateway_configuration.adoc
@@ -1,8 +1,10 @@
-// Copyright (c) 2020, RTE (http://www.rte-france.com)
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// Copyright (c) 2018-2020 RTE (http://www.rte-france.com)
+// See AUTHORS.txt
+// This document is subject to the terms of the Creative Commons Attribution 4.0 International license.
+// If a copy of the license was not distributed with this
+// file, You can obtain one at https://creativecommons.org/licenses/by/4.0/.
+// SPDX-License-Identifier: CC-BY-4.0
+
 
 
 

--- a/src/docs/asciidoc/deployment/configuration/client-gateway_filters-and-cors-configuration.adoc
+++ b/src/docs/asciidoc/deployment/configuration/client-gateway_filters-and-cors-configuration.adoc
@@ -1,8 +1,10 @@
-// Copyright (c) 2020, RTE (http://www.rte-france.com)
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// Copyright (c) 2018-2020 RTE (http://www.rte-france.com)
+// See AUTHORS.txt
+// This document is subject to the terms of the Creative Commons Attribution 4.0 International license.
+// If a copy of the license was not distributed with this
+// file, You can obtain one at https://creativecommons.org/licenses/by/4.0/.
+// SPDX-License-Identifier: CC-BY-4.0
+
 
 
 

--- a/src/docs/asciidoc/deployment/configuration/config_configuration.adoc
+++ b/src/docs/asciidoc/deployment/configuration/config_configuration.adoc
@@ -1,8 +1,10 @@
-// Copyright (c) 2020, RTE (http://www.rte-france.com)
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// Copyright (c) 2018-2020 RTE (http://www.rte-france.com)
+// See AUTHORS.txt
+// This document is subject to the terms of the Creative Commons Attribution 4.0 International license.
+// If a copy of the license was not distributed with this
+// file, You can obtain one at https://creativecommons.org/licenses/by/4.0/.
+// SPDX-License-Identifier: CC-BY-4.0
+
 
 
 

--- a/src/docs/asciidoc/deployment/configuration/configuration.adoc
+++ b/src/docs/asciidoc/deployment/configuration/configuration.adoc
@@ -1,8 +1,10 @@
-// Copyright (c) 2020, RTE (http://www.rte-france.com)
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// Copyright (c) 2018-2020 RTE (http://www.rte-france.com)
+// See AUTHORS.txt
+// This document is subject to the terms of the Creative Commons Attribution 4.0 International license.
+// If a copy of the license was not distributed with this
+// file, You can obtain one at https://creativecommons.org/licenses/by/4.0/.
+// SPDX-License-Identifier: CC-BY-4.0
+
 
 
 

--- a/src/docs/asciidoc/deployment/configuration/registry_configuration.adoc
+++ b/src/docs/asciidoc/deployment/configuration/registry_configuration.adoc
@@ -1,8 +1,10 @@
-// Copyright (c) 2020, RTE (http://www.rte-france.com)
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// Copyright (c) 2018-2020 RTE (http://www.rte-france.com)
+// See AUTHORS.txt
+// This document is subject to the terms of the Creative Commons Attribution 4.0 International license.
+// If a copy of the license was not distributed with this
+// file, You can obtain one at https://creativecommons.org/licenses/by/4.0/.
+// SPDX-License-Identifier: CC-BY-4.0
+
 
 
 

--- a/src/docs/asciidoc/deployment/configuration/security_configuration.adoc
+++ b/src/docs/asciidoc/deployment/configuration/security_configuration.adoc
@@ -1,8 +1,10 @@
-// Copyright (c) 2020, RTE (http://www.rte-france.com)
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// Copyright (c) 2018-2020 RTE (http://www.rte-france.com)
+// See AUTHORS.txt
+// This document is subject to the terms of the Creative Commons Attribution 4.0 International license.
+// If a copy of the license was not distributed with this
+// file, You can obtain one at https://creativecommons.org/licenses/by/4.0/.
+// SPDX-License-Identifier: CC-BY-4.0
+
 
 
 

--- a/src/docs/asciidoc/deployment/configuration/thirds_configuration.adoc
+++ b/src/docs/asciidoc/deployment/configuration/thirds_configuration.adoc
@@ -1,8 +1,10 @@
-// Copyright (c) 2020, RTE (http://www.rte-france.com)
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// Copyright (c) 2018-2020 RTE (http://www.rte-france.com)
+// See AUTHORS.txt
+// This document is subject to the terms of the Creative Commons Attribution 4.0 International license.
+// If a copy of the license was not distributed with this
+// file, You can obtain one at https://creativecommons.org/licenses/by/4.0/.
+// SPDX-License-Identifier: CC-BY-4.0
+
 
 
 

--- a/src/docs/asciidoc/deployment/configuration/users_configuration.adoc
+++ b/src/docs/asciidoc/deployment/configuration/users_configuration.adoc
@@ -1,8 +1,10 @@
-// Copyright (c) 2020, RTE (http://www.rte-france.com)
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// Copyright (c) 2018-2020 RTE (http://www.rte-france.com)
+// See AUTHORS.txt
+// This document is subject to the terms of the Creative Commons Attribution 4.0 International license.
+// If a copy of the license was not distributed with this
+// file, You can obtain one at https://creativecommons.org/licenses/by/4.0/.
+// SPDX-License-Identifier: CC-BY-4.0
+
 
 
 

--- a/src/docs/asciidoc/deployment/configuration/web-ui_configuration.adoc
+++ b/src/docs/asciidoc/deployment/configuration/web-ui_configuration.adoc
@@ -1,8 +1,10 @@
-// Copyright (c) 2020, RTE (http://www.rte-france.com)
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// Copyright (c) 2018-2020 RTE (http://www.rte-france.com)
+// See AUTHORS.txt
+// This document is subject to the terms of the Creative Commons Attribution 4.0 International license.
+// If a copy of the license was not distributed with this
+// file, You can obtain one at https://creativecommons.org/licenses/by/4.0/.
+// SPDX-License-Identifier: CC-BY-4.0
+
 
 
 

--- a/src/docs/asciidoc/deployment/index.adoc
+++ b/src/docs/asciidoc/deployment/index.adoc
@@ -1,8 +1,10 @@
-// Copyright (c) 2020, RTE (http://www.rte-france.com)
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// Copyright (c) 2018-2020 RTE (http://www.rte-france.com)
+// See AUTHORS.txt
+// This document is subject to the terms of the Creative Commons Attribution 4.0 International license.
+// If a copy of the license was not distributed with this
+// file, You can obtain one at https://creativecommons.org/licenses/by/4.0/.
+// SPDX-License-Identifier: CC-BY-4.0
+
 
 
 

--- a/src/docs/asciidoc/deployment/port_table.adoc
+++ b/src/docs/asciidoc/deployment/port_table.adoc
@@ -1,8 +1,10 @@
-// Copyright (c) 2020, RTE (http://www.rte-france.com)
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// Copyright (c) 2018-2020 RTE (http://www.rte-france.com)
+// See AUTHORS.txt
+// This document is subject to the terms of the Creative Commons Attribution 4.0 International license.
+// If a copy of the license was not distributed with this
+// file, You can obtain one at https://creativecommons.org/licenses/by/4.0/.
+// SPDX-License-Identifier: CC-BY-4.0
+
 
 
 

--- a/src/docs/asciidoc/deployment/users_groups_admin.adoc
+++ b/src/docs/asciidoc/deployment/users_groups_admin.adoc
@@ -1,8 +1,10 @@
-// Copyright (c) 2020, RTE (http://www.rte-france.com)
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// Copyright (c) 2018-2020 RTE (http://www.rte-france.com)
+// See AUTHORS.txt
+// This document is subject to the terms of the Creative Commons Attribution 4.0 International license.
+// If a copy of the license was not distributed with this
+// file, You can obtain one at https://creativecommons.org/licenses/by/4.0/.
+// SPDX-License-Identifier: CC-BY-4.0
+
 
 
 

--- a/src/docs/asciidoc/dev_env/env_variables.adoc
+++ b/src/docs/asciidoc/dev_env/env_variables.adoc
@@ -1,8 +1,10 @@
-// Copyright (c) 2020, RTE (http://www.rte-france.com)
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// Copyright (c) 2018-2020 RTE (http://www.rte-france.com)
+// See AUTHORS.txt
+// This document is subject to the terms of the Creative Commons Attribution 4.0 International license.
+// If a copy of the license was not distributed with this
+// file, You can obtain one at https://creativecommons.org/licenses/by/4.0/.
+// SPDX-License-Identifier: CC-BY-4.0
+
 
 
 

--- a/src/docs/asciidoc/dev_env/gradle.adoc
+++ b/src/docs/asciidoc/dev_env/gradle.adoc
@@ -1,8 +1,10 @@
-// Copyright (c) 2020, RTE (http://www.rte-france.com)
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// Copyright (c) 2018-2020 RTE (http://www.rte-france.com)
+// See AUTHORS.txt
+// This document is subject to the terms of the Creative Commons Attribution 4.0 International license.
+// If a copy of the license was not distributed with this
+// file, You can obtain one at https://creativecommons.org/licenses/by/4.0/.
+// SPDX-License-Identifier: CC-BY-4.0
+
 
 
 

--- a/src/docs/asciidoc/dev_env/index.adoc
+++ b/src/docs/asciidoc/dev_env/index.adoc
@@ -1,8 +1,10 @@
-// Copyright (c) 2020, RTE (http://www.rte-france.com)
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// Copyright (c) 2018-2020 RTE (http://www.rte-france.com)
+// See AUTHORS.txt
+// This document is subject to the terms of the Creative Commons Attribution 4.0 International license.
+// If a copy of the license was not distributed with this
+// file, You can obtain one at https://creativecommons.org/licenses/by/4.0/.
+// SPDX-License-Identifier: CC-BY-4.0
+
 
 
 

--- a/src/docs/asciidoc/dev_env/keycloak-configuration.adoc
+++ b/src/docs/asciidoc/dev_env/keycloak-configuration.adoc
@@ -1,8 +1,10 @@
-// Copyright (c) 2020, RTE (http://www.rte-france.com)
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// Copyright (c) 2018-2020 RTE (http://www.rte-france.com)
+// See AUTHORS.txt
+// This document is subject to the terms of the Creative Commons Attribution 4.0 International license.
+// If a copy of the license was not distributed with this
+// file, You can obtain one at https://creativecommons.org/licenses/by/4.0/.
+// SPDX-License-Identifier: CC-BY-4.0
+
 
 
 

--- a/src/docs/asciidoc/dev_env/launch_dev.adoc
+++ b/src/docs/asciidoc/dev_env/launch_dev.adoc
@@ -1,8 +1,10 @@
-// Copyright (c) 2020, RTE (http://www.rte-france.com)
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// Copyright (c) 2018-2020 RTE (http://www.rte-france.com)
+// See AUTHORS.txt
+// This document is subject to the terms of the Creative Commons Attribution 4.0 International license.
+// If a copy of the license was not distributed with this
+// file, You can obtain one at https://creativecommons.org/licenses/by/4.0/.
+// SPDX-License-Identifier: CC-BY-4.0
+
 
 
 

--- a/src/docs/asciidoc/dev_env/misc.adoc
+++ b/src/docs/asciidoc/dev_env/misc.adoc
@@ -1,8 +1,10 @@
-// Copyright (c) 2020, RTE (http://www.rte-france.com)
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// Copyright (c) 2018-2020 RTE (http://www.rte-france.com)
+// See AUTHORS.txt
+// This document is subject to the terms of the Creative Commons Attribution 4.0 International license.
+// If a copy of the license was not distributed with this
+// file, You can obtain one at https://creativecommons.org/licenses/by/4.0/.
+// SPDX-License-Identifier: CC-BY-4.0
+
 
 
 

--- a/src/docs/asciidoc/dev_env/project_structure.adoc
+++ b/src/docs/asciidoc/dev_env/project_structure.adoc
@@ -1,8 +1,10 @@
-// Copyright (c) 2020, RTE (http://www.rte-france.com)
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// Copyright (c) 2018-2020 RTE (http://www.rte-france.com)
+// See AUTHORS.txt
+// This document is subject to the terms of the Creative Commons Attribution 4.0 International license.
+// If a copy of the license was not distributed with this
+// file, You can obtain one at https://creativecommons.org/licenses/by/4.0/.
+// SPDX-License-Identifier: CC-BY-4.0
+
 
 
 

--- a/src/docs/asciidoc/dev_env/requirements.adoc
+++ b/src/docs/asciidoc/dev_env/requirements.adoc
@@ -1,8 +1,10 @@
-// Copyright (c) 2020, RTE (http://www.rte-france.com)
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// Copyright (c) 2018-2020 RTE (http://www.rte-france.com)
+// See AUTHORS.txt
+// This document is subject to the terms of the Creative Commons Attribution 4.0 International license.
+// If a copy of the license was not distributed with this
+// file, You can obtain one at https://creativecommons.org/licenses/by/4.0/.
+// SPDX-License-Identifier: CC-BY-4.0
+
 
 
 

--- a/src/docs/asciidoc/dev_env/scripts.adoc
+++ b/src/docs/asciidoc/dev_env/scripts.adoc
@@ -1,8 +1,10 @@
-// Copyright (c) 2020, RTE (http://www.rte-france.com)
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// Copyright (c) 2018-2020 RTE (http://www.rte-france.com)
+// See AUTHORS.txt
+// This document is subject to the terms of the Creative Commons Attribution 4.0 International license.
+// If a copy of the license was not distributed with this
+// file, You can obtain one at https://creativecommons.org/licenses/by/4.0/.
+// SPDX-License-Identifier: CC-BY-4.0
+
 
 
 

--- a/src/docs/asciidoc/dev_env/troubleshooting.adoc
+++ b/src/docs/asciidoc/dev_env/troubleshooting.adoc
@@ -1,8 +1,10 @@
-// Copyright (c) 2020, RTE (http://www.rte-france.com)
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// Copyright (c) 2018-2020 RTE (http://www.rte-france.com)
+// See AUTHORS.txt
+// This document is subject to the terms of the Creative Commons Attribution 4.0 International license.
+// If a copy of the license was not distributed with this
+// file, You can obtain one at https://creativecommons.org/licenses/by/4.0/.
+// SPDX-License-Identifier: CC-BY-4.0
+
 
 
 

--- a/src/docs/asciidoc/dev_env/ui.adoc
+++ b/src/docs/asciidoc/dev_env/ui.adoc
@@ -1,8 +1,10 @@
-// Copyright (c) 2020, RTE (http://www.rte-france.com)
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// Copyright (c) 2018-2020 RTE (http://www.rte-france.com)
+// See AUTHORS.txt
+// This document is subject to the terms of the Creative Commons Attribution 4.0 International license.
+// If a copy of the license was not distributed with this
+// file, You can obtain one at https://creativecommons.org/licenses/by/4.0/.
+// SPDX-License-Identifier: CC-BY-4.0
+
 
 
 

--- a/src/docs/asciidoc/docs/release_notes.adoc
+++ b/src/docs/asciidoc/docs/release_notes.adoc
@@ -1,8 +1,10 @@
-// Copyright (c) 2020, RTE (http://www.rte-france.com)
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// Copyright (c) 2018-2020 RTE (http://www.rte-france.com)
+// See AUTHORS.txt
+// This document is subject to the terms of the Creative Commons Attribution 4.0 International license.
+// If a copy of the license was not distributed with this
+// file, You can obtain one at https://creativecommons.org/licenses/by/4.0/.
+// SPDX-License-Identifier: CC-BY-4.0
+
 
 = Version SNAPSHOT
 

--- a/src/docs/asciidoc/docs/single_page_doc.adoc
+++ b/src/docs/asciidoc/docs/single_page_doc.adoc
@@ -1,8 +1,10 @@
-// Copyright (c) 2020, RTE (http://www.rte-france.com)
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// Copyright (c) 2018-2020 RTE (http://www.rte-france.com)
+// See AUTHORS.txt
+// This document is subject to the terms of the Creative Commons Attribution 4.0 International license.
+// If a copy of the license was not distributed with this
+// file, You can obtain one at https://creativecommons.org/licenses/by/4.0/.
+// SPDX-License-Identifier: CC-BY-4.0
+
 
 
 :single-page-doc:

--- a/src/docs/asciidoc/getting_started/index.adoc
+++ b/src/docs/asciidoc/getting_started/index.adoc
@@ -1,8 +1,10 @@
-// Copyright (c) 2020, RTE (http://www.rte-france.com)
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// Copyright (c) 2018-2020 RTE (http://www.rte-france.com)
+// See AUTHORS.txt
+// This document is subject to the terms of the Creative Commons Attribution 4.0 International license.
+// If a copy of the license was not distributed with this
+// file, You can obtain one at https://creativecommons.org/licenses/by/4.0/.
+// SPDX-License-Identifier: CC-BY-4.0
+
 
 
 

--- a/src/docs/asciidoc/getting_started/troubleshooting.adoc
+++ b/src/docs/asciidoc/getting_started/troubleshooting.adoc
@@ -1,8 +1,10 @@
-// Copyright (c) 2020, RTE (http://www.rte-france.com)
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// Copyright (c) 2018-2020 RTE (http://www.rte-france.com)
+// See AUTHORS.txt
+// This document is subject to the terms of the Creative Commons Attribution 4.0 International license.
+// If a copy of the license was not distributed with this
+// file, You can obtain one at https://creativecommons.org/licenses/by/4.0/.
+// SPDX-License-Identifier: CC-BY-4.0
+
 
 
 

--- a/src/docs/asciidoc/reference_doc/archives.adoc
+++ b/src/docs/asciidoc/reference_doc/archives.adoc
@@ -1,8 +1,10 @@
-// Copyright (c) 2020, RTE (http://www.rte-france.com)
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// Copyright (c) 2018-2020 RTE (http://www.rte-france.com)
+// See AUTHORS.txt
+// This document is subject to the terms of the Creative Commons Attribution 4.0 International license.
+// If a copy of the license was not distributed with this
+// file, You can obtain one at https://creativecommons.org/licenses/by/4.0/.
+// SPDX-License-Identifier: CC-BY-4.0
+
 
 
 

--- a/src/docs/asciidoc/reference_doc/bundle_technical_overview.adoc
+++ b/src/docs/asciidoc/reference_doc/bundle_technical_overview.adoc
@@ -1,8 +1,10 @@
-// Copyright (c) 2020, RTE (http://www.rte-france.com)
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// Copyright (c) 2018-2020 RTE (http://www.rte-france.com)
+// See AUTHORS.txt
+// This document is subject to the terms of the Creative Commons Attribution 4.0 International license.
+// If a copy of the license was not distributed with this
+// file, You can obtain one at https://creativecommons.org/licenses/by/4.0/.
+// SPDX-License-Identifier: CC-BY-4.0
+
 
 
 

--- a/src/docs/asciidoc/reference_doc/card_examples.adoc
+++ b/src/docs/asciidoc/reference_doc/card_examples.adoc
@@ -1,8 +1,10 @@
-// Copyright (c) 2020, RTE (http://www.rte-france.com)
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// Copyright (c) 2018-2020 RTE (http://www.rte-france.com)
+// See AUTHORS.txt
+// This document is subject to the terms of the Creative Commons Attribution 4.0 International license.
+// If a copy of the license was not distributed with this
+// file, You can obtain one at https://creativecommons.org/licenses/by/4.0/.
+// SPDX-License-Identifier: CC-BY-4.0
+
 
 
 

--- a/src/docs/asciidoc/reference_doc/card_structure.adoc
+++ b/src/docs/asciidoc/reference_doc/card_structure.adoc
@@ -1,8 +1,10 @@
-// Copyright (c) 2020, RTE (http://www.rte-france.com)
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// Copyright (c) 2018-2020 RTE (http://www.rte-france.com)
+// See AUTHORS.txt
+// This document is subject to the terms of the Creative Commons Attribution 4.0 International license.
+// If a copy of the license was not distributed with this
+// file, You can obtain one at https://creativecommons.org/licenses/by/4.0/.
+// SPDX-License-Identifier: CC-BY-4.0
+
 
 
 

--- a/src/docs/asciidoc/reference_doc/cards_consultation_service.adoc
+++ b/src/docs/asciidoc/reference_doc/cards_consultation_service.adoc
@@ -1,8 +1,10 @@
-// Copyright (c) 2020, RTE (http://www.rte-france.com)
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// Copyright (c) 2018-2020 RTE (http://www.rte-france.com)
+// See AUTHORS.txt
+// This document is subject to the terms of the Creative Commons Attribution 4.0 International license.
+// If a copy of the license was not distributed with this
+// file, You can obtain one at https://creativecommons.org/licenses/by/4.0/.
+// SPDX-License-Identifier: CC-BY-4.0
+
 
 
 

--- a/src/docs/asciidoc/reference_doc/cards_publication_service.adoc
+++ b/src/docs/asciidoc/reference_doc/cards_publication_service.adoc
@@ -1,8 +1,10 @@
-// Copyright (c) 2020, RTE (http://www.rte-france.com)
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// Copyright (c) 2018-2020 RTE (http://www.rte-france.com)
+// See AUTHORS.txt
+// This document is subject to the terms of the Creative Commons Attribution 4.0 International license.
+// If a copy of the license was not distributed with this
+// file, You can obtain one at https://creativecommons.org/licenses/by/4.0/.
+// SPDX-License-Identifier: CC-BY-4.0
+
 
 
 

--- a/src/docs/asciidoc/reference_doc/index.adoc
+++ b/src/docs/asciidoc/reference_doc/index.adoc
@@ -1,8 +1,10 @@
-// Copyright (c) 2020, RTE (http://www.rte-france.com)
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// Copyright (c) 2018-2020 RTE (http://www.rte-france.com)
+// See AUTHORS.txt
+// This document is subject to the terms of the Creative Commons Attribution 4.0 International license.
+// If a copy of the license was not distributed with this
+// file, You can obtain one at https://creativecommons.org/licenses/by/4.0/.
+// SPDX-License-Identifier: CC-BY-4.0
+
 
 
 

--- a/src/docs/asciidoc/reference_doc/publisher_definition.adoc
+++ b/src/docs/asciidoc/reference_doc/publisher_definition.adoc
@@ -1,8 +1,10 @@
-// Copyright (c) 2020, RTE (http://www.rte-france.com)
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// Copyright (c) 2018-2020 RTE (http://www.rte-france.com)
+// See AUTHORS.txt
+// This document is subject to the terms of the Creative Commons Attribution 4.0 International license.
+// If a copy of the license was not distributed with this
+// file, You can obtain one at https://creativecommons.org/licenses/by/4.0/.
+// SPDX-License-Identifier: CC-BY-4.0
+
 
 
 

--- a/src/docs/asciidoc/reference_doc/thirds_service.adoc
+++ b/src/docs/asciidoc/reference_doc/thirds_service.adoc
@@ -1,8 +1,10 @@
-// Copyright (c) 2020, RTE (http://www.rte-france.com)
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// Copyright (c) 2018-2020 RTE (http://www.rte-france.com)
+// See AUTHORS.txt
+// This document is subject to the terms of the Creative Commons Attribution 4.0 International license.
+// If a copy of the license was not distributed with this
+// file, You can obtain one at https://creativecommons.org/licenses/by/4.0/.
+// SPDX-License-Identifier: CC-BY-4.0
+
 
 
 

--- a/src/docs/asciidoc/reference_doc/users_service.adoc
+++ b/src/docs/asciidoc/reference_doc/users_service.adoc
@@ -1,8 +1,10 @@
-// Copyright (c) 2020, RTE (http://www.rte-france.com)
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// Copyright (c) 2018-2020 RTE (http://www.rte-france.com)
+// See AUTHORS.txt
+// This document is subject to the terms of the Creative Commons Attribution 4.0 International license.
+// If a copy of the license was not distributed with this
+// file, You can obtain one at https://creativecommons.org/licenses/by/4.0/.
+// SPDX-License-Identifier: CC-BY-4.0
+
 
 
 

--- a/src/docs/asciidoc/resources/index.adoc
+++ b/src/docs/asciidoc/resources/index.adoc
@@ -1,8 +1,10 @@
-// Copyright (c) 2020, RTE (http://www.rte-france.com)
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// Copyright (c) 2018-2020 RTE (http://www.rte-france.com)
+// See AUTHORS.txt
+// This document is subject to the terms of the Creative Commons Attribution 4.0 International license.
+// If a copy of the license was not distributed with this
+// file, You can obtain one at https://creativecommons.org/licenses/by/4.0/.
+// SPDX-License-Identifier: CC-BY-4.0
+
 
 
 

--- a/src/docs/asciidoc/resources/mock_pipeline.adoc
+++ b/src/docs/asciidoc/resources/mock_pipeline.adoc
@@ -1,8 +1,10 @@
-// Copyright (c) 2020, RTE (http://www.rte-france.com)
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// Copyright (c) 2018-2020 RTE (http://www.rte-france.com)
+// See AUTHORS.txt
+// This document is subject to the terms of the Creative Commons Attribution 4.0 International license.
+// If a copy of the license was not distributed with this
+// file, You can obtain one at https://creativecommons.org/licenses/by/4.0/.
+// SPDX-License-Identifier: CC-BY-4.0
+
 
 
 

--- a/src/main/headers/ADOC_LICENSE_HEADER.txt
+++ b/src/main/headers/ADOC_LICENSE_HEADER.txt
@@ -1,5 +1,6 @@
-// Copyright (c) 2020, RTE (http://www.rte-france.com)
-//
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+// Copyright (c) 2018-2020 RTE (http://www.rte-france.com)
+// See AUTHORS.txt
+// This document is subject to the terms of the Creative Commons Attribution 4.0 International license.
+// If a copy of the license was not distributed with this
+// file, You can obtain one at https://creativecommons.org/licenses/by/4.0/.
+// SPDX-License-Identifier: CC-BY-4.0

--- a/src/main/headers/HTML_LICENSE_HEADER.txt
+++ b/src/main/headers/HTML_LICENSE_HEADER.txt
@@ -1,5 +1,7 @@
-<!-- Copyright (c) 2020, RTE (http://www.rte-france.com)                 -->
-<!--                                                                     -->
-<!-- This Source Code Form is subject to the terms of the Mozilla Public -->
-<!-- License, v. 2.0. If a copy of the MPL was not distributed with this -->
-<!-- file, You can obtain one at http://mozilla.org/MPL/2.0/.            -->
+<!-- Copyright (c) 2018-2020, RTE (http://www.rte-france.com)              -->
+<!-- See AUTHORS.txt                                                       -->
+<!-- This Source Code Form is subject to the terms of the Mozilla Public   -->
+<!-- License, v. 2.0. If a copy of the MPL was not distributed with this   -->
+<!-- file, You can obtain one at http://mozilla.org/MPL/2.0/.              -->
+<!-- SPDX-License-Identifier: MPL-2.0                                      -->
+<!-- This file is part of the OperatorFabric project.                      -->

--- a/src/main/headers/JAVA_LICENSE_HEADER.txt
+++ b/src/main/headers/JAVA_LICENSE_HEADER.txt
@@ -1,6 +1,8 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */

--- a/src/main/headers/SH_LICENSE_HEADER.txt
+++ b/src/main/headers/SH_LICENSE_HEADER.txt
@@ -1,5 +1,8 @@
-# Copyright (c) 2020, RTE (http://www.rte-france.com)
-#
+# Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+# See AUTHORS.txt
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# SPDX-License-Identifier: MPL-2.0
+# This file is part of the OperatorFabric project.
+#

--- a/tools/generic/test-utilities/src/main/java/org/lfenergy/operatorfabric/test/AssertUtils.java
+++ b/tools/generic/test-utilities/src/main/java/org/lfenergy/operatorfabric/test/AssertUtils.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.test;

--- a/tools/generic/test-utilities/src/main/java/org/lfenergy/operatorfabric/test/EmptyListComparator.java
+++ b/tools/generic/test-utilities/src/main/java/org/lfenergy/operatorfabric/test/EmptyListComparator.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.test;

--- a/tools/generic/test-utilities/src/test/java/org/lfenergy/operatorfabric/test/TestUtilsShould.java
+++ b/tools/generic/test-utilities/src/test/java/org/lfenergy/operatorfabric/test/TestUtilsShould.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.test;

--- a/tools/generic/utilities/src/main/java/org/lfenergy/operatorfabric/data/Holder.java
+++ b/tools/generic/utilities/src/main/java/org/lfenergy/operatorfabric/data/Holder.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 package org.lfenergy.operatorfabric.data;
 

--- a/tools/generic/utilities/src/main/java/org/lfenergy/operatorfabric/utilities/ArrayUtils.java
+++ b/tools/generic/utilities/src/main/java/org/lfenergy/operatorfabric/utilities/ArrayUtils.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 package org.lfenergy.operatorfabric.utilities;
 

--- a/tools/generic/utilities/src/main/java/org/lfenergy/operatorfabric/utilities/CollectionUtils.java
+++ b/tools/generic/utilities/src/main/java/org/lfenergy/operatorfabric/utilities/CollectionUtils.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.utilities;

--- a/tools/generic/utilities/src/main/java/org/lfenergy/operatorfabric/utilities/IntrospectionUtils.java
+++ b/tools/generic/utilities/src/main/java/org/lfenergy/operatorfabric/utilities/IntrospectionUtils.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 package org.lfenergy.operatorfabric.utilities;
 

--- a/tools/generic/utilities/src/main/java/org/lfenergy/operatorfabric/utilities/PathUtils.java
+++ b/tools/generic/utilities/src/main/java/org/lfenergy/operatorfabric/utilities/PathUtils.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.utilities;

--- a/tools/generic/utilities/src/test/java/org/lfenergy/operatorfabric/utilities/ArrayUtilsShould.java
+++ b/tools/generic/utilities/src/test/java/org/lfenergy/operatorfabric/utilities/ArrayUtilsShould.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 package org.lfenergy.operatorfabric.utilities;
 

--- a/tools/generic/utilities/src/test/java/org/lfenergy/operatorfabric/utilities/IntrospectionUtilsShould.java
+++ b/tools/generic/utilities/src/test/java/org/lfenergy/operatorfabric/utilities/IntrospectionUtilsShould.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 package org.lfenergy.operatorfabric.utilities;
 

--- a/tools/generic/utilities/src/test/java/org/lfenergy/operatorfabric/utilities/PathUtilsShould.java
+++ b/tools/generic/utilities/src/test/java/org/lfenergy/operatorfabric/utilities/PathUtilsShould.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.utilities;

--- a/tools/spring/spring-mongo-utilities/src/main/java/org/lfenergy/operatorfabric/springtools/configuration/mongo/AbstractLocalMongoConfiguration.java
+++ b/tools/spring/spring-mongo-utilities/src/main/java/org/lfenergy/operatorfabric/springtools/configuration/mongo/AbstractLocalMongoConfiguration.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.springtools.configuration.mongo;

--- a/tools/spring/spring-mongo-utilities/src/main/java/org/lfenergy/operatorfabric/springtools/configuration/mongo/EnableOperatorFabricMongo.java
+++ b/tools/spring/spring-mongo-utilities/src/main/java/org/lfenergy/operatorfabric/springtools/configuration/mongo/EnableOperatorFabricMongo.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.springtools.configuration.mongo;

--- a/tools/spring/spring-mongo-utilities/src/main/java/org/lfenergy/operatorfabric/springtools/configuration/mongo/MongoConfiguration.java
+++ b/tools/spring/spring-mongo-utilities/src/main/java/org/lfenergy/operatorfabric/springtools/configuration/mongo/MongoConfiguration.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.springtools.configuration.mongo;

--- a/tools/spring/spring-mongo-utilities/src/main/java/org/lfenergy/operatorfabric/springtools/configuration/mongo/OperatorFabricMongoProperties.java
+++ b/tools/spring/spring-mongo-utilities/src/main/java/org/lfenergy/operatorfabric/springtools/configuration/mongo/OperatorFabricMongoProperties.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.springtools.configuration.mongo;

--- a/tools/spring/spring-oauth2-utilities/src/main/java/org/lfenergy/operatorfabric/springtools/configuration/oauth/BusConfiguration.java
+++ b/tools/spring/spring-oauth2-utilities/src/main/java/org/lfenergy/operatorfabric/springtools/configuration/oauth/BusConfiguration.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.springtools.configuration.oauth;

--- a/tools/spring/spring-oauth2-utilities/src/main/java/org/lfenergy/operatorfabric/springtools/configuration/oauth/EnableOperatorFabricOAuth2.java
+++ b/tools/spring/spring-oauth2-utilities/src/main/java/org/lfenergy/operatorfabric/springtools/configuration/oauth/EnableOperatorFabricOAuth2.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.springtools.configuration.oauth;

--- a/tools/spring/spring-oauth2-utilities/src/main/java/org/lfenergy/operatorfabric/springtools/configuration/oauth/EnableReactiveOperatorFabricOAuth2.java
+++ b/tools/spring/spring-oauth2-utilities/src/main/java/org/lfenergy/operatorfabric/springtools/configuration/oauth/EnableReactiveOperatorFabricOAuth2.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.springtools.configuration.oauth;

--- a/tools/spring/spring-oauth2-utilities/src/main/java/org/lfenergy/operatorfabric/springtools/configuration/oauth/OAuth2FeignRequestInterceptor.java
+++ b/tools/spring/spring-oauth2-utilities/src/main/java/org/lfenergy/operatorfabric/springtools/configuration/oauth/OAuth2FeignRequestInterceptor.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.springtools.configuration.oauth;

--- a/tools/spring/spring-oauth2-utilities/src/main/java/org/lfenergy/operatorfabric/springtools/configuration/oauth/OAuth2GenericConfiguration.java
+++ b/tools/spring/spring-oauth2-utilities/src/main/java/org/lfenergy/operatorfabric/springtools/configuration/oauth/OAuth2GenericConfiguration.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 package org.lfenergy.operatorfabric.springtools.configuration.oauth;
 

--- a/tools/spring/spring-oauth2-utilities/src/main/java/org/lfenergy/operatorfabric/springtools/configuration/oauth/OAuth2JwtProcessingUtilities.java
+++ b/tools/spring/spring-oauth2-utilities/src/main/java/org/lfenergy/operatorfabric/springtools/configuration/oauth/OAuth2JwtProcessingUtilities.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.springtools.configuration.oauth;

--- a/tools/spring/spring-oauth2-utilities/src/main/java/org/lfenergy/operatorfabric/springtools/configuration/oauth/OAuth2ReactiveConfiguration.java
+++ b/tools/spring/spring-oauth2-utilities/src/main/java/org/lfenergy/operatorfabric/springtools/configuration/oauth/OAuth2ReactiveConfiguration.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.springtools.configuration.oauth;

--- a/tools/spring/spring-oauth2-utilities/src/main/java/org/lfenergy/operatorfabric/springtools/configuration/oauth/OpFabJwtAuthenticationToken.java
+++ b/tools/spring/spring-oauth2-utilities/src/main/java/org/lfenergy/operatorfabric/springtools/configuration/oauth/OpFabJwtAuthenticationToken.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.springtools.configuration.oauth;

--- a/tools/spring/spring-oauth2-utilities/src/main/java/org/lfenergy/operatorfabric/springtools/configuration/oauth/UpdateUserEventListener.java
+++ b/tools/spring/spring-oauth2-utilities/src/main/java/org/lfenergy/operatorfabric/springtools/configuration/oauth/UpdateUserEventListener.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.springtools.configuration.oauth;

--- a/tools/spring/spring-oauth2-utilities/src/main/java/org/lfenergy/operatorfabric/springtools/configuration/oauth/UpdatedUserEvent.java
+++ b/tools/spring/spring-oauth2-utilities/src/main/java/org/lfenergy/operatorfabric/springtools/configuration/oauth/UpdatedUserEvent.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.springtools.configuration.oauth;

--- a/tools/spring/spring-oauth2-utilities/src/main/java/org/lfenergy/operatorfabric/springtools/configuration/oauth/UserServiceCache.java
+++ b/tools/spring/spring-oauth2-utilities/src/main/java/org/lfenergy/operatorfabric/springtools/configuration/oauth/UserServiceCache.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.springtools.configuration.oauth;

--- a/tools/spring/spring-oauth2-utilities/src/main/java/org/lfenergy/operatorfabric/springtools/configuration/oauth/UserServiceProxy.java
+++ b/tools/spring/spring-oauth2-utilities/src/main/java/org/lfenergy/operatorfabric/springtools/configuration/oauth/UserServiceProxy.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.springtools.configuration.oauth;

--- a/tools/spring/spring-oauth2-utilities/src/main/java/org/lfenergy/operatorfabric/springtools/configuration/oauth/jwt/JwtProperties.java
+++ b/tools/spring/spring-oauth2-utilities/src/main/java/org/lfenergy/operatorfabric/springtools/configuration/oauth/jwt/JwtProperties.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 package org.lfenergy.operatorfabric.springtools.configuration.oauth.jwt;
 

--- a/tools/spring/spring-oauth2-utilities/src/main/java/org/lfenergy/operatorfabric/springtools/configuration/oauth/jwt/groups/GroupsMode.java
+++ b/tools/spring/spring-oauth2-utilities/src/main/java/org/lfenergy/operatorfabric/springtools/configuration/oauth/jwt/groups/GroupsMode.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 package org.lfenergy.operatorfabric.springtools.configuration.oauth.jwt.groups;
 

--- a/tools/spring/spring-oauth2-utilities/src/main/java/org/lfenergy/operatorfabric/springtools/configuration/oauth/jwt/groups/GroupsProperties.java
+++ b/tools/spring/spring-oauth2-utilities/src/main/java/org/lfenergy/operatorfabric/springtools/configuration/oauth/jwt/groups/GroupsProperties.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 package org.lfenergy.operatorfabric.springtools.configuration.oauth.jwt.groups;
 

--- a/tools/spring/spring-oauth2-utilities/src/main/java/org/lfenergy/operatorfabric/springtools/configuration/oauth/jwt/groups/GroupsUtils.java
+++ b/tools/spring/spring-oauth2-utilities/src/main/java/org/lfenergy/operatorfabric/springtools/configuration/oauth/jwt/groups/GroupsUtils.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 package org.lfenergy.operatorfabric.springtools.configuration.oauth.jwt.groups;
 

--- a/tools/spring/spring-oauth2-utilities/src/main/java/org/lfenergy/operatorfabric/springtools/configuration/oauth/jwt/groups/RolesClaim.java
+++ b/tools/spring/spring-oauth2-utilities/src/main/java/org/lfenergy/operatorfabric/springtools/configuration/oauth/jwt/groups/RolesClaim.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 package org.lfenergy.operatorfabric.springtools.configuration.oauth.jwt.groups;
 

--- a/tools/spring/spring-oauth2-utilities/src/main/java/org/lfenergy/operatorfabric/springtools/configuration/oauth/jwt/groups/roles/RoleClaim.java
+++ b/tools/spring/spring-oauth2-utilities/src/main/java/org/lfenergy/operatorfabric/springtools/configuration/oauth/jwt/groups/roles/RoleClaim.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 package org.lfenergy.operatorfabric.springtools.configuration.oauth.jwt.groups.roles;
 

--- a/tools/spring/spring-oauth2-utilities/src/main/java/org/lfenergy/operatorfabric/springtools/configuration/oauth/jwt/groups/roles/RoleClaimCheckExistPath.java
+++ b/tools/spring/spring-oauth2-utilities/src/main/java/org/lfenergy/operatorfabric/springtools/configuration/oauth/jwt/groups/roles/RoleClaimCheckExistPath.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 package org.lfenergy.operatorfabric.springtools.configuration.oauth.jwt.groups.roles;
 

--- a/tools/spring/spring-oauth2-utilities/src/main/java/org/lfenergy/operatorfabric/springtools/configuration/oauth/jwt/groups/roles/RoleClaimStandard.java
+++ b/tools/spring/spring-oauth2-utilities/src/main/java/org/lfenergy/operatorfabric/springtools/configuration/oauth/jwt/groups/roles/RoleClaimStandard.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 package org.lfenergy.operatorfabric.springtools.configuration.oauth.jwt.groups.roles;
 

--- a/tools/spring/spring-oauth2-utilities/src/main/java/org/lfenergy/operatorfabric/springtools/configuration/oauth/jwt/groups/roles/RoleClaimStandardArray.java
+++ b/tools/spring/spring-oauth2-utilities/src/main/java/org/lfenergy/operatorfabric/springtools/configuration/oauth/jwt/groups/roles/RoleClaimStandardArray.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 package org.lfenergy.operatorfabric.springtools.configuration.oauth.jwt.groups.roles;
 

--- a/tools/spring/spring-oauth2-utilities/src/main/java/org/lfenergy/operatorfabric/springtools/configuration/oauth/jwt/groups/roles/RoleClaimStandardList.java
+++ b/tools/spring/spring-oauth2-utilities/src/main/java/org/lfenergy/operatorfabric/springtools/configuration/oauth/jwt/groups/roles/RoleClaimStandardList.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 package org.lfenergy.operatorfabric.springtools.configuration.oauth.jwt.groups.roles;
 

--- a/tools/spring/spring-oauth2-utilities/src/test/java/org/lfenergy/operatorfabric/springtools/configuration/oauth/UserServiceCacheShould.java
+++ b/tools/spring/spring-oauth2-utilities/src/test/java/org/lfenergy/operatorfabric/springtools/configuration/oauth/UserServiceCacheShould.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.springtools.configuration.oauth;

--- a/tools/spring/spring-oauth2-utilities/src/test/java/org/lfenergy/operatorfabric/springtools/configuration/oauth/application/UserServiceCacheTestApplication.java
+++ b/tools/spring/spring-oauth2-utilities/src/test/java/org/lfenergy/operatorfabric/springtools/configuration/oauth/application/UserServiceCacheTestApplication.java
@@ -1,11 +1,11 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
-
-
 
 package org.lfenergy.operatorfabric.springtools.configuration.oauth.application;
 

--- a/tools/spring/spring-oauth2-utilities/src/test/java/org/lfenergy/operatorfabric/springtools/configuration/oauth/jwt/groups/ExploShould.java
+++ b/tools/spring/spring-oauth2-utilities/src/test/java/org/lfenergy/operatorfabric/springtools/configuration/oauth/jwt/groups/ExploShould.java
@@ -1,3 +1,12 @@
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
+ */
+
 package org.lfenergy.operatorfabric.springtools.configuration.oauth.jwt.groups;
 
 import org.junit.jupiter.api.Test;

--- a/tools/spring/spring-oauth2-utilities/src/test/java/org/lfenergy/operatorfabric/springtools/configuration/oauth/jwt/groups/GroupsUtilsShould.java
+++ b/tools/spring/spring-oauth2-utilities/src/test/java/org/lfenergy/operatorfabric/springtools/configuration/oauth/jwt/groups/GroupsUtilsShould.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 package org.lfenergy.operatorfabric.springtools.configuration.oauth.jwt.groups;
 

--- a/tools/spring/spring-oauth2-utilities/src/test/java/org/lfenergy/operatorfabric/springtools/configuration/oauth/jwt/groups/GroupsUtilsWithApplicationFileConfigShould.java
+++ b/tools/spring/spring-oauth2-utilities/src/test/java/org/lfenergy/operatorfabric/springtools/configuration/oauth/jwt/groups/GroupsUtilsWithApplicationFileConfigShould.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 package org.lfenergy.operatorfabric.springtools.configuration.oauth.jwt.groups;
 

--- a/tools/spring/spring-oauth2-utilities/src/test/java/org/lfenergy/operatorfabric/springtools/configuration/oauth/jwt/groups/ToolsGeneratorTokenHelper.java
+++ b/tools/spring/spring-oauth2-utilities/src/test/java/org/lfenergy/operatorfabric/springtools/configuration/oauth/jwt/groups/ToolsGeneratorTokenHelper.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 package org.lfenergy.operatorfabric.springtools.configuration.oauth.jwt.groups;
 

--- a/tools/spring/spring-test-utilities/src/main/java/org/lfenergy/operatorfabric/springtools/configuration/test/OpFabUserDetails.java
+++ b/tools/spring/spring-test-utilities/src/main/java/org/lfenergy/operatorfabric/springtools/configuration/test/OpFabUserDetails.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.springtools.configuration.test;

--- a/tools/spring/spring-test-utilities/src/main/java/org/lfenergy/operatorfabric/springtools/configuration/test/WithMockOpFabUser.java
+++ b/tools/spring/spring-test-utilities/src/main/java/org/lfenergy/operatorfabric/springtools/configuration/test/WithMockOpFabUser.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.springtools.configuration.test;

--- a/tools/spring/spring-test-utilities/src/main/java/org/lfenergy/operatorfabric/springtools/configuration/test/WithMockOpFabUserSecurityContextFactory.java
+++ b/tools/spring/spring-test-utilities/src/main/java/org/lfenergy/operatorfabric/springtools/configuration/test/WithMockOpFabUserSecurityContextFactory.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.springtools.configuration.test;

--- a/tools/spring/spring-utilities/src/main/java/org/lfenergy/operatorfabric/springtools/error/model/ApiError.java
+++ b/tools/spring/spring-utilities/src/main/java/org/lfenergy/operatorfabric/springtools/error/model/ApiError.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.springtools.error.model;

--- a/tools/spring/spring-utilities/src/main/java/org/lfenergy/operatorfabric/springtools/error/model/ApiErrorException.java
+++ b/tools/spring/spring-utilities/src/main/java/org/lfenergy/operatorfabric/springtools/error/model/ApiErrorException.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.springtools.error.model;

--- a/tools/spring/spring-utilities/src/main/java/org/lfenergy/operatorfabric/springtools/json/InstantDeserializer.java
+++ b/tools/spring/spring-utilities/src/main/java/org/lfenergy/operatorfabric/springtools/json/InstantDeserializer.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.springtools.json;

--- a/tools/spring/spring-utilities/src/main/java/org/lfenergy/operatorfabric/springtools/json/InstantModule.java
+++ b/tools/spring/spring-utilities/src/main/java/org/lfenergy/operatorfabric/springtools/json/InstantModule.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.springtools.json;

--- a/tools/spring/spring-utilities/src/main/java/org/lfenergy/operatorfabric/springtools/json/InstantSerializer.java
+++ b/tools/spring/spring-utilities/src/main/java/org/lfenergy/operatorfabric/springtools/json/InstantSerializer.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.springtools.json;

--- a/tools/spring/spring-utilities/src/test/java/org/lfenergy/operatorfabric/springtools/json/InstantDeserializerShould.java
+++ b/tools/spring/spring-utilities/src/test/java/org/lfenergy/operatorfabric/springtools/json/InstantDeserializerShould.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 package org.lfenergy.operatorfabric.springtools.json;
 

--- a/tools/spring/spring-utilities/src/test/java/org/lfenergy/operatorfabric/springtools/json/InstantSerializerShould.java
+++ b/tools/spring/spring-utilities/src/test/java/org/lfenergy/operatorfabric/springtools/json/InstantSerializerShould.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 package org.lfenergy.operatorfabric.springtools.json;
 

--- a/tools/swagger-spring-generators/src/main/java/org/lfenergy/operatorfabric/generators/OpfabClientGenerator.java
+++ b/tools/swagger-spring-generators/src/main/java/org/lfenergy/operatorfabric/generators/OpfabClientGenerator.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.generators;

--- a/tools/swagger-spring-generators/src/main/java/org/lfenergy/operatorfabric/generators/OpfabSpringGenerator.java
+++ b/tools/swagger-spring-generators/src/main/java/org/lfenergy/operatorfabric/generators/OpfabSpringGenerator.java
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 package org.lfenergy.operatorfabric.generators;

--- a/ui/main/src/app/app-routing.module.ts
+++ b/ui/main/src/app/app-routing.module.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {NgModule} from '@angular/core';

--- a/ui/main/src/app/app.component.html
+++ b/ui/main/src/app/app.component.html
@@ -1,8 +1,11 @@
-<!-- Copyright (c) 2020, RTE (http://www.rte-france.com)                 -->
-<!--                                                                     -->
-<!-- This Source Code Form is subject to the terms of the Mozilla Public -->
-<!-- License, v. 2.0. If a copy of the MPL was not distributed with this -->
-<!-- file, You can obtain one at http://mozilla.org/MPL/2.0/.            -->
+<!-- Copyright (c) 2018-2020, RTE (http://www.rte-france.com)              -->
+<!-- See AUTHORS.txt                                                       -->
+<!-- This Source Code Form is subject to the terms of the Mozilla Public   -->
+<!-- License, v. 2.0. If a copy of the MPL was not distributed with this   -->
+<!-- file, You can obtain one at http://mozilla.org/MPL/2.0/.              -->
+<!-- SPDX-License-Identifier: MPL-2.0                                      -->
+<!-- This file is part of the OperatorFabric project.                      -->
+
 
 
 

--- a/ui/main/src/app/app.component.scss
+++ b/ui/main/src/app/app.component.scss
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 .button {margin-right: 8px;}
 

--- a/ui/main/src/app/app.component.ts
+++ b/ui/main/src/app/app.component.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import { Component, OnInit } from '@angular/core';

--- a/ui/main/src/app/app.module.ts
+++ b/ui/main/src/app/app.module.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {BrowserModule} from '@angular/platform-browser';

--- a/ui/main/src/app/components/login/login.component.html
+++ b/ui/main/src/app/components/login/login.component.html
@@ -1,8 +1,11 @@
-<!-- Copyright (c) 2020, RTE (http://www.rte-france.com)                 -->
-<!--                                                                     -->
-<!-- This Source Code Form is subject to the terms of the Mozilla Public -->
-<!-- License, v. 2.0. If a copy of the MPL was not distributed with this -->
-<!-- file, You can obtain one at http://mozilla.org/MPL/2.0/.            -->
+<!-- Copyright (c) 2018-2020, RTE (http://www.rte-france.com)              -->
+<!-- See AUTHORS.txt                                                       -->
+<!-- This Source Code Form is subject to the terms of the Mozilla Public   -->
+<!-- License, v. 2.0. If a copy of the MPL was not distributed with this   -->
+<!-- file, You can obtain one at http://mozilla.org/MPL/2.0/.              -->
+<!-- SPDX-License-Identifier: MPL-2.0                                      -->
+<!-- This file is part of the OperatorFabric project.                      -->
+
 
 
 <div class="container">

--- a/ui/main/src/app/components/login/login.component.spec.ts
+++ b/ui/main/src/app/components/login/login.component.spec.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {async, ComponentFixture, TestBed} from '@angular/core/testing';

--- a/ui/main/src/app/components/login/login.component.ts
+++ b/ui/main/src/app/components/login/login.component.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {Component, OnInit} from '@angular/core';

--- a/ui/main/src/app/components/navbar/custom-logo/custom-logo.component.css
+++ b/ui/main/src/app/components/navbar/custom-logo/custom-logo.component.css
@@ -1,7 +1,10 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 

--- a/ui/main/src/app/components/navbar/custom-logo/custom-logo.component.html
+++ b/ui/main/src/app/components/navbar/custom-logo/custom-logo.component.html
@@ -1,8 +1,11 @@
-<!-- Copyright (c) 2020, RTE (http://www.rte-france.com)                 -->
-<!--                                                                     -->
-<!-- This Source Code Form is subject to the terms of the Mozilla Public -->
-<!-- License, v. 2.0. If a copy of the MPL was not distributed with this -->
-<!-- file, You can obtain one at http://mozilla.org/MPL/2.0/.            -->
+<!-- Copyright (c) 2018-2020, RTE (http://www.rte-france.com)              -->
+<!-- See AUTHORS.txt                                                       -->
+<!-- This Source Code Form is subject to the terms of the Mozilla Public   -->
+<!-- License, v. 2.0. If a copy of the MPL was not distributed with this   -->
+<!-- file, You can obtain one at http://mozilla.org/MPL/2.0/.              -->
+<!-- SPDX-License-Identifier: MPL-2.0                                      -->
+<!-- This file is part of the OperatorFabric project.                      -->
+
 
 
 <img [src]="getImage()" [attr.width]="width" [attr.height]="height" alt="logo"/>

--- a/ui/main/src/app/components/navbar/custom-logo/custom-logo.component.spec.ts
+++ b/ui/main/src/app/components/navbar/custom-logo/custom-logo.component.spec.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 

--- a/ui/main/src/app/components/navbar/custom-logo/custom-logo.component.ts
+++ b/ui/main/src/app/components/navbar/custom-logo/custom-logo.component.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 import { Component, OnInit, Input } from '@angular/core';
 import { DomSanitizer, SafeUrl } from '@angular/platform-browser';

--- a/ui/main/src/app/components/navbar/icon/icon.component.html
+++ b/ui/main/src/app/components/navbar/icon/icon.component.html
@@ -1,8 +1,11 @@
-<!-- Copyright (c) 2020, RTE (http://www.rte-france.com)                 -->
-<!--                                                                     -->
-<!-- This Source Code Form is subject to the terms of the Mozilla Public -->
-<!-- License, v. 2.0. If a copy of the MPL was not distributed with this -->
-<!-- file, You can obtain one at http://mozilla.org/MPL/2.0/.            -->
+<!-- Copyright (c) 2018-2020, RTE (http://www.rte-france.com)              -->
+<!-- See AUTHORS.txt                                                       -->
+<!-- This Source Code Form is subject to the terms of the Mozilla Public   -->
+<!-- License, v. 2.0. If a copy of the MPL was not distributed with this   -->
+<!-- file, You can obtain one at http://mozilla.org/MPL/2.0/.              -->
+<!-- SPDX-License-Identifier: MPL-2.0                                      -->
+<!-- This file is part of the OperatorFabric project.                      -->
+
 
 
 <svg x="0px" y="0px" [attr.width]="size" [attr.height]="size" [ngClass]="bright"

--- a/ui/main/src/app/components/navbar/icon/icon.component.scss
+++ b/ui/main/src/app/components/navbar/icon/icon.component.scss
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 @import "~assets/styles/_variables.scss";
 

--- a/ui/main/src/app/components/navbar/icon/icon.component.spec.ts
+++ b/ui/main/src/app/components/navbar/icon/icon.component.spec.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';

--- a/ui/main/src/app/components/navbar/icon/icon.component.ts
+++ b/ui/main/src/app/components/navbar/icon/icon.component.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {Component, Input, OnInit} from '@angular/core';

--- a/ui/main/src/app/components/navbar/info/info.component.html
+++ b/ui/main/src/app/components/navbar/info/info.component.html
@@ -1,8 +1,11 @@
-<!-- Copyright (c) 2020, RTE (http://www.rte-france.com)                 -->
-<!--                                                                     -->
-<!-- This Source Code Form is subject to the terms of the Mozilla Public -->
-<!-- License, v. 2.0. If a copy of the MPL was not distributed with this -->
-<!-- file, You can obtain one at http://mozilla.org/MPL/2.0/.            -->
+<!-- Copyright (c) 2018-2020, RTE (http://www.rte-france.com)              -->
+<!-- See AUTHORS.txt                                                       -->
+<!-- This Source Code Form is subject to the terms of the Mozilla Public   -->
+<!-- License, v. 2.0. If a copy of the MPL was not distributed with this   -->
+<!-- file, You can obtain one at http://mozilla.org/MPL/2.0/.              -->
+<!-- SPDX-License-Identifier: MPL-2.0                                      -->
+<!-- This file is part of the OperatorFabric project.                      -->
+
 
 
 <div class="text-center navbar-info-block" placement="bottom">

--- a/ui/main/src/app/components/navbar/info/info.component.scss
+++ b/ui/main/src/app/components/navbar/info/info.component.scss
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 .navbar-info-block {
   display: inline-block;

--- a/ui/main/src/app/components/navbar/info/info.component.spec.ts
+++ b/ui/main/src/app/components/navbar/info/info.component.spec.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {async, ComponentFixture, TestBed} from '@angular/core/testing';

--- a/ui/main/src/app/components/navbar/info/info.component.ts
+++ b/ui/main/src/app/components/navbar/info/info.component.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {Component, OnInit} from '@angular/core';

--- a/ui/main/src/app/components/navbar/menus/menu-link/menu-link.component.html
+++ b/ui/main/src/app/components/navbar/menus/menu-link/menu-link.component.html
@@ -1,8 +1,11 @@
-<!-- Copyright (c) 2020, RTE (http://www.rte-france.com)                 -->
-<!--                                                                     -->
-<!-- This Source Code Form is subject to the terms of the Mozilla Public -->
-<!-- License, v. 2.0. If a copy of the MPL was not distributed with this -->
-<!-- file, You can obtain one at http://mozilla.org/MPL/2.0/.            -->
+<!-- Copyright (c) 2018-2020, RTE (http://www.rte-france.com)              -->
+<!-- See AUTHORS.txt                                                       -->
+<!-- This Source Code Form is subject to the terms of the Mozilla Public   -->
+<!-- License, v. 2.0. If a copy of the MPL was not distributed with this   -->
+<!-- file, You can obtain one at http://mozilla.org/MPL/2.0/.              -->
+<!-- SPDX-License-Identifier: MPL-2.0                                      -->
+<!-- This file is part of the OperatorFabric project.                      -->
+
 
 <div *ngIf=menusOpenInTabs>
   <a class="text-link" [href]="menuEntry.url" target="_blank" rel="noopener noreferrer" translate>{{menu.id}}.{{menu.version}}.{{menuEntry.label}}</a>

--- a/ui/main/src/app/components/navbar/menus/menu-link/menu-link.component.scss
+++ b/ui/main/src/app/components/navbar/menus/menu-link/menu-link.component.scss
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 .text-link {

--- a/ui/main/src/app/components/navbar/menus/menu-link/menu-link.component.spec.ts
+++ b/ui/main/src/app/components/navbar/menus/menu-link/menu-link.component.spec.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 

--- a/ui/main/src/app/components/navbar/menus/menu-link/menu-link.component.ts
+++ b/ui/main/src/app/components/navbar/menus/menu-link/menu-link.component.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 import {Component, Input, OnInit} from '@angular/core';
 import {ThirdMenu, ThirdMenuEntry} from "@ofModel/thirds.model";

--- a/ui/main/src/app/components/navbar/navbar.component.html
+++ b/ui/main/src/app/components/navbar/navbar.component.html
@@ -1,8 +1,11 @@
-<!-- Copyright (c) 2020, RTE (http://www.rte-france.com)                 -->
-<!--                                                                     -->
-<!-- This Source Code Form is subject to the terms of the Mozilla Public -->
-<!-- License, v. 2.0. If a copy of the MPL was not distributed with this -->
-<!-- file, You can obtain one at http://mozilla.org/MPL/2.0/.            -->
+<!-- Copyright (c) 2018-2020, RTE (http://www.rte-france.com)              -->
+<!-- See AUTHORS.txt                                                       -->
+<!-- This Source Code Form is subject to the terms of the Mozilla Public   -->
+<!-- License, v. 2.0. If a copy of the MPL was not distributed with this   -->
+<!-- file, You can obtain one at http://mozilla.org/MPL/2.0/.              -->
+<!-- SPDX-License-Identifier: MPL-2.0                                      -->
+<!-- This file is part of the OperatorFabric project.                      -->
+
 
 
 <nav class="navbar navbar-expand-lg fixed-top  opfab-navbar">

--- a/ui/main/src/app/components/navbar/navbar.component.scss
+++ b/ui/main/src/app/components/navbar/navbar.component.scss
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
  ::ng-deep .opfab-menu-link {

--- a/ui/main/src/app/components/navbar/navbar.component.spec.ts
+++ b/ui/main/src/app/components/navbar/navbar.component.spec.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {async, ComponentFixture, TestBed} from '@angular/core/testing';

--- a/ui/main/src/app/components/navbar/navbar.component.ts
+++ b/ui/main/src/app/components/navbar/navbar.component.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {Component, OnInit} from '@angular/core';

--- a/ui/main/src/app/model/card-operation.model.spec.ts
+++ b/ui/main/src/app/model/card-operation.model.spec.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 import {CardOperation, CardOperationType} from "@ofModel/card-operation.model";
 import {getRandomAlphanumericValue} from "@tests/helpers";

--- a/ui/main/src/app/model/card-operation.model.ts
+++ b/ui/main/src/app/model/card-operation.model.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {LightCard} from './light-card.model';

--- a/ui/main/src/app/model/card.model.ts
+++ b/ui/main/src/app/model/card.model.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {Severity} from "@ofModel/light-card.model";

--- a/ui/main/src/app/model/datetime-ngb.model.spec.ts
+++ b/ui/main/src/app/model/datetime-ngb.model.spec.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 import { DateTimeNgb, padNumber, toInteger, isNumber } from './datetime-ngb.model';
 

--- a/ui/main/src/app/model/datetime-ngb.model.ts
+++ b/ui/main/src/app/model/datetime-ngb.model.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 import { NgbDateParserFormatter, NgbDateStruct, NgbTimeStruct } from '@ng-bootstrap/ng-bootstrap';
 

--- a/ui/main/src/app/model/detail-context.model.ts
+++ b/ui/main/src/app/model/detail-context.model.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {Card} from "@ofModel/card.model";

--- a/ui/main/src/app/model/feed-filter.model.ts
+++ b/ui/main/src/app/model/feed-filter.model.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {LightCard} from "@ofModel/light-card.model";

--- a/ui/main/src/app/model/i18n.model.ts
+++ b/ui/main/src/app/model/i18n.model.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {Map} from "@ofModel/map";

--- a/ui/main/src/app/model/light-card.model.ts
+++ b/ui/main/src/app/model/light-card.model.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {I18n} from "@ofModel/i18n.model";

--- a/ui/main/src/app/model/map.ts
+++ b/ui/main/src/app/model/map.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 export class Map<T> {

--- a/ui/main/src/app/model/message.model.ts
+++ b/ui/main/src/app/model/message.model.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {I18n} from "@ofModel/i18n.model";

--- a/ui/main/src/app/model/page.model.ts
+++ b/ui/main/src/app/model/page.model.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {Severity} from "@ofModel/light-card.model";

--- a/ui/main/src/app/model/thirds.model.ts
+++ b/ui/main/src/app/model/thirds.model.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {Card, Detail} from "@ofModel/card.model";

--- a/ui/main/src/app/model/user-context.model.ts
+++ b/ui/main/src/app/model/user-context.model.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 export class UserContext{

--- a/ui/main/src/app/model/user.model.ts
+++ b/ui/main/src/app/model/user.model.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 export class User {

--- a/ui/main/src/app/modules/about/about.component.html
+++ b/ui/main/src/app/modules/about/about.component.html
@@ -1,3 +1,11 @@
+<!-- Copyright (c) 2018-2020, RTE (http://www.rte-france.com)              -->
+<!-- See AUTHORS.txt                                                       -->
+<!-- This Source Code Form is subject to the terms of the Mozilla Public   -->
+<!-- License, v. 2.0. If a copy of the MPL was not distributed with this   -->
+<!-- file, You can obtain one at http://mozilla.org/MPL/2.0/.              -->
+<!-- SPDX-License-Identifier: MPL-2.0                                      -->
+<!-- This file is part of the OperatorFabric project.                      -->
+
 <ul class="about-application-list">
     <li *ngFor="let elem of (aboutElements|async)">
         <span class="about-application-name">{{elem.name}}</span>

--- a/ui/main/src/app/modules/about/about.component.scss
+++ b/ui/main/src/app/modules/about/about.component.scss
@@ -1,3 +1,12 @@
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
+ */
+
 .about-application-list{
   margin-top: 15%;
   list-style-type: none;

--- a/ui/main/src/app/modules/about/about.component.ts
+++ b/ui/main/src/app/modules/about/about.component.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 import {Component, OnInit} from '@angular/core';
 import {AppState} from '@ofStore/index';

--- a/ui/main/src/app/modules/archives/archive.component.spec.ts
+++ b/ui/main/src/app/modules/archives/archive.component.spec.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {async, ComponentFixture, TestBed} from '@angular/core/testing';

--- a/ui/main/src/app/modules/archives/archives-routing.module.ts
+++ b/ui/main/src/app/modules/archives/archives-routing.module.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {NgModule} from '@angular/core';

--- a/ui/main/src/app/modules/archives/archives.component.html
+++ b/ui/main/src/app/modules/archives/archives.component.html
@@ -1,8 +1,11 @@
-<!-- Copyright (c) 2020, RTE (http://www.rte-france.com)                 -->
-<!--                                                                     -->
-<!-- This Source Code Form is subject to the terms of the Mozilla Public -->
-<!-- License, v. 2.0. If a copy of the MPL was not distributed with this -->
-<!-- file, You can obtain one at http://mozilla.org/MPL/2.0/.            -->
+<!-- Copyright (c) 2018-2020, RTE (http://www.rte-france.com)              -->
+<!-- See AUTHORS.txt                                                       -->
+<!-- This Source Code Form is subject to the terms of the Mozilla Public   -->
+<!-- License, v. 2.0. If a copy of the MPL was not distributed with this   -->
+<!-- file, You can obtain one at http://mozilla.org/MPL/2.0/.              -->
+<!-- SPDX-License-Identifier: MPL-2.0                                      -->
+<!-- This file is part of the OperatorFabric project.                      -->
+
 
 
 <div class="row archives-page">

--- a/ui/main/src/app/modules/archives/archives.component.scss
+++ b/ui/main/src/app/modules/archives/archives.component.scss
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 .alert-info {
     color: var(--opfab-text-color);

--- a/ui/main/src/app/modules/archives/archives.component.ts
+++ b/ui/main/src/app/modules/archives/archives.component.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {Component, OnInit} from '@angular/core';

--- a/ui/main/src/app/modules/archives/archives.module.spec.ts
+++ b/ui/main/src/app/modules/archives/archives.module.spec.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {ArchivesModule} from './archives.module';

--- a/ui/main/src/app/modules/archives/archives.module.ts
+++ b/ui/main/src/app/modules/archives/archives.module.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {NgModule} from '@angular/core';

--- a/ui/main/src/app/modules/archives/components/archive-filters/archive-filters.component.css
+++ b/ui/main/src/app/modules/archives/components/archive-filters/archive-filters.component.css
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 .nomarginrow {
     margin-left:0;

--- a/ui/main/src/app/modules/archives/components/archive-filters/archive-filters.component.html
+++ b/ui/main/src/app/modules/archives/components/archive-filters/archive-filters.component.html
@@ -1,8 +1,11 @@
-<!-- Copyright (c) 2020, RTE (http://www.rte-france.com)                 -->
-<!--                                                                     -->
-<!-- This Source Code Form is subject to the terms of the Mozilla Public -->
-<!-- License, v. 2.0. If a copy of the MPL was not distributed with this -->
-<!-- file, You can obtain one at http://mozilla.org/MPL/2.0/.            -->
+<!-- Copyright (c) 2018-2020, RTE (http://www.rte-france.com)              -->
+<!-- See AUTHORS.txt                                                       -->
+<!-- This Source Code Form is subject to the terms of the Mozilla Public   -->
+<!-- License, v. 2.0. If a copy of the MPL was not distributed with this   -->
+<!-- file, You can obtain one at http://mozilla.org/MPL/2.0/.              -->
+<!-- SPDX-License-Identifier: MPL-2.0                                      -->
+<!-- This file is part of the OperatorFabric project.                      -->
+
 
 <form [formGroup]="archiveForm">
   <div class="container-fluid">

--- a/ui/main/src/app/modules/archives/components/archive-filters/archive-filters.component.spec.ts
+++ b/ui/main/src/app/modules/archives/components/archive-filters/archive-filters.component.spec.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {async, ComponentFixture, getTestBed, TestBed} from '@angular/core/testing';

--- a/ui/main/src/app/modules/archives/components/archive-filters/archive-filters.component.ts
+++ b/ui/main/src/app/modules/archives/components/archive-filters/archive-filters.component.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import { Component, OnInit } from '@angular/core';

--- a/ui/main/src/app/modules/archives/components/archive-filters/datetime-filter/datetime-filter.component.css
+++ b/ui/main/src/app/modules/archives/components/archive-filters/datetime-filter/datetime-filter.component.css
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 .nomarginrow {
     margin-left:0;

--- a/ui/main/src/app/modules/archives/components/archive-filters/datetime-filter/datetime-filter.component.html
+++ b/ui/main/src/app/modules/archives/components/archive-filters/datetime-filter/datetime-filter.component.html
@@ -1,8 +1,11 @@
-<!-- Copyright (c) 2020, RTE (http://www.rte-france.com)                 -->
-<!--                                                                     -->
-<!-- This Source Code Form is subject to the terms of the Mozilla Public -->
-<!-- License, v. 2.0. If a copy of the MPL was not distributed with this -->
-<!-- file, You can obtain one at http://mozilla.org/MPL/2.0/.            -->
+<!-- Copyright (c) 2018-2020, RTE (http://www.rte-france.com)              -->
+<!-- See AUTHORS.txt                                                       -->
+<!-- This Source Code Form is subject to the terms of the Mozilla Public   -->
+<!-- License, v. 2.0. If a copy of the MPL was not distributed with this   -->
+<!-- file, You can obtain one at http://mozilla.org/MPL/2.0/.              -->
+<!-- SPDX-License-Identifier: MPL-2.0                                      -->
+<!-- This file is part of the OperatorFabric project.                      -->
+
 
 <ng-container [formGroup]="datetimeForm">
     <div class="form-row nomarginrow">

--- a/ui/main/src/app/modules/archives/components/archive-filters/datetime-filter/datetime-filter.component.spec.ts
+++ b/ui/main/src/app/modules/archives/components/archive-filters/datetime-filter/datetime-filter.component.spec.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 

--- a/ui/main/src/app/modules/archives/components/archive-filters/datetime-filter/datetime-filter.component.ts
+++ b/ui/main/src/app/modules/archives/components/archive-filters/datetime-filter/datetime-filter.component.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 import { Component,Input, forwardRef } from '@angular/core';
 import { ControlValueAccessor, FormGroup, FormControl,

--- a/ui/main/src/app/modules/archives/components/archive-filters/multi-filter/multi-filter.component.css
+++ b/ui/main/src/app/modules/archives/components/archive-filters/multi-filter/multi-filter.component.css
@@ -1,7 +1,10 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 

--- a/ui/main/src/app/modules/archives/components/archive-filters/multi-filter/multi-filter.component.html
+++ b/ui/main/src/app/modules/archives/components/archive-filters/multi-filter/multi-filter.component.html
@@ -1,8 +1,11 @@
-<!-- Copyright (c) 2020, RTE (http://www.rte-france.com)                 -->
-<!--                                                                     -->
-<!-- This Source Code Form is subject to the terms of the Mozilla Public -->
-<!-- License, v. 2.0. If a copy of the MPL was not distributed with this -->
-<!-- file, You can obtain one at http://mozilla.org/MPL/2.0/.            -->
+<!-- Copyright (c) 2018-2020, RTE (http://www.rte-france.com)              -->
+<!-- See AUTHORS.txt                                                       -->
+<!-- This Source Code Form is subject to the terms of the Mozilla Public   -->
+<!-- License, v. 2.0. If a copy of the MPL was not distributed with this   -->
+<!-- file, You can obtain one at http://mozilla.org/MPL/2.0/.              -->
+<!-- SPDX-License-Identifier: MPL-2.0                                      -->
+<!-- This file is part of the OperatorFabric project.                      -->
+
 
 
 <div class="form-group" [formGroup]="parentForm">

--- a/ui/main/src/app/modules/archives/components/archive-filters/multi-filter/multi-filter.component.spec.ts
+++ b/ui/main/src/app/modules/archives/components/archive-filters/multi-filter/multi-filter.component.spec.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 

--- a/ui/main/src/app/modules/archives/components/archive-filters/multi-filter/multi-filter.component.ts
+++ b/ui/main/src/app/modules/archives/components/archive-filters/multi-filter/multi-filter.component.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 import { Component, OnInit, Input } from '@angular/core';
 import { Observable, of } from 'rxjs';

--- a/ui/main/src/app/modules/archives/components/archive-list/archive-list-page/archive-list-page.component.html
+++ b/ui/main/src/app/modules/archives/components/archive-list/archive-list-page/archive-list-page.component.html
@@ -1,8 +1,11 @@
-<!-- Copyright (c) 2020, RTE (http://www.rte-france.com)                 -->
-<!--                                                                     -->
-<!-- This Source Code Form is subject to the terms of the Mozilla Public -->
-<!-- License, v. 2.0. If a copy of the MPL was not distributed with this -->
-<!-- file, You can obtain one at http://mozilla.org/MPL/2.0/.            -->
+<!-- Copyright (c) 2018-2020, RTE (http://www.rte-france.com)              -->
+<!-- See AUTHORS.txt                                                       -->
+<!-- This Source Code Form is subject to the terms of the Mozilla Public   -->
+<!-- License, v. 2.0. If a copy of the MPL was not distributed with this   -->
+<!-- file, You can obtain one at http://mozilla.org/MPL/2.0/.              -->
+<!-- SPDX-License-Identifier: MPL-2.0                                      -->
+<!-- This file is part of the OperatorFabric project.                      -->
+
 
 <ngb-pagination *ngIf="(collectionSize$ | async) > (size$ | async)"
   [collectionSize]="collectionSize$ | async"

--- a/ui/main/src/app/modules/archives/components/archive-list/archive-list-page/archive-list-page.component.scss
+++ b/ui/main/src/app/modules/archives/components/archive-list/archive-list-page/archive-list-page.component.scss
@@ -1,7 +1,10 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 

--- a/ui/main/src/app/modules/archives/components/archive-list/archive-list-page/archive-list-page.component.spec.ts
+++ b/ui/main/src/app/modules/archives/components/archive-list/archive-list-page/archive-list-page.component.spec.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import { ArchiveListPageComponent } from './archive-list-page.component';

--- a/ui/main/src/app/modules/archives/components/archive-list/archive-list-page/archive-list-page.component.ts
+++ b/ui/main/src/app/modules/archives/components/archive-list/archive-list-page/archive-list-page.component.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import { Component, OnInit, Input } from '@angular/core';

--- a/ui/main/src/app/modules/archives/components/archive-list/archive-list.component.html
+++ b/ui/main/src/app/modules/archives/components/archive-list/archive-list.component.html
@@ -1,8 +1,11 @@
-<!-- Copyright (c) 2020, RTE (http://www.rte-france.com)                 -->
-<!--                                                                     -->
-<!-- This Source Code Form is subject to the terms of the Mozilla Public -->
-<!-- License, v. 2.0. If a copy of the MPL was not distributed with this -->
-<!-- file, You can obtain one at http://mozilla.org/MPL/2.0/.            -->
+<!-- Copyright (c) 2018-2020, RTE (http://www.rte-france.com)              -->
+<!-- See AUTHORS.txt                                                       -->
+<!-- This Source Code Form is subject to the terms of the Mozilla Public   -->
+<!-- License, v. 2.0. If a copy of the MPL was not distributed with this   -->
+<!-- file, You can obtain one at http://mozilla.org/MPL/2.0/.              -->
+<!-- SPDX-License-Identifier: MPL-2.0                                      -->
+<!-- This file is part of the OperatorFabric project.                      -->
+
 
 
 <div class="container-fluid">

--- a/ui/main/src/app/modules/archives/components/archive-list/archive-list.component.scss
+++ b/ui/main/src/app/modules/archives/components/archive-list/archive-list.component.scss
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 .feed-content {

--- a/ui/main/src/app/modules/archives/components/archive-list/archive-list.component.ts
+++ b/ui/main/src/app/modules/archives/components/archive-list/archive-list.component.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {Component, Input, OnInit} from '@angular/core';

--- a/ui/main/src/app/modules/cards/cards.module.ts
+++ b/ui/main/src/app/modules/cards/cards.module.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {ModuleWithProviders, NgModule} from '@angular/core';

--- a/ui/main/src/app/modules/cards/components/action/action.component.html
+++ b/ui/main/src/app/modules/cards/components/action/action.component.html
@@ -1,8 +1,11 @@
-<!-- Copyright (c) 2020, RTE (http://www.rte-france.com)                 -->
-<!--                                                                     -->
-<!-- This Source Code Form is subject to the terms of the Mozilla Public -->
-<!-- License, v. 2.0. If a copy of the MPL was not distributed with this -->
-<!-- file, You can obtain one at http://mozilla.org/MPL/2.0/.            -->
+<!-- Copyright (c) 2018-2020, RTE (http://www.rte-france.com)              -->
+<!-- See AUTHORS.txt                                                       -->
+<!-- This Source Code Form is subject to the terms of the Mozilla Public   -->
+<!-- License, v. 2.0. If a copy of the MPL was not distributed with this   -->
+<!-- file, You can obtain one at http://mozilla.org/MPL/2.0/.              -->
+<!-- SPDX-License-Identifier: MPL-2.0                                      -->
+<!-- This file is part of the OperatorFabric project.                      -->
+
 
 <button *ngIf="!action.hidden"
         type="button"

--- a/ui/main/src/app/modules/cards/components/action/action.component.scss
+++ b/ui/main/src/app/modules/cards/components/action/action.component.scss
@@ -1,7 +1,10 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 

--- a/ui/main/src/app/modules/cards/components/action/action.component.spec.ts
+++ b/ui/main/src/app/modules/cards/components/action/action.component.spec.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 import {async, ComponentFixture, getTestBed, TestBed} from '@angular/core/testing';
 

--- a/ui/main/src/app/modules/cards/components/action/action.component.ts
+++ b/ui/main/src/app/modules/cards/components/action/action.component.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {Component, Input, OnInit} from '@angular/core';

--- a/ui/main/src/app/modules/cards/components/action/confirm-modal/confirm-modal.component.html
+++ b/ui/main/src/app/modules/cards/components/action/confirm-modal/confirm-modal.component.html
@@ -1,8 +1,11 @@
-<!-- Copyright (c) 2020, RTE (http://www.rte-france.com)                 -->
-<!--                                                                     -->
-<!-- This Source Code Form is subject to the terms of the Mozilla Public -->
-<!-- License, v. 2.0. If a copy of the MPL was not distributed with this -->
-<!-- file, You can obtain one at http://mozilla.org/MPL/2.0/.            -->
+<!-- Copyright (c) 2018-2020, RTE (http://www.rte-france.com)              -->
+<!-- See AUTHORS.txt                                                       -->
+<!-- This Source Code Form is subject to the terms of the Mozilla Public   -->
+<!-- License, v. 2.0. If a copy of the MPL was not distributed with this   -->
+<!-- file, You can obtain one at http://mozilla.org/MPL/2.0/.              -->
+<!-- SPDX-License-Identifier: MPL-2.0                                      -->
+<!-- This file is part of the OperatorFabric project.                      -->
+
 
 <div class="modal-header bg-dark">
     <h4 class="modal-title" id="modal-title">Action Status Changed</h4>

--- a/ui/main/src/app/modules/cards/components/action/confirm-modal/confirm-modal.component.ts
+++ b/ui/main/src/app/modules/cards/components/action/confirm-modal/confirm-modal.component.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 import {NgbActiveModal} from "@ng-bootstrap/ng-bootstrap";
 import {Component} from "@angular/core";

--- a/ui/main/src/app/modules/cards/components/card-details/card-details.component.html
+++ b/ui/main/src/app/modules/cards/components/card-details/card-details.component.html
@@ -1,8 +1,11 @@
-<!-- Copyright (c) 2020, RTE (http://www.rte-france.com)                 -->
-<!--                                                                     -->
-<!-- This Source Code Form is subject to the terms of the Mozilla Public -->
-<!-- License, v. 2.0. If a copy of the MPL was not distributed with this -->
-<!-- file, You can obtain one at http://mozilla.org/MPL/2.0/.            -->
+<!-- Copyright (c) 2018-2020, RTE (http://www.rte-france.com)              -->
+<!-- See AUTHORS.txt                                                       -->
+<!-- This Source Code Form is subject to the terms of the Mozilla Public   -->
+<!-- License, v. 2.0. If a copy of the MPL was not distributed with this   -->
+<!-- file, You can obtain one at http://mozilla.org/MPL/2.0/.              -->
+<!-- SPDX-License-Identifier: MPL-2.0                                      -->
+<!-- This file is part of the OperatorFabric project.                      -->
+
 
 
 <of-details [card]="card" [style.visibility]="card ? 'visible' : 'hidden'">

--- a/ui/main/src/app/modules/cards/components/card-details/card-details.component.scss
+++ b/ui/main/src/app/modules/cards/components/card-details/card-details.component.scss
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
  .close {

--- a/ui/main/src/app/modules/cards/components/card-details/card-details.component.spec.ts
+++ b/ui/main/src/app/modules/cards/components/card-details/card-details.component.spec.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {async, ComponentFixture, TestBed} from '@angular/core/testing';

--- a/ui/main/src/app/modules/cards/components/card-details/card-details.component.ts
+++ b/ui/main/src/app/modules/cards/components/card-details/card-details.component.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {Component, OnInit} from '@angular/core';

--- a/ui/main/src/app/modules/cards/components/card/card.component.html
+++ b/ui/main/src/app/modules/cards/components/card/card.component.html
@@ -1,8 +1,11 @@
-<!-- Copyright (c) 2020, RTE (http://www.rte-france.com)                 -->
-<!--                                                                     -->
-<!-- This Source Code Form is subject to the terms of the Mozilla Public -->
-<!-- License, v. 2.0. If a copy of the MPL was not distributed with this -->
-<!-- file, You can obtain one at http://mozilla.org/MPL/2.0/.            -->
+<!-- Copyright (c) 2018-2020, RTE (http://www.rte-france.com)              -->
+<!-- See AUTHORS.txt                                                       -->
+<!-- This Source Code Form is subject to the terms of the Mozilla Public   -->
+<!-- License, v. 2.0. If a copy of the MPL was not distributed with this   -->
+<!-- file, You can obtain one at http://mozilla.org/MPL/2.0/.              -->
+<!-- SPDX-License-Identifier: MPL-2.0                                      -->
+<!-- This file is part of the OperatorFabric project.                      -->
+
 
 
 <div class="card light-card-detail  rounded" [class.border-light]="open" (click)="select()">

--- a/ui/main/src/app/modules/cards/components/card/card.component.scss
+++ b/ui/main/src/app/modules/cards/components/card/card.component.scss
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 .light-card-detail {

--- a/ui/main/src/app/modules/cards/components/card/card.component.spec.ts
+++ b/ui/main/src/app/modules/cards/components/card/card.component.spec.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {async, ComponentFixture, getTestBed, TestBed} from '@angular/core/testing';

--- a/ui/main/src/app/modules/cards/components/card/card.component.ts
+++ b/ui/main/src/app/modules/cards/components/card/card.component.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {Component, Input, OnDestroy, OnInit} from '@angular/core';

--- a/ui/main/src/app/modules/cards/components/detail/detail.component.html
+++ b/ui/main/src/app/modules/cards/components/detail/detail.component.html
@@ -1,8 +1,11 @@
-<!-- Copyright (c) 2020, RTE (http://www.rte-france.com)                 -->
-<!--                                                                     -->
-<!-- This Source Code Form is subject to the terms of the Mozilla Public -->
-<!-- License, v. 2.0. If a copy of the MPL was not distributed with this -->
-<!-- file, You can obtain one at http://mozilla.org/MPL/2.0/.            -->
+<!-- Copyright (c) 2018-2020, RTE (http://www.rte-france.com)              -->
+<!-- See AUTHORS.txt                                                       -->
+<!-- This Source Code Form is subject to the terms of the Mozilla Public   -->
+<!-- License, v. 2.0. If a copy of the MPL was not distributed with this   -->
+<!-- file, You can obtain one at http://mozilla.org/MPL/2.0/.              -->
+<!-- SPDX-License-Identifier: MPL-2.0                                      -->
+<!-- This file is part of the OperatorFabric project.                      -->
+
 
 
 <link *ngFor="let cssUrl of hrefsOfCssLink" [href]="cssUrl" rel="stylesheet" type="text/css">

--- a/ui/main/src/app/modules/cards/components/detail/detail.component.spec.ts
+++ b/ui/main/src/app/modules/cards/components/detail/detail.component.spec.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {async, ComponentFixture, getTestBed, TestBed} from '@angular/core/testing';

--- a/ui/main/src/app/modules/cards/components/detail/detail.component.ts
+++ b/ui/main/src/app/modules/cards/components/detail/detail.component.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {Component, ElementRef, Input, OnInit, SimpleChanges, OnChanges} from '@angular/core';

--- a/ui/main/src/app/modules/cards/components/details/details.component.html
+++ b/ui/main/src/app/modules/cards/components/details/details.component.html
@@ -1,8 +1,11 @@
-<!-- Copyright (c) 2020, RTE (http://www.rte-france.com)                 -->
-<!--                                                                     -->
-<!-- This Source Code Form is subject to the terms of the Mozilla Public -->
-<!-- License, v. 2.0. If a copy of the MPL was not distributed with this -->
-<!-- file, You can obtain one at http://mozilla.org/MPL/2.0/.            -->
+<!-- Copyright (c) 2018-2020, RTE (http://www.rte-france.com)              -->
+<!-- See AUTHORS.txt                                                       -->
+<!-- This Source Code Form is subject to the terms of the Mozilla Public   -->
+<!-- License, v. 2.0. If a copy of the MPL was not distributed with this   -->
+<!-- file, You can obtain one at http://mozilla.org/MPL/2.0/.              -->
+<!-- SPDX-License-Identifier: MPL-2.0                                      -->
+<!-- This file is part of the OperatorFabric project.                      -->
+
 
 
 <div calcHeightDirective parentId="parentFeedContent" fixedHeightClass="fixed-height-details" calcHeightClass="calc-height-details">

--- a/ui/main/src/app/modules/cards/components/details/details.component.scss
+++ b/ui/main/src/app/modules/cards/components/details/details.component.scss
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 .calc-height-details {

--- a/ui/main/src/app/modules/cards/components/details/details.component.spec.ts
+++ b/ui/main/src/app/modules/cards/components/details/details.component.spec.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {async, ComponentFixture, TestBed} from '@angular/core/testing';

--- a/ui/main/src/app/modules/cards/components/details/details.component.ts
+++ b/ui/main/src/app/modules/cards/components/details/details.component.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {AfterViewInit, Component, ContentChildren, Input, OnChanges, QueryList, SimpleChanges} from '@angular/core';

--- a/ui/main/src/app/modules/cards/services/handlebars.service.spec.ts
+++ b/ui/main/src/app/modules/cards/services/handlebars.service.spec.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {getTestBed, TestBed} from '@angular/core/testing';

--- a/ui/main/src/app/modules/cards/services/handlebars.service.ts
+++ b/ui/main/src/app/modules/cards/services/handlebars.service.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {Injectable} from "@angular/core";

--- a/ui/main/src/app/modules/feed/components/card-list/card-list.component.html
+++ b/ui/main/src/app/modules/feed/components/card-list/card-list.component.html
@@ -1,8 +1,11 @@
-<!-- Copyright (c) 2020, RTE (http://www.rte-france.com)                 -->
-<!--                                                                     -->
-<!-- This Source Code Form is subject to the terms of the Mozilla Public -->
-<!-- License, v. 2.0. If a copy of the MPL was not distributed with this -->
-<!-- file, You can obtain one at http://mozilla.org/MPL/2.0/.            -->
+<!-- Copyright (c) 2018-2020, RTE (http://www.rte-france.com)              -->
+<!-- See AUTHORS.txt                                                       -->
+<!-- This Source Code Form is subject to the terms of the Mozilla Public   -->
+<!-- License, v. 2.0. If a copy of the MPL was not distributed with this   -->
+<!-- file, You can obtain one at http://mozilla.org/MPL/2.0/.              -->
+<!-- SPDX-License-Identifier: MPL-2.0                                      -->
+<!-- This file is part of the OperatorFabric project.                      -->
+
 
 
 <div class="container-fluid feed-content" calcHeightDirective parentId="parentFeedContent" fixedHeightClass="fixed-height-feed-content" calcHeightClass="calc-height-feed-content">

--- a/ui/main/src/app/modules/feed/components/card-list/card-list.component.scss
+++ b/ui/main/src/app/modules/feed/components/card-list/card-list.component.scss
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 .feed-content {

--- a/ui/main/src/app/modules/feed/components/card-list/card-list.component.spec.ts
+++ b/ui/main/src/app/modules/feed/components/card-list/card-list.component.spec.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {async, ComponentFixture, TestBed} from '@angular/core/testing';

--- a/ui/main/src/app/modules/feed/components/card-list/card-list.component.ts
+++ b/ui/main/src/app/modules/feed/components/card-list/card-list.component.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {Component, Input, OnInit} from '@angular/core';

--- a/ui/main/src/app/modules/feed/components/card-list/filters/filters.component.html
+++ b/ui/main/src/app/modules/feed/components/card-list/filters/filters.component.html
@@ -1,8 +1,11 @@
-<!-- Copyright (c) 2020, RTE (http://www.rte-france.com)                 -->
-<!--                                                                     -->
-<!-- This Source Code Form is subject to the terms of the Mozilla Public -->
-<!-- License, v. 2.0. If a copy of the MPL was not distributed with this -->
-<!-- file, You can obtain one at http://mozilla.org/MPL/2.0/.            -->
+<!-- Copyright (c) 2018-2020, RTE (http://www.rte-france.com)              -->
+<!-- See AUTHORS.txt                                                       -->
+<!-- This Source Code Form is subject to the terms of the Mozilla Public   -->
+<!-- License, v. 2.0. If a copy of the MPL was not distributed with this   -->
+<!-- file, You can obtain one at http://mozilla.org/MPL/2.0/.              -->
+<!-- SPDX-License-Identifier: MPL-2.0                                      -->
+<!-- This file is part of the OperatorFabric project.                      -->
+
 
 <div class="rounded opfab-feedbar-bgcolor">
     <div class="row nomarginrow" >

--- a/ui/main/src/app/modules/feed/components/card-list/filters/filters.component.scss
+++ b/ui/main/src/app/modules/feed/components/card-list/filters/filters.component.scss
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
  ::ng-deep .popover {

--- a/ui/main/src/app/modules/feed/components/card-list/filters/filters.component.spec.ts
+++ b/ui/main/src/app/modules/feed/components/card-list/filters/filters.component.spec.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {async, ComponentFixture, TestBed} from '@angular/core/testing';

--- a/ui/main/src/app/modules/feed/components/card-list/filters/filters.component.ts
+++ b/ui/main/src/app/modules/feed/components/card-list/filters/filters.component.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {Component, OnInit} from '@angular/core';

--- a/ui/main/src/app/modules/feed/components/card-list/filters/severity-sort/severity-sort.component.html
+++ b/ui/main/src/app/modules/feed/components/card-list/filters/severity-sort/severity-sort.component.html
@@ -1,8 +1,12 @@
-<!-- Copyright (c) 2020, RTE (http://www.rte-france.com)                 -->
-<!--                                                                     -->
-<!-- This Source Code Form is subject to the terms of the Mozilla Public -->
-<!-- License, v. 2.0. If a copy of the MPL was not distributed with this -->
-<!-- file, You can obtain one at http:F//mozilla.org/MPL/2.0/.            -->
+<!-- Copyright (c) 2018-2020, RTE (http://www.rte-france.com)              -->
+<!-- See AUTHORS.txt                                                       -->
+<!-- This Source Code Form is subject to the terms of the Mozilla Public   -->
+<!-- License, v. 2.0. If a copy of the MPL was not distributed with this   -->
+<!-- file, You can obtain one at http://mozilla.org/MPL/2.0/.              -->
+<!-- SPDX-License-Identifier: MPL-2.0                                      -->
+<!-- This file is part of the OperatorFabric project.                      -->
+
+
 
 <ng-template #sortLabel>
     <span *ngIf="toggleActive"translate>feed.sort.severityPub</span>

--- a/ui/main/src/app/modules/feed/components/card-list/filters/severity-sort/severity-sort.component.spec.ts
+++ b/ui/main/src/app/modules/feed/components/card-list/filters/severity-sort/severity-sort.component.spec.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 

--- a/ui/main/src/app/modules/feed/components/card-list/filters/severity-sort/severity-sort.component.ts
+++ b/ui/main/src/app/modules/feed/components/card-list/filters/severity-sort/severity-sort.component.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 import { Component, OnInit } from '@angular/core';
 import {Store} from "@ngrx/store";

--- a/ui/main/src/app/modules/feed/components/card-list/filters/tags-filter/tags-filter.component.html
+++ b/ui/main/src/app/modules/feed/components/card-list/filters/tags-filter/tags-filter.component.html
@@ -1,8 +1,11 @@
-<!-- Copyright (c) 2020, RTE (http://www.rte-france.com)                 -->
-<!--                                                                     -->
-<!-- This Source Code Form is subject to the terms of the Mozilla Public -->
-<!-- License, v. 2.0. If a copy of the MPL was not distributed with this -->
-<!-- file, You can obtain one at http://mozilla.org/MPL/2.0/.            -->
+<!-- Copyright (c) 2018-2020, RTE (http://www.rte-france.com)              -->
+<!-- See AUTHORS.txt                                                       -->
+<!-- This Source Code Form is subject to the terms of the Mozilla Public   -->
+<!-- License, v. 2.0. If a copy of the MPL was not distributed with this   -->
+<!-- file, You can obtain one at http://mozilla.org/MPL/2.0/.              -->
+<!-- SPDX-License-Identifier: MPL-2.0                                      -->
+<!-- This file is part of the OperatorFabric project.                      -->
+
 
 
 <form [formGroup]="tagFilterForm" id="time-filter-form">

--- a/ui/main/src/app/modules/feed/components/card-list/filters/tags-filter/tags-filter.component.scss
+++ b/ui/main/src/app/modules/feed/components/card-list/filters/tags-filter/tags-filter.component.scss
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 .tags-field {
   ::ng-deep .dropdown-toggle {

--- a/ui/main/src/app/modules/feed/components/card-list/filters/tags-filter/tags-filter.component.spec.ts
+++ b/ui/main/src/app/modules/feed/components/card-list/filters/tags-filter/tags-filter.component.spec.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {async, ComponentFixture, TestBed} from '@angular/core/testing';

--- a/ui/main/src/app/modules/feed/components/card-list/filters/tags-filter/tags-filter.component.ts
+++ b/ui/main/src/app/modules/feed/components/card-list/filters/tags-filter/tags-filter.component.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {Component, OnDestroy, OnInit} from '@angular/core';

--- a/ui/main/src/app/modules/feed/components/card-list/filters/time-filter/time-filter.component.html
+++ b/ui/main/src/app/modules/feed/components/card-list/filters/time-filter/time-filter.component.html
@@ -1,8 +1,11 @@
-<!-- Copyright (c) 2020, RTE (http://www.rte-france.com)                 -->
-<!--                                                                     -->
-<!-- This Source Code Form is subject to the terms of the Mozilla Public -->
-<!-- License, v. 2.0. If a copy of the MPL was not distributed with this -->
-<!-- file, You can obtain one at http://mozilla.org/MPL/2.0/.            -->
+<!-- Copyright (c) 2018-2020, RTE (http://www.rte-france.com)              -->
+<!-- See AUTHORS.txt                                                       -->
+<!-- This Source Code Form is subject to the terms of the Mozilla Public   -->
+<!-- License, v. 2.0. If a copy of the MPL was not distributed with this   -->
+<!-- file, You can obtain one at http://mozilla.org/MPL/2.0/.              -->
+<!-- SPDX-License-Identifier: MPL-2.0                                      -->
+<!-- This file is part of the OperatorFabric project.                      -->
+
 
 <ng-template #filterTimeContent>
 

--- a/ui/main/src/app/modules/feed/components/card-list/filters/time-filter/time-filter.component.spec.ts
+++ b/ui/main/src/app/modules/feed/components/card-list/filters/time-filter/time-filter.component.spec.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {async, ComponentFixture, TestBed ,flush , fakeAsync} from '@angular/core/testing';

--- a/ui/main/src/app/modules/feed/components/card-list/filters/time-filter/time-filter.component.ts
+++ b/ui/main/src/app/modules/feed/components/card-list/filters/time-filter/time-filter.component.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import { Component, OnDestroy, OnInit } from '@angular/core';

--- a/ui/main/src/app/modules/feed/components/card-list/filters/type-filter/type-filter.component.html
+++ b/ui/main/src/app/modules/feed/components/card-list/filters/type-filter/type-filter.component.html
@@ -1,8 +1,11 @@
-<!-- Copyright (c) 2020, RTE (http://www.rte-france.com)                 -->
-<!--                                                                     -->
-<!-- This Source Code Form is subject to the terms of the Mozilla Public -->
-<!-- License, v. 2.0. If a copy of the MPL was not distributed with this -->
-<!-- file, You can obtain one at http://mozilla.org/MPL/2.0/.            -->
+<!-- Copyright (c) 2018-2020, RTE (http://www.rte-france.com)              -->
+<!-- See AUTHORS.txt                                                       -->
+<!-- This Source Code Form is subject to the terms of the Mozilla Public   -->
+<!-- License, v. 2.0. If a copy of the MPL was not distributed with this   -->
+<!-- file, You can obtain one at http://mozilla.org/MPL/2.0/.              -->
+<!-- SPDX-License-Identifier: MPL-2.0                                      -->
+<!-- This file is part of the OperatorFabric project.                      -->
+
 
 
     <ng-template #filterTypeContent>

--- a/ui/main/src/app/modules/feed/components/card-list/filters/type-filter/type-filter.component.scss
+++ b/ui/main/src/app/modules/feed/components/card-list/filters/type-filter/type-filter.component.scss
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 @import "~assets/styles/_variables.scss";
 

--- a/ui/main/src/app/modules/feed/components/card-list/filters/type-filter/type-filter.component.spec.ts
+++ b/ui/main/src/app/modules/feed/components/card-list/filters/type-filter/type-filter.component.spec.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {async, ComponentFixture, TestBed} from '@angular/core/testing';

--- a/ui/main/src/app/modules/feed/components/card-list/filters/type-filter/type-filter.component.ts
+++ b/ui/main/src/app/modules/feed/components/card-list/filters/type-filter/type-filter.component.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {Component, OnDestroy, OnInit} from '@angular/core';

--- a/ui/main/src/app/modules/feed/components/time-line/custom-timeline-chart/custom-timeline-chart.component.html
+++ b/ui/main/src/app/modules/feed/components/time-line/custom-timeline-chart/custom-timeline-chart.component.html
@@ -1,8 +1,11 @@
-<!-- Copyright (c) 2020, RTE (http://www.rte-france.com)                 -->
-<!--                                                                     -->
-<!-- This Source Code Form is subject to the terms of the Mozilla Public -->
-<!-- License, v. 2.0. If a copy of the MPL was not distributed with this -->
-<!-- file, You can obtain one at http://mozilla.org/MPL/2.0/.            -->
+<!-- Copyright (c) 2018-2020, RTE (http://www.rte-france.com)              -->
+<!-- See AUTHORS.txt                                                       -->
+<!-- This Source Code Form is subject to the terms of the Mozilla Public   -->
+<!-- License, v. 2.0. If a copy of the MPL was not distributed with this   -->
+<!-- file, You can obtain one at http://mozilla.org/MPL/2.0/.              -->
+<!-- SPDX-License-Identifier: MPL-2.0                                      -->
+<!-- This file is part of the OperatorFabric project.                      -->
+
 
 <ngx-charts-chart
         [view]="[width, height]" xmlns:svg="http://www.w3.org/1999/svg"

--- a/ui/main/src/app/modules/feed/components/time-line/custom-timeline-chart/custom-timeline-chart.component.scss
+++ b/ui/main/src/app/modules/feed/components/time-line/custom-timeline-chart/custom-timeline-chart.component.scss
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
  
  
 .ngx-charts {

--- a/ui/main/src/app/modules/feed/components/time-line/custom-timeline-chart/custom-timeline-chart.component.spec.ts
+++ b/ui/main/src/app/modules/feed/components/time-line/custom-timeline-chart/custom-timeline-chart.component.spec.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 import {async, ComponentFixture, TestBed} from '@angular/core/testing';
 import {CustomTimelineChartComponent} from './custom-timeline-chart.component';

--- a/ui/main/src/app/modules/feed/components/time-line/custom-timeline-chart/custom-timeline-chart.component.ts
+++ b/ui/main/src/app/modules/feed/components/time-line/custom-timeline-chart/custom-timeline-chart.component.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 import {
   ChangeDetectorRef,

--- a/ui/main/src/app/modules/feed/components/time-line/directives/mouse-wheel.directive.ts
+++ b/ui/main/src/app/modules/feed/components/time-line/directives/mouse-wheel.directive.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 import {Directive, EventEmitter, HostListener, Output} from '@angular/core';
 

--- a/ui/main/src/app/modules/feed/components/time-line/init-chart/init-chart.component.html
+++ b/ui/main/src/app/modules/feed/components/time-line/init-chart/init-chart.component.html
@@ -1,8 +1,11 @@
-<!-- Copyright (c) 2020, RTE (http://www.rte-france.com)                 -->
-<!--                                                                     -->
-<!-- This Source Code Form is subject to the terms of the Mozilla Public -->
-<!-- License, v. 2.0. If a copy of the MPL was not distributed with this -->
-<!-- file, You can obtain one at http://mozilla.org/MPL/2.0/.            -->
+<!-- Copyright (c) 2018-2020, RTE (http://www.rte-france.com)              -->
+<!-- See AUTHORS.txt                                                       -->
+<!-- This Source Code Form is subject to the terms of the Mozilla Public   -->
+<!-- License, v. 2.0. If a copy of the MPL was not distributed with this   -->
+<!-- file, You can obtain one at http://mozilla.org/MPL/2.0/.              -->
+<!-- SPDX-License-Identifier: MPL-2.0                                      -->
+<!-- This file is part of the OperatorFabric project.                      -->
+
 
 <div class="timeline">
   <div class="menu-timeline">

--- a/ui/main/src/app/modules/feed/components/time-line/init-chart/init-chart.component.scss
+++ b/ui/main/src/app/modules/feed/components/time-line/init-chart/init-chart.component.scss
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 .timeline {

--- a/ui/main/src/app/modules/feed/components/time-line/init-chart/init-chart.component.spec.ts
+++ b/ui/main/src/app/modules/feed/components/time-line/init-chart/init-chart.component.spec.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 import {async, ComponentFixture, TestBed} from '@angular/core/testing';
 import {InitChartComponent} from './init-chart.component';

--- a/ui/main/src/app/modules/feed/components/time-line/init-chart/init-chart.component.ts
+++ b/ui/main/src/app/modules/feed/components/time-line/init-chart/init-chart.component.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 import { Component, Input, OnDestroy, OnInit } from '@angular/core';
 import * as _ from 'lodash';

--- a/ui/main/src/app/modules/feed/components/time-line/time-line.component.html
+++ b/ui/main/src/app/modules/feed/components/time-line/time-line.component.html
@@ -1,8 +1,11 @@
-<!-- Copyright (c) 2020, RTE (http://www.rte-france.com)                 -->
-<!--                                                                     -->
-<!-- This Source Code Form is subject to the terms of the Mozilla Public -->
-<!-- License, v. 2.0. If a copy of the MPL was not distributed with this -->
-<!-- file, You can obtain one at http://mozilla.org/MPL/2.0/.            -->
+<!-- Copyright (c) 2018-2020, RTE (http://www.rte-france.com)              -->
+<!-- See AUTHORS.txt                                                       -->
+<!-- This Source Code Form is subject to the terms of the Mozilla Public   -->
+<!-- License, v. 2.0. If a copy of the MPL was not distributed with this   -->
+<!-- file, You can obtain one at http://mozilla.org/MPL/2.0/.              -->
+<!-- SPDX-License-Identifier: MPL-2.0                                      -->
+<!-- This file is part of the OperatorFabric project.                      -->
+
 
 
 <div class="text-dark container-fluid opfab-timeline-bgcolor" style="height: 100%;">

--- a/ui/main/src/app/modules/feed/components/time-line/time-line.component.spec.ts
+++ b/ui/main/src/app/modules/feed/components/time-line/time-line.component.spec.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {async, ComponentFixture, TestBed} from '@angular/core/testing';

--- a/ui/main/src/app/modules/feed/components/time-line/time-line.component.ts
+++ b/ui/main/src/app/modules/feed/components/time-line/time-line.component.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import { Component, OnInit, OnDestroy } from '@angular/core';

--- a/ui/main/src/app/modules/feed/feed-routing.module.spec.ts
+++ b/ui/main/src/app/modules/feed/feed-routing.module.spec.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {FeedRoutingModule} from './feed-routing.module';

--- a/ui/main/src/app/modules/feed/feed-routing.module.ts
+++ b/ui/main/src/app/modules/feed/feed-routing.module.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {NgModule} from '@angular/core';

--- a/ui/main/src/app/modules/feed/feed.component.html
+++ b/ui/main/src/app/modules/feed/feed.component.html
@@ -1,8 +1,11 @@
-<!-- Copyright (c) 2020, RTE (http://www.rte-france.com)                 -->
-<!--                                                                     -->
-<!-- This Source Code Form is subject to the terms of the Mozilla Public -->
-<!-- License, v. 2.0. If a copy of the MPL was not distributed with this -->
-<!-- file, You can obtain one at http://mozilla.org/MPL/2.0/.            -->
+<!-- Copyright (c) 2018-2020, RTE (http://www.rte-france.com)              -->
+<!-- See AUTHORS.txt                                                       -->
+<!-- This Source Code Form is subject to the terms of the Mozilla Public   -->
+<!-- License, v. 2.0. If a copy of the MPL was not distributed with this   -->
+<!-- file, You can obtain one at http://mozilla.org/MPL/2.0/.              -->
+<!-- SPDX-License-Identifier: MPL-2.0                                      -->
+<!-- This file is part of the OperatorFabric project.                      -->
+
 
 
 <div class="container-fluid">

--- a/ui/main/src/app/modules/feed/feed.component.scss
+++ b/ui/main/src/app/modules/feed/feed.component.scss
@@ -1,8 +1,11 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 

--- a/ui/main/src/app/modules/feed/feed.component.spec.ts
+++ b/ui/main/src/app/modules/feed/feed.component.spec.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {async, ComponentFixture, TestBed} from '@angular/core/testing';

--- a/ui/main/src/app/modules/feed/feed.component.ts
+++ b/ui/main/src/app/modules/feed/feed.component.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {AfterViewInit, Component, OnInit} from '@angular/core';

--- a/ui/main/src/app/modules/feed/feed.module.spec.ts
+++ b/ui/main/src/app/modules/feed/feed.module.spec.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {FeedModule} from './feed.module';

--- a/ui/main/src/app/modules/feed/feed.module.ts
+++ b/ui/main/src/app/modules/feed/feed.module.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {NgModule} from '@angular/core';

--- a/ui/main/src/app/modules/settings/components/settings/base-setting/base-setting.component.html
+++ b/ui/main/src/app/modules/settings/components/settings/base-setting/base-setting.component.html
@@ -1,8 +1,11 @@
-<!-- Copyright (c) 2020, RTE (http://www.rte-france.com)                 -->
-<!--                                                                     -->
-<!-- This Source Code Form is subject to the terms of the Mozilla Public -->
-<!-- License, v. 2.0. If a copy of the MPL was not distributed with this -->
-<!-- file, You can obtain one at http://mozilla.org/MPL/2.0/.            -->
+<!-- Copyright (c) 2018-2020, RTE (http://www.rte-france.com)              -->
+<!-- See AUTHORS.txt                                                       -->
+<!-- This Source Code Form is subject to the terms of the Mozilla Public   -->
+<!-- License, v. 2.0. If a copy of the MPL was not distributed with this   -->
+<!-- file, You can obtain one at http://mozilla.org/MPL/2.0/.              -->
+<!-- SPDX-License-Identifier: MPL-2.0                                      -->
+<!-- This file is part of the OperatorFabric project.                      -->
+
 
 
 <p>

--- a/ui/main/src/app/modules/settings/components/settings/base-setting/base-setting.component.ts
+++ b/ui/main/src/app/modules/settings/components/settings/base-setting/base-setting.component.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {Component, Input, OnDestroy, OnInit} from '@angular/core';

--- a/ui/main/src/app/modules/settings/components/settings/checkbox-setting/checkbox-setting.component.html
+++ b/ui/main/src/app/modules/settings/components/settings/checkbox-setting/checkbox-setting.component.html
@@ -1,8 +1,11 @@
-<!-- Copyright (c) 2020, RTE (http://www.rte-france.com)                 -->
-<!--                                                                     -->
-<!-- This Source Code Form is subject to the terms of the Mozilla Public -->
-<!-- License, v. 2.0. If a copy of the MPL was not distributed with this -->
-<!-- file, You can obtain one at http://mozilla.org/MPL/2.0/.            -->
+<!-- Copyright (c) 2018-2020, RTE (http://www.rte-france.com)              -->
+<!-- See AUTHORS.txt                                                       -->
+<!-- This Source Code Form is subject to the terms of the Mozilla Public   -->
+<!-- License, v. 2.0. If a copy of the MPL was not distributed with this   -->
+<!-- file, You can obtain one at http://mozilla.org/MPL/2.0/.              -->
+<!-- SPDX-License-Identifier: MPL-2.0                                      -->
+<!-- This file is part of the OperatorFabric project.                      -->
+
 
 <form [formGroup]="form" class="form-check-inline" id="checkbox-setting-form">
     <div class="form-group" >

--- a/ui/main/src/app/modules/settings/components/settings/checkbox-setting/checkbox-setting.component.scss
+++ b/ui/main/src/app/modules/settings/components/settings/checkbox-setting/checkbox-setting.component.scss
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 label {
   padding-right: 10px;

--- a/ui/main/src/app/modules/settings/components/settings/checkbox-setting/checkbox-setting.component.spec.ts
+++ b/ui/main/src/app/modules/settings/components/settings/checkbox-setting/checkbox-setting.component.spec.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 

--- a/ui/main/src/app/modules/settings/components/settings/checkbox-setting/checkbox-setting.component.ts
+++ b/ui/main/src/app/modules/settings/components/settings/checkbox-setting/checkbox-setting.component.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 import {Component, OnDestroy, OnInit} from '@angular/core';
 import {BaseSettingComponent} from "../base-setting/base-setting.component";

--- a/ui/main/src/app/modules/settings/components/settings/email-setting/email-setting.component.html
+++ b/ui/main/src/app/modules/settings/components/settings/email-setting/email-setting.component.html
@@ -1,8 +1,11 @@
-<!-- Copyright (c) 2020, RTE (http://www.rte-france.com)                 -->
-<!--                                                                     -->
-<!-- This Source Code Form is subject to the terms of the Mozilla Public -->
-<!-- License, v. 2.0. If a copy of the MPL was not distributed with this -->
-<!-- file, You can obtain one at http://mozilla.org/MPL/2.0/.            -->
+<!-- Copyright (c) 2018-2020, RTE (http://www.rte-france.com)              -->
+<!-- See AUTHORS.txt                                                       -->
+<!-- This Source Code Form is subject to the terms of the Mozilla Public   -->
+<!-- License, v. 2.0. If a copy of the MPL was not distributed with this   -->
+<!-- file, You can obtain one at http://mozilla.org/MPL/2.0/.              -->
+<!-- SPDX-License-Identifier: MPL-2.0                                      -->
+<!-- This file is part of the OperatorFabric project.                      -->
+
 
 
 <form [formGroup]="form">

--- a/ui/main/src/app/modules/settings/components/settings/email-setting/email-setting.component.spec.ts
+++ b/ui/main/src/app/modules/settings/components/settings/email-setting/email-setting.component.spec.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {async, ComponentFixture, TestBed} from '@angular/core/testing';

--- a/ui/main/src/app/modules/settings/components/settings/email-setting/email-setting.component.ts
+++ b/ui/main/src/app/modules/settings/components/settings/email-setting/email-setting.component.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {Component, OnDestroy, OnInit, Input} from '@angular/core';

--- a/ui/main/src/app/modules/settings/components/settings/list-setting/list-setting.component.html
+++ b/ui/main/src/app/modules/settings/components/settings/list-setting/list-setting.component.html
@@ -1,8 +1,11 @@
-<!-- Copyright (c) 2020, RTE (http://www.rte-france.com)                 -->
-<!--                                                                     -->
-<!-- This Source Code Form is subject to the terms of the Mozilla Public -->
-<!-- License, v. 2.0. If a copy of the MPL was not distributed with this -->
-<!-- file, You can obtain one at http://mozilla.org/MPL/2.0/.            -->
+<!-- Copyright (c) 2018-2020, RTE (http://www.rte-france.com)              -->
+<!-- See AUTHORS.txt                                                       -->
+<!-- This Source Code Form is subject to the terms of the Mozilla Public   -->
+<!-- License, v. 2.0. If a copy of the MPL was not distributed with this   -->
+<!-- file, You can obtain one at http://mozilla.org/MPL/2.0/.              -->
+<!-- SPDX-License-Identifier: MPL-2.0                                      -->
+<!-- This file is part of the OperatorFabric project.                      -->
+
 
 
 <form [formGroup]="form">

--- a/ui/main/src/app/modules/settings/components/settings/list-setting/list-setting.component.spec.ts
+++ b/ui/main/src/app/modules/settings/components/settings/list-setting/list-setting.component.spec.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {async, ComponentFixture, TestBed} from '@angular/core/testing';

--- a/ui/main/src/app/modules/settings/components/settings/list-setting/list-setting.component.ts
+++ b/ui/main/src/app/modules/settings/components/settings/list-setting/list-setting.component.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {Component, Input, OnDestroy, OnInit} from '@angular/core';

--- a/ui/main/src/app/modules/settings/components/settings/multi-settings/multi-settings.component.html
+++ b/ui/main/src/app/modules/settings/components/settings/multi-settings/multi-settings.component.html
@@ -1,8 +1,11 @@
-<!-- Copyright (c) 2020, RTE (http://www.rte-france.com)                 -->
-<!--                                                                     -->
-<!-- This Source Code Form is subject to the terms of the Mozilla Public -->
-<!-- License, v. 2.0. If a copy of the MPL was not distributed with this -->
-<!-- file, You can obtain one at http://mozilla.org/MPL/2.0/.            -->
+<!-- Copyright (c) 2018-2020, RTE (http://www.rte-france.com)              -->
+<!-- See AUTHORS.txt                                                       -->
+<!-- This Source Code Form is subject to the terms of the Mozilla Public   -->
+<!-- License, v. 2.0. If a copy of the MPL was not distributed with this   -->
+<!-- file, You can obtain one at http://mozilla.org/MPL/2.0/.              -->
+<!-- SPDX-License-Identifier: MPL-2.0                                      -->
+<!-- This file is part of the OperatorFabric project.                      -->
+
 
 
 <p>

--- a/ui/main/src/app/modules/settings/components/settings/multi-settings/multi-settings.component.ts
+++ b/ui/main/src/app/modules/settings/components/settings/multi-settings/multi-settings.component.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {Component, OnDestroy, OnInit} from '@angular/core';

--- a/ui/main/src/app/modules/settings/components/settings/settings.component.html
+++ b/ui/main/src/app/modules/settings/components/settings/settings.component.html
@@ -1,8 +1,11 @@
-<!-- Copyright (c) 2020, RTE (http://www.rte-france.com)                 -->
-<!--                                                                     -->
-<!-- This Source Code Form is subject to the terms of the Mozilla Public -->
-<!-- License, v. 2.0. If a copy of the MPL was not distributed with this -->
-<!-- file, You can obtain one at http://mozilla.org/MPL/2.0/.            -->
+<!-- Copyright (c) 2018-2020, RTE (http://www.rte-france.com)              -->
+<!-- See AUTHORS.txt                                                       -->
+<!-- This Source Code Form is subject to the terms of the Mozilla Public   -->
+<!-- License, v. 2.0. If a copy of the MPL was not distributed with this   -->
+<!-- file, You can obtain one at http://mozilla.org/MPL/2.0/.              -->
+<!-- SPDX-License-Identifier: MPL-2.0                                      -->
+<!-- This file is part of the OperatorFabric project.                      -->
+
 
 
 <div class="container-fluid">

--- a/ui/main/src/app/modules/settings/components/settings/settings.component.spec.ts
+++ b/ui/main/src/app/modules/settings/components/settings/settings.component.spec.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {async, ComponentFixture, TestBed} from '@angular/core/testing';

--- a/ui/main/src/app/modules/settings/components/settings/settings.component.ts
+++ b/ui/main/src/app/modules/settings/components/settings/settings.component.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {Component, OnInit} from '@angular/core';

--- a/ui/main/src/app/modules/settings/components/settings/text-setting/text-setting.component.html
+++ b/ui/main/src/app/modules/settings/components/settings/text-setting/text-setting.component.html
@@ -1,8 +1,11 @@
-<!-- Copyright (c) 2020, RTE (http://www.rte-france.com)                 -->
-<!--                                                                     -->
-<!-- This Source Code Form is subject to the terms of the Mozilla Public -->
-<!-- License, v. 2.0. If a copy of the MPL was not distributed with this -->
-<!-- file, You can obtain one at http://mozilla.org/MPL/2.0/.            -->
+<!-- Copyright (c) 2018-2020, RTE (http://www.rte-france.com)              -->
+<!-- See AUTHORS.txt                                                       -->
+<!-- This Source Code Form is subject to the terms of the Mozilla Public   -->
+<!-- License, v. 2.0. If a copy of the MPL was not distributed with this   -->
+<!-- file, You can obtain one at http://mozilla.org/MPL/2.0/.              -->
+<!-- SPDX-License-Identifier: MPL-2.0                                      -->
+<!-- This file is part of the OperatorFabric project.                      -->
+
 
 
 <form [formGroup]="form">

--- a/ui/main/src/app/modules/settings/components/settings/text-setting/text-setting.component.spec.ts
+++ b/ui/main/src/app/modules/settings/components/settings/text-setting/text-setting.component.spec.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {async, ComponentFixture, TestBed} from '@angular/core/testing';

--- a/ui/main/src/app/modules/settings/components/settings/text-setting/text-setting.component.ts
+++ b/ui/main/src/app/modules/settings/components/settings/text-setting/text-setting.component.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {Component, Input, OnDestroy, OnInit} from '@angular/core';

--- a/ui/main/src/app/modules/settings/components/settings/type-ahead-settings/type-ahead-settings.component.html
+++ b/ui/main/src/app/modules/settings/components/settings/type-ahead-settings/type-ahead-settings.component.html
@@ -1,8 +1,11 @@
-<!-- Copyright (c) 2020, RTE (http://www.rte-france.com)                 -->
-<!--                                                                     -->
-<!-- This Source Code Form is subject to the terms of the Mozilla Public -->
-<!-- License, v. 2.0. If a copy of the MPL was not distributed with this -->
-<!-- file, You can obtain one at http://mozilla.org/MPL/2.0/.            -->
+<!-- Copyright (c) 2018-2020, RTE (http://www.rte-france.com)              -->
+<!-- See AUTHORS.txt                                                       -->
+<!-- This Source Code Form is subject to the terms of the Mozilla Public   -->
+<!-- License, v. 2.0. If a copy of the MPL was not distributed with this   -->
+<!-- file, You can obtain one at http://mozilla.org/MPL/2.0/.              -->
+<!-- SPDX-License-Identifier: MPL-2.0                                      -->
+<!-- This file is part of the OperatorFabric project.                      -->
+
 
 
 <form [formGroup]="form" id="time-filter-form">

--- a/ui/main/src/app/modules/settings/components/settings/type-ahead-settings/type-ahead-settings.component.scss
+++ b/ui/main/src/app/modules/settings/components/settings/type-ahead-settings/type-ahead-settings.component.scss
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 .tags-field {
     ::ng-deep .dropdown-toggle {

--- a/ui/main/src/app/modules/settings/components/settings/type-ahead-settings/type-ahead-settings.component.spec.ts
+++ b/ui/main/src/app/modules/settings/components/settings/type-ahead-settings/type-ahead-settings.component.spec.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {async, ComponentFixture, TestBed} from '@angular/core/testing';

--- a/ui/main/src/app/modules/settings/components/settings/type-ahead-settings/type-ahead-settings.component.ts
+++ b/ui/main/src/app/modules/settings/components/settings/type-ahead-settings/type-ahead-settings.component.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {Component, OnDestroy, OnInit} from '@angular/core';

--- a/ui/main/src/app/modules/settings/settings-routing.module.ts
+++ b/ui/main/src/app/modules/settings/settings-routing.module.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {NgModule} from '@angular/core';

--- a/ui/main/src/app/modules/settings/settings.module.ts
+++ b/ui/main/src/app/modules/settings/settings.module.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {NgModule} from '@angular/core';

--- a/ui/main/src/app/modules/thirdparty/iframedisplay.component.html
+++ b/ui/main/src/app/modules/thirdparty/iframedisplay.component.html
@@ -1,8 +1,11 @@
-<!-- Copyright (c) 2020, RTE (http://www.rte-france.com)                 -->
-<!--                                                                     -->
-<!-- This Source Code Form is subject to the terms of the Mozilla Public -->
-<!-- License, v. 2.0. If a copy of the MPL was not distributed with this -->
-<!-- file, You can obtain one at http://mozilla.org/MPL/2.0/.            -->
+<!-- Copyright (c) 2018-2020, RTE (http://www.rte-france.com)              -->
+<!-- See AUTHORS.txt                                                       -->
+<!-- This Source Code Form is subject to the terms of the Mozilla Public   -->
+<!-- License, v. 2.0. If a copy of the MPL was not distributed with this   -->
+<!-- file, You can obtain one at http://mozilla.org/MPL/2.0/.              -->
+<!-- SPDX-License-Identifier: MPL-2.0                                      -->
+<!-- This file is part of the OperatorFabric project.                      -->
+
 
 
 <div class="fill-available">

--- a/ui/main/src/app/modules/thirdparty/iframedisplay.component.scss
+++ b/ui/main/src/app/modules/thirdparty/iframedisplay.component.scss
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
  .fill-available {

--- a/ui/main/src/app/modules/thirdparty/iframedisplay.component.ts
+++ b/ui/main/src/app/modules/thirdparty/iframedisplay.component.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {Component, OnInit} from '@angular/core';

--- a/ui/main/src/app/modules/thirdparty/thirdparty-routing.module.ts
+++ b/ui/main/src/app/modules/thirdparty/thirdparty-routing.module.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {NgModule} from '@angular/core';

--- a/ui/main/src/app/modules/thirdparty/thirdparty.module.ts
+++ b/ui/main/src/app/modules/thirdparty/thirdparty.module.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {NgModule} from '@angular/core';

--- a/ui/main/src/app/modules/utilities/calc-height.directive.spec.ts
+++ b/ui/main/src/app/modules/utilities/calc-height.directive.spec.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {CalcHeightDirective} from "./calc-height.directive";

--- a/ui/main/src/app/modules/utilities/calc-height.directive.ts
+++ b/ui/main/src/app/modules/utilities/calc-height.directive.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {

--- a/ui/main/src/app/modules/utilities/components/resizable/resizable.component.css
+++ b/ui/main/src/app/modules/utilities/components/resizable/resizable.component.css
@@ -1,7 +1,10 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 

--- a/ui/main/src/app/modules/utilities/components/resizable/resizable.component.html
+++ b/ui/main/src/app/modules/utilities/components/resizable/resizable.component.html
@@ -1,8 +1,11 @@
-<!-- Copyright (c) 2020, RTE (http://www.rte-france.com)                 -->
-<!--                                                                     -->
-<!-- This Source Code Form is subject to the terms of the Mozilla Public -->
-<!-- License, v. 2.0. If a copy of the MPL was not distributed with this -->
-<!-- file, You can obtain one at http://mozilla.org/MPL/2.0/.            -->
+<!-- Copyright (c) 2018-2020, RTE (http://www.rte-france.com)              -->
+<!-- See AUTHORS.txt                                                       -->
+<!-- This Source Code Form is subject to the terms of the Mozilla Public   -->
+<!-- License, v. 2.0. If a copy of the MPL was not distributed with this   -->
+<!-- file, You can obtain one at http://mozilla.org/MPL/2.0/.              -->
+<!-- SPDX-License-Identifier: MPL-2.0                                      -->
+<!-- This file is part of the OperatorFabric project.                      -->
+
 
 <p>
   resizable works!

--- a/ui/main/src/app/modules/utilities/components/resizable/resizable.component.spec.ts
+++ b/ui/main/src/app/modules/utilities/components/resizable/resizable.component.spec.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 

--- a/ui/main/src/app/modules/utilities/components/resizable/resizable.component.ts
+++ b/ui/main/src/app/modules/utilities/components/resizable/resizable.component.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 import { Component, AfterViewInit, HostListener } from '@angular/core';
 

--- a/ui/main/src/app/modules/utilities/fontawesome-icons.module.ts
+++ b/ui/main/src/app/modules/utilities/fontawesome-icons.module.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 import { NgModule } from '@angular/core';
 import { FaIconLibrary, FontAwesomeModule } from '@fortawesome/angular-fontawesome';

--- a/ui/main/src/app/modules/utilities/utilities.module.ts
+++ b/ui/main/src/app/modules/utilities/utilities.module.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import { NgModule } from '@angular/core';

--- a/ui/main/src/app/services/authentication/auth-implicit-flow.config.ts
+++ b/ui/main/src/app/services/authentication/auth-implicit-flow.config.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 import {AuthConfig} from 'angular-oauth2-oidc';
 import {environment} from '@env/environment';

--- a/ui/main/src/app/services/authentication/authentication.service.ts
+++ b/ui/main/src/app/services/authentication/authentication.service.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {Injectable} from '@angular/core';

--- a/ui/main/src/app/services/card.service.spec.ts
+++ b/ui/main/src/app/services/card.service.spec.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 import {inject, TestBed} from '@angular/core/testing';
 

--- a/ui/main/src/app/services/card.service.ts
+++ b/ui/main/src/app/services/card.service.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {Injectable} from '@angular/core';

--- a/ui/main/src/app/services/config.service.spec.ts
+++ b/ui/main/src/app/services/config.service.spec.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {getTestBed, TestBed} from '@angular/core/testing';

--- a/ui/main/src/app/services/config.service.ts
+++ b/ui/main/src/app/services/config.service.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {Injectable} from '@angular/core';

--- a/ui/main/src/app/services/filter.service.spec.ts
+++ b/ui/main/src/app/services/filter.service.spec.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {TestBed} from '@angular/core/testing';

--- a/ui/main/src/app/services/filter.service.ts
+++ b/ui/main/src/app/services/filter.service.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {Injectable} from '@angular/core';

--- a/ui/main/src/app/services/global-style.service.ts
+++ b/ui/main/src/app/services/global-style.service.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {Inject} from "@angular/core";

--- a/ui/main/src/app/services/guid.service.ts
+++ b/ui/main/src/app/services/guid.service.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {Inject} from "@angular/core";

--- a/ui/main/src/app/services/i18n.service.spec.ts
+++ b/ui/main/src/app/services/i18n.service.spec.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {getTestBed, TestBed} from '@angular/core/testing';

--- a/ui/main/src/app/services/i18n.service.ts
+++ b/ui/main/src/app/services/i18n.service.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {Injectable} from '@angular/core';

--- a/ui/main/src/app/services/interceptors.service.spec.ts
+++ b/ui/main/src/app/services/interceptors.service.spec.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {inject, TestBed} from '@angular/core/testing';

--- a/ui/main/src/app/services/interceptors.service.ts
+++ b/ui/main/src/app/services/interceptors.service.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {Injectable} from '@angular/core';

--- a/ui/main/src/app/services/notify.service.spec.ts
+++ b/ui/main/src/app/services/notify.service.spec.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 import { NotifyService } from './notify.service';
 import { TestBed } from '@angular/core/testing';

--- a/ui/main/src/app/services/notify.service.ts
+++ b/ui/main/src/app/services/notify.service.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {Injectable} from '@angular/core';

--- a/ui/main/src/app/services/services.module.ts
+++ b/ui/main/src/app/services/services.module.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {ModuleWithProviders, NgModule, Optional, SkipSelf} from '@angular/core';

--- a/ui/main/src/app/services/settings.service.spec.ts
+++ b/ui/main/src/app/services/settings.service.spec.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {getTestBed, TestBed} from '@angular/core/testing';

--- a/ui/main/src/app/services/settings.service.ts
+++ b/ui/main/src/app/services/settings.service.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {Injectable} from '@angular/core';

--- a/ui/main/src/app/services/sound-notification.service.spec.ts
+++ b/ui/main/src/app/services/sound-notification.service.spec.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 import { TestBed } from '@angular/core/testing';
 

--- a/ui/main/src/app/services/sound-notification.service.ts
+++ b/ui/main/src/app/services/sound-notification.service.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {Injectable} from '@angular/core';

--- a/ui/main/src/app/services/third-action.service.spec.ts
+++ b/ui/main/src/app/services/third-action.service.spec.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 import {async, getTestBed, TestBed,} from "@angular/core/testing";
 import {Store} from "@ngrx/store";

--- a/ui/main/src/app/services/third-action.service.ts
+++ b/ui/main/src/app/services/third-action.service.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 /* Copyright (c) 2018, RTE (http://www.rte-france.com)
 *

--- a/ui/main/src/app/services/thirds.service.spec.ts
+++ b/ui/main/src/app/services/thirds.service.spec.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {getTestBed, TestBed} from '@angular/core/testing';

--- a/ui/main/src/app/services/thirds.service.ts
+++ b/ui/main/src/app/services/thirds.service.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {Injectable} from '@angular/core';

--- a/ui/main/src/app/services/time.service.spec.ts
+++ b/ui/main/src/app/services/time.service.spec.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {TestBed} from '@angular/core/testing';

--- a/ui/main/src/app/services/time.service.ts
+++ b/ui/main/src/app/services/time.service.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {Injectable} from '@angular/core';

--- a/ui/main/src/app/services/user.service.ts
+++ b/ui/main/src/app/services/user.service.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 import { Injectable } from "@angular/core";
 import { environment } from '@env/environment';

--- a/ui/main/src/app/store/actions/archive.actions.ts
+++ b/ui/main/src/app/store/actions/archive.actions.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {Action} from '@ngrx/store';

--- a/ui/main/src/app/store/actions/authentication.actions.ts
+++ b/ui/main/src/app/store/actions/authentication.actions.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {Action} from '@ngrx/store';

--- a/ui/main/src/app/store/actions/card.actions.ts
+++ b/ui/main/src/app/store/actions/card.actions.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {Action} from '@ngrx/store';

--- a/ui/main/src/app/store/actions/config.actions.ts
+++ b/ui/main/src/app/store/actions/config.actions.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {Action} from '@ngrx/store';

--- a/ui/main/src/app/store/actions/feed.actions.ts
+++ b/ui/main/src/app/store/actions/feed.actions.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {Action} from '@ngrx/store';

--- a/ui/main/src/app/store/actions/light-card.actions.ts
+++ b/ui/main/src/app/store/actions/light-card.actions.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {Action} from '@ngrx/store';

--- a/ui/main/src/app/store/actions/menu.actions.ts
+++ b/ui/main/src/app/store/actions/menu.actions.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {Action} from '@ngrx/store';

--- a/ui/main/src/app/store/actions/settings.actions.ts
+++ b/ui/main/src/app/store/actions/settings.actions.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {Action} from '@ngrx/store';

--- a/ui/main/src/app/store/actions/timeline.actions.ts
+++ b/ui/main/src/app/store/actions/timeline.actions.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {Action} from '@ngrx/store';

--- a/ui/main/src/app/store/actions/translate.actions.ts
+++ b/ui/main/src/app/store/actions/translate.actions.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 import {Action} from "@ngrx/store";
 import {Map} from "@ofModel/map";

--- a/ui/main/src/app/store/actions/user.actions.ts
+++ b/ui/main/src/app/store/actions/user.actions.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 import {User} from '@ofModel/user.model';
 import {Action} from '@ngrx/store';

--- a/ui/main/src/app/store/effects/archive.effects.spec.ts
+++ b/ui/main/src/app/store/effects/archive.effects.spec.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {getSeveralRandomLightCards} from '@tests/helpers';

--- a/ui/main/src/app/store/effects/archive.effects.ts
+++ b/ui/main/src/app/store/effects/archive.effects.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {Injectable} from '@angular/core';

--- a/ui/main/src/app/store/effects/authentication.effects.spec.ts
+++ b/ui/main/src/app/store/effects/authentication.effects.spec.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 import {
     AcceptLogOut,

--- a/ui/main/src/app/store/effects/authentication.effects.ts
+++ b/ui/main/src/app/store/effects/authentication.effects.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {Injectable} from '@angular/core';

--- a/ui/main/src/app/store/effects/card-operation.effects.spec.ts
+++ b/ui/main/src/app/store/effects/card-operation.effects.spec.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 import {Actions} from '@ngrx/effects';
 import {hot} from 'jasmine-marbles';

--- a/ui/main/src/app/store/effects/card-operation.effects.ts
+++ b/ui/main/src/app/store/effects/card-operation.effects.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {Injectable} from '@angular/core';

--- a/ui/main/src/app/store/effects/card.effects.spec.ts
+++ b/ui/main/src/app/store/effects/card.effects.spec.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {CardEffects} from './card.effects';

--- a/ui/main/src/app/store/effects/card.effects.ts
+++ b/ui/main/src/app/store/effects/card.effects.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 /* Copyright (c) 2018, RTE (http://www.rte-france.com)
 *

--- a/ui/main/src/app/store/effects/config.effects.spec.ts
+++ b/ui/main/src/app/store/effects/config.effects.spec.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {ConfigEffects} from './config.effects';

--- a/ui/main/src/app/store/effects/config.effects.ts
+++ b/ui/main/src/app/store/effects/config.effects.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {Inject, Injectable} from '@angular/core';

--- a/ui/main/src/app/store/effects/custom-router.effects.spec.ts
+++ b/ui/main/src/app/store/effects/custom-router.effects.spec.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {Actions} from '@ngrx/effects';

--- a/ui/main/src/app/store/effects/custom-router.effects.ts
+++ b/ui/main/src/app/store/effects/custom-router.effects.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {Injectable} from "@angular/core";

--- a/ui/main/src/app/store/effects/feed-filters.effects.spec.ts
+++ b/ui/main/src/app/store/effects/feed-filters.effects.spec.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {Actions} from '@ngrx/effects';

--- a/ui/main/src/app/store/effects/feed-filters.effects.ts
+++ b/ui/main/src/app/store/effects/feed-filters.effects.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {Injectable} from '@angular/core';

--- a/ui/main/src/app/store/effects/light-card.effects.ts
+++ b/ui/main/src/app/store/effects/light-card.effects.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {Injectable} from '@angular/core';

--- a/ui/main/src/app/store/effects/menu.effects.spec.ts
+++ b/ui/main/src/app/store/effects/menu.effects.spec.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {MenuEffects} from './menu.effects';

--- a/ui/main/src/app/store/effects/menu.effects.ts
+++ b/ui/main/src/app/store/effects/menu.effects.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {Injectable} from '@angular/core';

--- a/ui/main/src/app/store/effects/settings.effects.spec.ts
+++ b/ui/main/src/app/store/effects/settings.effects.spec.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {SettingsEffects} from './settings.effects';

--- a/ui/main/src/app/store/effects/settings.effects.ts
+++ b/ui/main/src/app/store/effects/settings.effects.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {Injectable} from '@angular/core';

--- a/ui/main/src/app/store/effects/translate.effects.spec.ts
+++ b/ui/main/src/app/store/effects/translate.effects.spec.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 import {
     generateRandomArray,

--- a/ui/main/src/app/store/effects/translate.effects.ts
+++ b/ui/main/src/app/store/effects/translate.effects.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 import {Injectable} from "@angular/core";
 import {Store} from "@ngrx/store";

--- a/ui/main/src/app/store/effects/user.effects.spec.ts
+++ b/ui/main/src/app/store/effects/user.effects.spec.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
  
 /* Copyright (c) 2018, RTE (http://www.rte-france.com)

--- a/ui/main/src/app/store/effects/user.effects.ts
+++ b/ui/main/src/app/store/effects/user.effects.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 import {Injectable} from '@angular/core';
 import {Store} from '@ngrx/store';

--- a/ui/main/src/app/store/index.ts
+++ b/ui/main/src/app/store/index.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import * as fromRouter from '@ngrx/router-store';

--- a/ui/main/src/app/store/reducers/archive.reducer.spec.ts
+++ b/ui/main/src/app/store/reducers/archive.reducer.spec.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 import { reducer} from './archive.reducer';
 import { UpdateArchiveFilter } from '@ofStore/actions/archive.actions';

--- a/ui/main/src/app/store/reducers/archive.reducer.ts
+++ b/ui/main/src/app/store/reducers/archive.reducer.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import { archiveInitialState, ArchiveState } from '@ofStates/archive.state';

--- a/ui/main/src/app/store/reducers/authentication.reducer.spec.ts
+++ b/ui/main/src/app/store/reducers/authentication.reducer.spec.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {getExpirationTime, reducer} from './authentication.reducer';

--- a/ui/main/src/app/store/reducers/authentication.reducer.ts
+++ b/ui/main/src/app/store/reducers/authentication.reducer.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {AuthenticationActions, AuthenticationActionTypes} from '@ofActions/authentication.actions';

--- a/ui/main/src/app/store/reducers/card.reducer.spec.ts
+++ b/ui/main/src/app/store/reducers/card.reducer.spec.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {reducer} from '@ofStore/reducers/card.reducer';

--- a/ui/main/src/app/store/reducers/card.reducer.ts
+++ b/ui/main/src/app/store/reducers/card.reducer.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {CardFeedState} from '@ofStates/feed.state';

--- a/ui/main/src/app/store/reducers/config.reducer.spec.ts
+++ b/ui/main/src/app/store/reducers/config.reducer.spec.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {reducer} from "@ofStore/reducers/config.reducer";

--- a/ui/main/src/app/store/reducers/config.reducer.ts
+++ b/ui/main/src/app/store/reducers/config.reducer.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {configInitialState, ConfigState} from "@ofStates/config.state";

--- a/ui/main/src/app/store/reducers/light-card.reducer.spec.ts
+++ b/ui/main/src/app/store/reducers/light-card.reducer.spec.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {reducer} from './light-card.reducer';

--- a/ui/main/src/app/store/reducers/light-card.reducer.ts
+++ b/ui/main/src/app/store/reducers/light-card.reducer.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {LightCardActions, LightCardActionTypes} from '@ofActions/light-card.actions';

--- a/ui/main/src/app/store/reducers/menu.reducer.spec.ts
+++ b/ui/main/src/app/store/reducers/menu.reducer.spec.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {reducer} from "@ofStore/reducers/menu.reducer";

--- a/ui/main/src/app/store/reducers/menu.reducer.ts
+++ b/ui/main/src/app/store/reducers/menu.reducer.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {CardFeedState} from '@ofStates/feed.state';

--- a/ui/main/src/app/store/reducers/settings.reducer.spec.ts
+++ b/ui/main/src/app/store/reducers/settings.reducer.spec.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {reducer} from "@ofStore/reducers/settings.reducer";

--- a/ui/main/src/app/store/reducers/settings.reducer.ts
+++ b/ui/main/src/app/store/reducers/settings.reducer.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {settingsInitialState, SettingsState} from "@ofStates/settings.state";

--- a/ui/main/src/app/store/reducers/timeline.reducer.ts
+++ b/ui/main/src/app/store/reducers/timeline.reducer.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {LightCardActions} from '@ofActions/light-card.actions';

--- a/ui/main/src/app/store/reducers/user.reducer.spec.ts
+++ b/ui/main/src/app/store/reducers/user.reducer.spec.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 import { reducer } from "./user.reducer";
 import { userInitialState } from '@ofStore/states/user.state';

--- a/ui/main/src/app/store/reducers/user.reducer.ts
+++ b/ui/main/src/app/store/reducers/user.reducer.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 import { userInitialState, UserState } from '@ofStore/states/user.state';
 import * as userActions from '@ofStore/actions/user.actions';

--- a/ui/main/src/app/store/selectors/archive.selectors.spec.ts
+++ b/ui/main/src/app/store/selectors/archive.selectors.spec.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {AppState} from '@ofStore/index';

--- a/ui/main/src/app/store/selectors/archive.selectors.ts
+++ b/ui/main/src/app/store/selectors/archive.selectors.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {AppState} from '@ofStore/index';

--- a/ui/main/src/app/store/selectors/authentication.selectors.spec.ts
+++ b/ui/main/src/app/store/selectors/authentication.selectors.spec.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {AppState} from "@ofStore/index";

--- a/ui/main/src/app/store/selectors/authentication.selectors.ts
+++ b/ui/main/src/app/store/selectors/authentication.selectors.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {createFeatureSelector, createSelector} from '@ngrx/store';

--- a/ui/main/src/app/store/selectors/card.selectors.spec.ts
+++ b/ui/main/src/app/store/selectors/card.selectors.spec.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {AppState} from '@ofStore/index';

--- a/ui/main/src/app/store/selectors/card.selectors.ts
+++ b/ui/main/src/app/store/selectors/card.selectors.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {AppState} from '@ofStore/index';

--- a/ui/main/src/app/store/selectors/config.selectors.spec.ts
+++ b/ui/main/src/app/store/selectors/config.selectors.spec.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {AppState} from "@ofStore/index";

--- a/ui/main/src/app/store/selectors/config.selectors.ts
+++ b/ui/main/src/app/store/selectors/config.selectors.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {AppState} from "@ofStore/index";

--- a/ui/main/src/app/store/selectors/feed.selectors.spec.ts
+++ b/ui/main/src/app/store/selectors/feed.selectors.spec.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {AppState} from '@ofStore/index';

--- a/ui/main/src/app/store/selectors/feed.selectors.ts
+++ b/ui/main/src/app/store/selectors/feed.selectors.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {createSelector} from '@ngrx/store';

--- a/ui/main/src/app/store/selectors/menu.selectors.ts
+++ b/ui/main/src/app/store/selectors/menu.selectors.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {AppState} from "@ofStore/index";

--- a/ui/main/src/app/store/selectors/router.selectors.ts
+++ b/ui/main/src/app/store/selectors/router.selectors.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {createFeatureSelector, createSelector} from '@ngrx/store';

--- a/ui/main/src/app/store/selectors/settings.selectors.spec.ts
+++ b/ui/main/src/app/store/selectors/settings.selectors.spec.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {AppState} from "@ofStore/index";

--- a/ui/main/src/app/store/selectors/settings.selectors.ts
+++ b/ui/main/src/app/store/selectors/settings.selectors.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {AppState} from "@ofStore/index";

--- a/ui/main/src/app/store/selectors/settings.x.config.selectors.spec.ts
+++ b/ui/main/src/app/store/selectors/settings.x.config.selectors.spec.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {AppState} from "@ofStore/index";

--- a/ui/main/src/app/store/selectors/settings.x.config.selectors.ts
+++ b/ui/main/src/app/store/selectors/settings.x.config.selectors.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {AppState} from "@ofStore/index";

--- a/ui/main/src/app/store/selectors/timeline.selectors.ts
+++ b/ui/main/src/app/store/selectors/timeline.selectors.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {createSelector} from '@ngrx/store';

--- a/ui/main/src/app/store/state.module.spec.ts
+++ b/ui/main/src/app/store/state.module.spec.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {StateModule} from './state.module';

--- a/ui/main/src/app/store/state.module.ts
+++ b/ui/main/src/app/store/state.module.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {ModuleWithProviders, NgModule} from '@angular/core';

--- a/ui/main/src/app/store/states/archive.state.ts
+++ b/ui/main/src/app/store/states/archive.state.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {LightCard} from '@ofModel/light-card.model';

--- a/ui/main/src/app/store/states/authentication.state.ts
+++ b/ui/main/src/app/store/states/authentication.state.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {Guid} from 'guid-typescript';

--- a/ui/main/src/app/store/states/card.state.ts
+++ b/ui/main/src/app/store/states/card.state.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {Card} from '@ofModel/card.model';

--- a/ui/main/src/app/store/states/config.state.ts
+++ b/ui/main/src/app/store/states/config.state.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 export const CONFIG_LOAD_MAX_RETRIES = 5;

--- a/ui/main/src/app/store/states/feed.state.spec.ts
+++ b/ui/main/src/app/store/states/feed.state.spec.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {Severity} from "@ofModel/light-card.model";

--- a/ui/main/src/app/store/states/feed.state.ts
+++ b/ui/main/src/app/store/states/feed.state.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {createEntityAdapter, EntityAdapter, EntityState} from '@ngrx/entity';

--- a/ui/main/src/app/store/states/menu.state.ts
+++ b/ui/main/src/app/store/states/menu.state.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {ThirdMenu} from "@ofModel/thirds.model";

--- a/ui/main/src/app/store/states/router.state.ts
+++ b/ui/main/src/app/store/states/router.state.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 

--- a/ui/main/src/app/store/states/settings.state.ts
+++ b/ui/main/src/app/store/states/settings.state.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 export interface SettingsState{

--- a/ui/main/src/app/store/states/timeline.state.ts
+++ b/ui/main/src/app/store/states/timeline.state.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {EntityState} from '@ngrx/entity';

--- a/ui/main/src/app/store/states/user.state.ts
+++ b/ui/main/src/app/store/states/user.state.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 export interface UserState {

--- a/ui/main/src/assets/sounds/attribution.adoc
+++ b/ui/main/src/assets/sounds/attribution.adoc
@@ -1,3 +1,10 @@
+// Copyright (c) 2018-2020 RTE (http://www.rte-france.com)
+// See AUTHORS.txt
+// This document is subject to the terms of the Creative Commons Attribution 4.0 International license.
+// If a copy of the license was not distributed with this
+// file, You can obtain one at https://creativecommons.org/licenses/by/4.0/.
+// SPDX-License-Identifier: CC-BY-4.0
+
 = Attribution for Sound Assets
 
 The sound assets from this directory are licensed under the Creative Commons CC0 1.0 Universal license

--- a/ui/main/src/assets/styles/_variables.scss
+++ b/ui/main/src/assets/styles/_variables.scss
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 @import '../../../node_modules/bootstrap/scss/bootstrap';

--- a/ui/main/src/assets/styles/navbar.scss
+++ b/ui/main/src/assets/styles/navbar.scss
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 @each $color, $value in $theme-colors {

--- a/ui/main/src/assets/styles/popover.scss
+++ b/ui/main/src/assets/styles/popover.scss
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 @import "variables";

--- a/ui/main/src/assets/styles/style.css
+++ b/ui/main/src/assets/styles/style.css
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 @font-face {
     font-family: 'Material Icons';

--- a/ui/main/src/assets/styles/styles.scss
+++ b/ui/main/src/assets/styles/styles.scss
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 /* You can add global styles to this file, and also import other style files */

--- a/ui/main/src/assets/styles/utilities.scss
+++ b/ui/main/src/assets/styles/utilities.scss
@@ -1,9 +1,12 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
  */
+
 
 
 @import "variables";

--- a/ui/main/src/environments/environment.prod.ts
+++ b/ui/main/src/environments/environment.prod.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 export const environment = {

--- a/ui/main/src/environments/environment.ts
+++ b/ui/main/src/environments/environment.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 // This file can be replaced during build by using the `fileReplacements` array.

--- a/ui/main/src/environments/environment.vps.ts
+++ b/ui/main/src/environments/environment.vps.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 // This file can be replaced during build by using the `fileReplacements` array.

--- a/ui/main/src/index.html
+++ b/ui/main/src/index.html
@@ -1,8 +1,11 @@
-<!-- Copyright (c) 2020, RTE (http://www.rte-france.com)                 -->
-<!--                                                                     -->
-<!-- This Source Code Form is subject to the terms of the Mozilla Public -->
-<!-- License, v. 2.0. If a copy of the MPL was not distributed with this -->
-<!-- file, You can obtain one at http://mozilla.org/MPL/2.0/.            -->
+<!-- Copyright (c) 2018-2020, RTE (http://www.rte-france.com)              -->
+<!-- See AUTHORS.txt                                                       -->
+<!-- This Source Code Form is subject to the terms of the Mozilla Public   -->
+<!-- License, v. 2.0. If a copy of the MPL was not distributed with this   -->
+<!-- file, You can obtain one at http://mozilla.org/MPL/2.0/.              -->
+<!-- SPDX-License-Identifier: MPL-2.0                                      -->
+<!-- This file is part of the OperatorFabric project.                      -->
+
 
 
 <!doctype html>

--- a/ui/main/src/main.ts
+++ b/ui/main/src/main.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {enableProdMode} from '@angular/core';

--- a/ui/main/src/polyfills.ts
+++ b/ui/main/src/polyfills.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 /**

--- a/ui/main/src/silent-refresh.html
+++ b/ui/main/src/silent-refresh.html
@@ -1,8 +1,11 @@
-<!-- Copyright (c) 2020, RTE (http://www.rte-france.com)                 -->
-<!--                                                                     -->
-<!-- This Source Code Form is subject to the terms of the Mozilla Public -->
-<!-- License, v. 2.0. If a copy of the MPL was not distributed with this -->
-<!-- file, You can obtain one at http://mozilla.org/MPL/2.0/.            -->
+<!-- Copyright (c) 2018-2020, RTE (http://www.rte-france.com)              -->
+<!-- See AUTHORS.txt                                                       -->
+<!-- This Source Code Form is subject to the terms of the Mozilla Public   -->
+<!-- License, v. 2.0. If a copy of the MPL was not distributed with this   -->
+<!-- file, You can obtain one at http://mozilla.org/MPL/2.0/.              -->
+<!-- SPDX-License-Identifier: MPL-2.0                                      -->
+<!-- This file is part of the OperatorFabric project.                      -->
+
 
 <!DOCTYPE html>
 <html lang="en">

--- a/ui/main/src/test.ts
+++ b/ui/main/src/test.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 // This file is required by karma.conf.js and loads recursively all the .spec and framework files

--- a/ui/main/src/tests/helpers.ts
+++ b/ui/main/src/tests/helpers.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 
 import {LightCard, Severity} from '@ofModel/light-card.model';

--- a/ui/main/src/tests/mocks/thirds.service.mock.ts
+++ b/ui/main/src/tests/mocks/thirds.service.mock.ts
@@ -1,9 +1,3 @@
-/* Copyright (c) 2020, RTE (http://www.rte-france.com)
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
 
 import {Observable, of} from "rxjs";
 import {ThirdMenu, ThirdMenuEntry} from "@ofModel/thirds.model";

--- a/web-ui/README.adoc
+++ b/web-ui/README.adoc
@@ -1,3 +1,10 @@
+// Copyright (c) 2018-2020 RTE (http://www.rte-france.com)
+// See AUTHORS.txt
+// This document is subject to the terms of the Creative Commons Attribution 4.0 International license.
+// If a copy of the license was not distributed with this
+// file, You can obtain one at https://creativecommons.org/licenses/by/4.0/.
+// SPDX-License-Identifier: CC-BY-4.0
+
 
 The adhoc `web-ui` service is now a plain `Nginx` server within a docker container.
 


### PR DESCRIPTION
I separated the documentation changes (explaining how copyright headers should be maintained) from the actual updating of the headers in all files so they're not lost in it.

To make sure there were no side effects, I checked locally that the build was passing and that the application was running (using deploy) normally.