### PR TITLE
[OC-924]  OpFab doc  dead link in Entities section

### DIFF
--- a/src/docs/asciidoc/reference_doc/users_service.adoc
+++ b/src/docs/asciidoc/reference_doc/users_service.adoc
@@ -56,7 +56,7 @@ ifndef::single-page-doc[<<{gradle-rootdir}/documentation/current/reference_doc/i
 === Entities
 Entities are used to send cards to several users without a name specifically. The information about membership to an
 entity is stored in the user information. Examples using entities can be found 
-ifdef::single-page-doc[<<card_recipients, recipients section>>]
+ifdef::single-page-doc[<<_send_to_several_users, here>>]
 ifndef::single-page-doc[<<{gradle-rootdir}/documentation/current/reference_doc/index.adoc#_send_to_several_users, here>>]
 .
 

--- a/src/docs/asciidoc/reference_doc/users_service.adoc
+++ b/src/docs/asciidoc/reference_doc/users_service.adoc
@@ -50,14 +50,14 @@ The notion of group is loose and can be used to simulate role in `OperatorFabric
 Groups are used to send cards to several users without a name specifically. The information about membership to a
 group is stored in the user information. The rules used to send cards are described in the
 ifdef::single-page-doc[<<card_recipients, recipients section>>]
-ifndef::single-page-doc[<<{gradle-rootdir}/documentation/current/reference/index.adoc#card_recipients, recipients section>>]
+ifndef::single-page-doc[<<{gradle-rootdir}/documentation/current/reference_doc/index.adoc#card_recipients, recipients section>>]
 .
 
 === Entities
 Entities are used to send cards to several users without a name specifically. The information about membership to an
-entity is stored in the user information. The rules used to send cards are described in the
+entity is stored in the user information. Examples using entities can be found 
 ifdef::single-page-doc[<<card_recipients, recipients section>>]
-ifndef::single-page-doc[<<{gradle-rootdir}/documentation/current/reference/index.adoc#card_recipients, recipients section>>]
+ifndef::single-page-doc[<<{gradle-rootdir}/documentation/current/reference_doc/index.adoc#_send_to_several_users, here>>]
 .
 
 ==== Alternative way to manage groups


### PR DESCRIPTION
RELEASE NOTE 
Task : 
[OC-924] Correct OpFab doc dead link in Entities section

[OC-924]: https://opfab.atlassian.net/browse/OC-924