### PR TITLE
sets timeout for SSE to 1 year

### DIFF
--- a/config/dev/ngnix.conf
+++ b/config/dev/ngnix.conf
@@ -106,8 +106,8 @@ server {
       return 204;
     }
     proxy_set_header Host $http_host;
-    # for SSE, keeps it alive
-    proxy_read_timeout 24h;
+    # for SSE, keeps it alive, for one year as `1y` doesn't work
+   proxy_read_timeout 365d;
     proxy_pass http://172.17.0.1:2104/;
   }
   location  /cardspub/cards/userCard {

--- a/config/docker/default-web-dev.conf
+++ b/config/docker/default-web-dev.conf
@@ -106,8 +106,8 @@ server {
       return 204;
     }
     proxy_set_header Host $http_host;
-    # for SSE, keeps it alive
-    proxy_read_timeout 24h;
+    # for SSE, keeps it alive, for one year as `1y` doesn't work
+    proxy_read_timeout 365d;
     proxy_pass http://cards-consultation:8080/;
   }
   location /cardspub/cards/userCard {

--- a/config/docker/ngnix.conf
+++ b/config/docker/ngnix.conf
@@ -44,8 +44,8 @@ server {
   }
   location /cards/ {
     proxy_set_header Host $http_host;
-    # for SSE, keeps it alive
-    proxy_read_timeout 24h;
+    # for SSE, keeps it alive, for one year as `1y` doesn't work
+    proxy_read_timeout 365d;
     proxy_pass http://cards-consultation:8080/;
   }
   location /cardspub/cards/userCard {


### PR DESCRIPTION
Signed-off-by: LE-GALL Ronan Ext <43667786+rlg-rte@users.noreply.github.com>

Leaves SSE open for one year by setting the `proxy_timeout` for `cardSubscription` to 365 days(the 1y configuration doesn't work).