### PR TITLE
OC-979 Documentation update

### DIFF
--- a/services/core/thirds/src/main/java/org/lfenergy/operatorfabric/thirds/model/ProcessData.java
+++ b/services/core/thirds/src/main/java/org/lfenergy/operatorfabric/thirds/model/ProcessData.java
@@ -8,14 +8,12 @@
  */
 
 
-
 package org.lfenergy.operatorfabric.thirds.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.*;
 import lombok.extern.slf4j.Slf4j;
 
-import javax.validation.Valid;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;

--- a/services/core/thirds/src/main/java/org/lfenergy/operatorfabric/thirds/model/ProcessStatesData.java
+++ b/services/core/thirds/src/main/java/org/lfenergy/operatorfabric/thirds/model/ProcessStatesData.java
@@ -13,9 +13,7 @@ package org.lfenergy.operatorfabric.thirds.model;
 import lombok.*;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 @Data
 @NoArgsConstructor

--- a/src/docs/asciidoc/architecture/index.adoc
+++ b/src/docs/asciidoc/architecture/index.adoc
@@ -6,8 +6,6 @@
 // SPDX-License-Identifier: CC-BY-4.0
 
 
-
-
 [[architecture]]
 = OperatorFabric Architecture
 
@@ -31,7 +29,7 @@ image::FunctionalDiagram.jpg[functional diagram]
 
 To do the job, the following business components are defined :
 
-- Card Publication : this component receives the cards from third party tools or users
+- Card Publication : this component receives the cards from third-party tools or users
 - Card Consultation : this component delivers the cards to the operators and provide access to all cards exchanged (archives)
 - Card rendering and process definition : this component stores the information for the card rendering (templates, internationalization, ...) and a light description of the process associate (states, response card, ...). This configuration data can be provided either by an administrator or by a third party tool.
 - User Management : this component is used to manage users, groups and entities.
@@ -43,17 +41,17 @@ The business objects can be represented as follows :
 image::BusinessObjects.jpg[business objects diagram]
 
 * Card : the core business object which contains the data to show to the user(or operator) 
-* Publisher : the third party which publishes or receives cards
+* Publisher : the emitter of the card (be it a third-party tool or an entity)
 * User : the operator receiving cards and responding via response cards
 * Group : a group (containing a list of users)
 * Entity : an entity (containing a list of users)
-* Process : the process the card is dealing with 
+* Process : the process the card is about
 * State : the step in the process
 * Card Rendering : data for card rendering 
 
 == Technical Architecture
 
-The architecture is based on independant modules. All business services are accessible via REST API.
+The architecture is based on independent modules. All business services are accessible via REST API.
 
 image::LogicalDiagram.jpg[functional diagram]
 

--- a/src/docs/asciidoc/deployment/configuration/configuration.adoc
+++ b/src/docs/asciidoc/deployment/configuration/configuration.adoc
@@ -9,11 +9,8 @@
 
 
 :springboot_doc: https://docs.spring.io/spring-boot/docs/2.1.2.RELEASE/
-:spring_doc: https://docs.spring.io/spring/docs/5.1.4.RELEASE/
 :mongo_doc: https://docs.mongodb.com/manual/reference/
-:spring_amqp_doc: https://docs.spring.io/spring-amqp/docs/2.1.3.RELEASE/reference/htmlsingle/
 //TODO Check if versions are correct
-//TODO check if all links are used
 
 = Configuration
 

--- a/src/docs/asciidoc/deployment/index.adoc
+++ b/src/docs/asciidoc/deployment/index.adoc
@@ -62,6 +62,4 @@ IMPORTANT: The ADMIN role doesn't grant any special privileges when it comes to 
 archived), so a user with the ADMIN role will only see cards that have been addressed to them (or to one of their
 groups (or entities)), just like any other user.
 
-include::../OC-979_WIP.adoc[leveloffset=+1]
-
 

--- a/src/docs/asciidoc/dev_env/launch_dev.adoc
+++ b/src/docs/asciidoc/dev_env/launch_dev.adoc
@@ -84,7 +84,7 @@ cd ${OF_HOME}/config/dev
 docker-compose up -d
 ----
 
-The configuration of the `web-ui` embeds a grayscale favicon which can be usefull to spot the `OperatorFabric` dev tab in the browser.
+The configuration of the `web-ui` embeds a grayscale favicon which can be useful to spot the `OperatorFabric` dev tab in the browser.
 Sometime a `CTRL+F5` on the tab is required to refresh the favicon.
 
 == Build OperatorFabric with Gradle

--- a/src/docs/asciidoc/dev_env/requirements.adoc
+++ b/src/docs/asciidoc/dev_env/requirements.adoc
@@ -6,8 +6,6 @@
 // SPDX-License-Identifier: CC-BY-4.0
 
 
-
-
 = Requirements
 
 This section describes the projects requirements regardless of installation options.

--- a/src/docs/asciidoc/getting_started/index.adoc
+++ b/src/docs/asciidoc/getting_started/index.adoc
@@ -86,7 +86,7 @@ section of the reference documentation.
 ----
 {
 	"publisher" : "message-publisher",
-	"publisherVersion" : "1",
+	"processVersion" : "1",
 	"process" :"defaultProcess",
 	"processId" : "hello-world-1",
 	"state" : "messageState",
@@ -114,7 +114,7 @@ We can send a new version of the card (updateCard.json):
 ----
 {
 	"publisher" : "message-publisher",
-	"publisherVersion" : "1",
+	"processVersion" : "1",
 	"process"  :"defaultProcess",
 	"processId" : "hello-world-1",
 	"state"  $: "messageState",
@@ -284,7 +284,7 @@ You can send the following card to test your new bundle:
 ----
 {
 	"publisher" : "message-publisher",
-	"publisherVersion" : "2",
+	"processVersion" : "2",
 	"process"  :"defaultProcess",
 	"processId" : "hello-world-1",
 	"state": "messageState",
@@ -300,7 +300,7 @@ You can send the following card to test your new bundle:
 }
 ----
 
-To use the new bundle, we set publisherVersion to "2"
+To use the new bundle, we set processVersion to "2"
 
 To send the card:
 
@@ -397,7 +397,7 @@ We can now send cards and simulate the process, first we send a card at the begi
 ----
 {
 	"publisher" : "alert-publisher",
-	"publisherVersion" : "1",
+	"processVersion" : "1",
 	"process"  :"criticalSituation",
 	"processId" : "alert1",
 	"state": "criticalSituation-begin",
@@ -442,7 +442,7 @@ To view the card in the time line, you need to set times in the card using timeS
 ----
  {
 	"publisher" : "scheduledMaintenance-publisher",
-	"publisherVersion" : "1",
+	"processVersion" : "1",
 	"process"  :"maintenanceProcess",
 	"processId" : "maintenance-1",
 	"state": "planned",

--- a/src/docs/asciidoc/getting_started/troubleshooting.adoc
+++ b/src/docs/asciidoc/getting_started/troubleshooting.adoc
@@ -101,9 +101,9 @@ The previous server response is return for a request like:
 The bundle is lacking localized folder and doesn't contain the requested 
 localization.
 
-If you have access to the `card-publication` micro service source code you
+If you have access to the `thirds` micro service source code you
 should list the content of 
-`$CARDS_PUBLICATION_PROJECT/build/docker-volume/third-storage`
+`$THIRDS_PROJECT/build/docker-volume/third-storage`
 
 === Solution
 

--- a/src/docs/asciidoc/reference_doc/archives.adoc
+++ b/src/docs/asciidoc/reference_doc/archives.adoc
@@ -7,7 +7,6 @@
 
 
 
-
 = Archived Cards
 
 == Key concepts

--- a/src/docs/asciidoc/reference_doc/bundle_technical_overview.adoc
+++ b/src/docs/asciidoc/reference_doc/bundle_technical_overview.adoc
@@ -6,8 +6,6 @@
 // SPDX-License-Identifier: CC-BY-4.0
 
 
-
-
 [[bundle_technical_overview]]
 = Bundle Technical overview
 
@@ -44,7 +42,7 @@ Sample json i18n file
     "module":
       {
         "name": "Emergency Module",
-        "description": "The emergency module managed ermergencies"
+        "description": "The emergency module managed emergencies"
       }
   }
 }

--- a/src/docs/asciidoc/reference_doc/card_examples.adoc
+++ b/src/docs/asciidoc/reference_doc/card_examples.adoc
@@ -5,9 +5,6 @@
 // file, You can obtain one at https://creativecommons.org/licenses/by/4.0/.
 // SPDX-License-Identifier: CC-BY-4.0
 
-
-
-
 = Cards Examples
 
 Before detailing the content of cards, let's show you what cards look like through few examples of json.
@@ -23,7 +20,8 @@ The following card contains only the mandatory attributes.
 ....
 {
 	"publisher":"TSO1",
-	"publisherVersion":"0.1",
+	"processVersion":"0.1",
+    "process":"process",
 	"processInstanceId":"process-000",
 	"startDate":1546297200000,
 	"severity":"INFORMATION",
@@ -37,7 +35,9 @@ The following card contains only the mandatory attributes.
 }
 ....
 
-This an information about the process `process-000`, send by the `TSO1`. The title and the summary refer to `i18n` keys defined in the associated `i18n` files of the publisher. This card is displayable since the first january 2019 and should only be received by the user using the `tso1-operator` login.
+This an information about the process instance `process-000` of process `process`, sent by `TSO1`. The title and the summary refer to `i18n` keys
+defined in the associated `i18n` files of the process. This card is displayable since the first january 2019 and
+should only be received by the user using the `tso1-operator` login.
 
 === Send to several users
 
@@ -48,7 +48,8 @@ The following example is nearly the same as the previous one except for the reci
 ....
 {
 	"publisher":"TSO1",
-	"publisherVersion":"0.1",
+	"processVersion":"0.1",
+    "process":"process",
 	"processInstanceId":"process-000",
 	"startDate":1546297200000,
 	"severity":"INFORMATION",
@@ -70,7 +71,8 @@ The following example is nearly the same as the previous one except for the reci
 ....
 {
 	"publisher":"TSO1",
-	"publisherVersion":"0.1",
+	"processVersion":"0.1",
+    "process":"process",
 	"processInstanceId":"process-000",
 	"startDate":1546297200000,
 	"severity":"INFORMATION",
@@ -92,7 +94,8 @@ The following example is nearly the same as the previous one except for the reci
 ....
 {
 	"publisher":"TSO1",
-	"publisherVersion":"0.1",
+	"processVersion":"0.1",
+    "process":"process",
 	"processInstanceId":"process-000",
 	"startDate":1546297200000,
 	"severity":"INFORMATION",
@@ -106,11 +109,13 @@ The following example is nearly the same as the previous one except for the reci
 }
 ....
 
-Here, the recipients are a group and an entity, the `TSO1` group and `ENTITY1` entity. So all users who are both members of this group and this entity will receive the card.
+Here, the recipients are a group and an entity, the `TSO1` group and `ENTITY1` entity. So all users who are both members
+of this group and this entity will receive the card.
 
 ==== Complex case
 
-If this card need to be view by a user who is not in the `TSO1` group, it's possible to tune more precisely the definition of the recipient. If the `tso2-operator` needs to see also this card, the recipient definition could be(the following code details only the recipient part):
+If this card need to be viewed by a user who is not in the `TSO1` group, it's possible to tune more precisely the
+definition of the recipient. If the `tso2-operator` needs to see also this card, the recipient definition could be(the following code details only the recipient part):
 
 ....
 "recipient":{ 
@@ -135,7 +140,8 @@ For this example we will use our previous example for the `TSO1` group with a `d
 ....
 {
 	"publisher":"TSO1",
-	"publisherVersion":"0.1",
+	"processVersion":"0.1",
+    "process":"process",
 	"processInstanceId":"process-000",
 	"startDate":1546297200000,
 	"severity":"INFORMATION",
@@ -159,7 +165,7 @@ there is no rendering configuration.
 === Fully useful
 
 When a card is selected in the feed (of the GUI), the data is displayed in the detail panel.
-The way details are formatted depends on the template uploaded by Third parties as
+The way details are formatted depends on the template contained in the bundle associated with the process as
 ifdef::single-page-doc[<<bundle_technical_overview, described here>>]
 ifndef::single-page-doc[<<{gradle-rootdir}/documentation/current/reference_doc/index.adoc#bundle_technical_overview, described here>>]
 . To have an effective example without to many actions to performed, the following example will use an already existing
@@ -169,8 +175,9 @@ At the card level, the attributes in the card telling OperatorFabric which templ
 
 ....
 {
-	"publisher":"TEST",
-	"publisherVersion":"1",
+	"publisher":"TEST_PUBLISHER",
+	"processVersion":"1",
+    "process":"TEST",
 	"processInstanceId":"process-000",
 	"startDate":1546297200000,
 	"severity":"INFORMATION",
@@ -186,7 +193,9 @@ At the card level, the attributes in the card telling OperatorFabric which templ
 }
 ....
 
-So here a single custom data is defined and it's `rootProp`. This attribute is used by the template called by the `details` attribute. This attribute contains an array of `json` object containing an `i18n` key and a `template` reference. Each of those object is a tab in the detail panel of the GUI. The template to used are defined and configured in the `Third` bundle upload into the server by the publisher.
+So here a single custom data is defined and it's `rootProp`. This attribute is used by the template called by the
+`details` attribute. This attribute contains an array of `json` object containing an `i18n` key and a `template`
+reference. Each of those object is a tab in the detail panel of the GUI.
 
 [[display_rules]]
 == Display Rules

--- a/src/docs/asciidoc/reference_doc/card_structure.adoc
+++ b/src/docs/asciidoc/reference_doc/card_structure.adoc
@@ -5,11 +5,7 @@
 // file, You can obtain one at https://creativecommons.org/licenses/by/4.0/.
 // SPDX-License-Identifier: CC-BY-4.0
 
-
-
-
 //TODO Remove unnecessary anchors
-
 [[card_structure]]
 = Card Structure
 
@@ -26,20 +22,25 @@ Those attributes are used by OperatorFabric to manage how cards are stored, to w
 
 Below, the `json` technical key is in the '()' following the title.
 
-[[card_publisher]]
 ==== Publisher (`publisher`)
+The publisher field bears the identifier of the emitter of the card, be it an entity or an external service.
 
-Quite obviously it's the Third party which publish the card. This information is used to look up for Presentation resources of the card.
+[[card_process]]
+==== Process (`process`)
+This field indicates which process the card is attached to. This information is used to resolve the presentation
+resources (bundle) used to render the card and card details.
 
-[[card_publisher_version]]
-==== Publisher Version (`publisherVersion`)
+[[card_process_version]]
+==== Process Version (`processVersion`)
+The rendering of cards of a given process can evolve over time. To allow for this while making sure previous cards
+remain correctly handled, OperatorFabric can manage several versions of the same process.
+The `processVersion` field indicate which version of the process should be used to retrieve the presentation resources
+(i18n, templates, etc.) to render this card.
 
-Refers the `version` of `publisher third` to use to render this card (i18n, title, summary and details).
-As through time, the presentation of a publisher card data changes, this changes are managed through `publisherVersion` in OperatorFabric. Each version is keep in the system in order to be able to display correctly old cards.
-
-==== Process Identifier (`processInstanceId`)
-
-It's the way to identify the process to which the card is associated. A card represent a state of a process.
+==== Process Instance Identifier (`processInstanceId`)
+A card is associated to a given process, which defines how it is rendered, but it is also more precisely associated to
+a *specific instance* of this process. The `processId` field contains the unique identifier of the process instance
+of which the card represents the current state.
 
 [[start_date]]
 ==== Start Date (`startDate`)
@@ -98,8 +99,6 @@ ifdef::single-page-doc[<<display_rules, Display rules>>]
 ifndef::single-page-doc[<<{gradle-rootdir}/documentation/current/reference_doc/index.adoc#display_rules, Display rules>>]
 for some examples.
 
-
-
 === Optional information
 
 ==== Tags (`tag`)
@@ -109,7 +108,6 @@ Tags are intended as an additional way to filter cards in the feed of the GUI.
 ==== EntityRecipients (`entityRecipients`)
 
 Used to send to cards to entity : all users members of the listed entities will receive the card. If it is used in conjunction with groups recipients, users must be members of one of the entities AND one of the groups to receive the cards.
-
 
 === Last Time to Decide (`lttd`)
 
@@ -124,7 +122,6 @@ Unique identifier of the card in the OperatorFabric system. This attribute can b
 ==== id (`id`)
 
 State id of the associated process, determined by `OperatorFabric` can be set arbitrarily by the `publisher`.
-
 
 
 === Other technical attributes
@@ -167,8 +164,8 @@ displayed, see below.
 
 
 [WARNING]
-You must not use dot in json field names. In this case, the card will be refused with following message :  "Error, unable to handle pushed Cards: Map key xxx.xxx contains dots but no replacement was configured!""
-
+You must not use dot in json field names. In this case, the card will be refused with following message :
+"Error, unable to handle pushed Cards: Map key xxx.xxx contains dots but no replacement was configured!""
 
 == Presentation Information of the card
 
@@ -176,26 +173,30 @@ You must not use dot in json field names. In this case, the card will be refused
 
 This attribute is a string of objects containing a `title` attribute which is `i18n` key and a `template` attribute
 which refers to a template name contained in the publisher bundle. The bundle in which those resources will be looked
-for is the one corresponding of the
-ifdef::single-page-doc[<<card_publisher_version, version>>]
-ifndef::single-page-doc[<<{gradle-rootdir}/documentation/current/reference_doc/index.adoc#card_publisher_version, version>>]
+for is the one corresponding to the
+ifdef::single-page-doc[<<card_process_version, version>>]
+ifndef::single-page-doc[<<{gradle-rootdir}/documentation/current/reference_doc/index.adoc#card_process_version, version>>]
 declared in the card for the current
-ifdef::single-page-doc[<<card_publisher, publisher>>]
-ifndef::single-page-doc[<<{gradle-rootdir}/documentation/current/reference_doc/index.adoc#card_publisher, publisher>>]
+ifdef::single-page-doc[<<card_process, process>>]
+ifndef::single-page-doc[<<{gradle-rootdir}/documentation/current/reference_doc/index.adoc#card_process, process>>]
 .
 If no resource is found, either because there is no bundle for the given version or
 there is no resource for the given key, then the corresponding key is displayed in the details section of the GUI.
 
-See more documentation about third bundles
+See more documentation about bundles
 ifdef::single-page-doc[<<bundle_technical_overview, here>>]
 ifndef::single-page-doc[<<{gradle-rootdir}/documentation/current/reference_doc/index.adoc#bundle_technical_overview, here>>]
 .
 
 *example:*
 
-The `TEST` publisher has only a `0.1` version uploaded in the current `OperatorFabric` system. The `details` value is `[{"title":{"key":"first.tab.title"},"template":"template0"}]`.
+The `TEST` process only has a `0.1` version uploaded in the current `OperatorFabric` system. The `details` value is
+`[{"title":{"key":"first.tab.title"},"template":"template0"}]`.
 
-If the `publisherVersion` of the card is `2` then only the `title` key declared in the `details` array will be displays without any translation, i.e. the tab will contains `TEST.2.first.tab.title` and will be empty. If the `l10n` for the title is not available, then the tab title will be still `TEST.2.first.tab.title` but the template will be compute and the details section will display the template content.
+If the `processVersion` of the card is `2` then only the `title` key declared in the `details` array will be displayed
+without any translation, i.e. the tab will contains `TEST.2.first.tab.title` and will be empty. If the `l10n` for
+the title is not available, then the tab title will be still `TEST.2.first.tab.title` but the template will be computed
+and the details section will display the template content.
 
 === TimeSpans (`timeSpans`)
 
@@ -213,6 +214,7 @@ card:
 {
 	"publisher":"TSO1",
 	"publisherVersion":"0.1",
+    "process":"process",
 	"processInstanceId":"process-000",
 	"startDate":1546297200000,
 	"severity":"INFORMATION",

--- a/src/docs/asciidoc/reference_doc/process_definition.adoc
+++ b/src/docs/asciidoc/reference_doc/process_definition.adoc
@@ -6,17 +6,13 @@
 // SPDX-License-Identifier: CC-BY-4.0
 
 
+//TODO OC-979
+= Declaring a Process and its configuration
 
+The business configuration for processes is declared in the form of a bundle, as described below.
+Once this bundle fully created, it must be uploaded to the server through the Thirds service.
 
-= Declaring a Third Party Service
-
-This sections explains Third Party Service Configuration
-
-The third party service configuration is declared using a bundle which is described below.
-Once this bundle fully created, it must be uploaded to the server which will apply this configuration into current
-for further web UI calls.
-
-The way configuration is done is explained throughout examples before a more technical review of the configuration details.
+The way configuration is done is explained with examples before a more technical review of the configuration details.
 The following instructions describe tests to perform on OperatorFabric to understand how customization is working in it.
 The card data used here are sent automatically using a script as described
 ifdef::single-page-doc[<<card_sending_script, here>>]
@@ -26,11 +22,13 @@ ifndef::single-page-doc[<<{gradle-rootdir}/documentation/current/reference_doc/i
 == Requirements
 
 Those examples are played in an environment where an OperatorFabric instance (all micro-services) is running along
-a MongoDB Database and a RabbitMQ instances.
+a MongoDB Database and a RabbitMQ instance.
 
 == Bundle
 
-Third bundles customize the way third card details are displayed. Those `tar.gz` archives contain a descriptor file
+A bundle contains all the configuration regarding a given business process, describing for example the various steps
+of the process but also how the associated cards and card details should be displayed.
+Those `tar.gz` archives contain a descriptor file
 named `config.json`, eventually some `css files`, `i18n files` and `handlebars templates` to do so.
 
 For didactic purposes, in this section, the third name is `BUNDLE_TEST` (to match the parameters used by the script).
@@ -38,7 +36,7 @@ This bundle is localized for `en` and `fr`.
 
 As detailed in the `Third core service README` the bundle contains at least a metadata file called `config.json`,
 a `css` folder, an `i18n` folder and a `template` folder.
- All elements except the `config.json file` are optional.
+All elements except the `config.json file` are optional.
 
 The files of this example are organized as below:
 
@@ -59,78 +57,16 @@ bundle
         └── template2.handlebars
 ....
 
-To summarize, there are 5 directories and 8 files.
-
 === The config.json file
 
 It's a description file in `json` format. It lists the content of the bundle.
 
 *example*
 
-....
-{
-  "name": "BUNDLE_TEST",
-  "version": "1",
-  "csses": [
-    "bundleTest"
-  ],
-  "i18nLabelKey": "third-name-in-menu-bar",
-  "menuEntries": [
-    {
-      "id": "uid test 0",
-      "url": "https://opfab.github.io/whatisopfab/",
-      "label": "first-menu-entry"
-    },
-    {
-      "id": "uid test 0",
-      "url": "https://www.lfenergy.org/",
-      "label": "b-menu-entry"
-    },
-    {
-      "id": "uid test 1",
-      "url": "https://github.com/opfab/opfab.github.io",
-      "label": "the-other-menu-entry"
-    }
-  ],
-  "processes" : {
-      "simpleProcess" : {
-        "start" : {
-          "details" : [ {
-            "title" : {
-              "key" : "start.first.title"
-            },
-            "titleStyle" : "startTitle text-danger",
-            "templateName" : "template1"
-          } ],
-          "actions" : {
-            "finish" : {
-              "type" : "URL",
-              "url": "http://somewher.org/simpleProcess/finish",
-              "lockAction" : true,
-              "called" : false,
-              "updateStateBeforeAction" : false,
-              "hidden" : true,
-              "buttonStyle" : "buttonClass",
-              "label" : {
-                "key" : "my.card.my.action.label"
-              },
-            }
-          }
-        },
-        "end" : {
-          "details" : [ {
-            "title" : {
-              "key" : "end.first.title"
-            },
-            "titleStyle" : "startTitle text-info",
-            "templateName" : "template2",
-            "styles" : [ "bundleTest.css" ]
-          } ]
-        }
-      }
-    }
-}
-....
+[source,JSON]
+----
+include::../../../../services/core/thirds/src/main/docker/volume/thirds-storage/TEST/config.json[]
+----
 
 - name: third name;
 - version: enable the correct display, even the old ones as all versions are stored by the server. Your *card* has a version
@@ -156,11 +92,14 @@ for details.
 
 === i18n
 
-There are two ways of i18n for third service. The first one is done using l10n files which are located in the `i18n` folder, the second one throughout l10n name folder nested in the `template` folder.
+There are two ways of i18n for third service. The first one is done using l10n files which are located in the `i18n`
+folder, the second one throughout l10n name folder nested in the `template` folder.
 
 The `i18n` folder contains one json file per l10n.
 
-These localisation is used for integration of the third service into OperatorFabric, i.e. the label displayed for the third service, the label displayed for each tab of the details of the third card, the label of the actions in cards if any or the additional third entries in OperatorFabric(more on that at the chapter ????).
+These localisation is used for integration of the third service into OperatorFabric, i.e. the label displayed for the
+third service, the label displayed for each tab of the details of the third card, the label of the actions in cards if
+any or the additional third entries in OperatorFabric(more on that at the chapter ????).
 
 ====  Template folder
 
@@ -175,15 +114,19 @@ The choice of i18n keys is left to the Third service maintainer. The keys are re
 * `config.json` file:
 	** `i18nLabelKey`: key used for the label for the third service displayed in the main menu bar of OperatorFabric;
 	** `label` of `menu entry declaration`: key used to l10n the `menu entries` declared by the Third party in the bundle;
-* `card data`: values of `card title` and `card summary` refer to `i18n keys` as well as `key attribute` in the `card detail` section of the card data.
+* `card data`: values of `card title` and `card summary` refer to `i18n keys` as well as `key attribute` in the
+`card detail` section of the card data.
 
 *example*
 
-So in this example the third service is named `Bundle Test` with `BUNDLE_TEST` technical name. The bundle provide an english and a french l10n.
+So in this example the third service is named `Bundle Test` with `BUNDLE_TEST` technical name. The bundle provide an
+english and a french l10n.
 
-The example bundle defined an new menu entry given access to 3 entries. The title and the summary have to be l10n, so needs to be the 2 tabs titles.
+The example bundle defined an new menu entry given access to 3 entries. The title and the summary have to be l10n,
+so needs to be the 2 tabs titles.
 
-The name of the third service as displayed in the main menu bar of OperatorFabric. It will have the key `"third-name-in-menu-bar"`. The english l10n will be `Bundle Test` and the french one will be `Bundle de test`.
+The name of the third service as displayed in the main menu bar of OperatorFabric. It will have the key
+`"third-name-in-menu-bar"`. The english l10n will be `Bundle Test` and the french one will be `Bundle de test`.
 
 A name for the three entries in the third entry menu. Their keys will be in order `"first-menu-entry"`, `"b-menu-entry"` and `"the-other-menu-entry"` for an english l10n as `Entry One`, `Entry Two` and `Entry Three` and in french as `Entrée une`, `Entrée deux` and `Entrée trois`.
 
@@ -339,7 +282,7 @@ Regarding the card detail customization, all the examples in this section will b
 
 [[card_sending_script]]
 ....
-$OPERATOR_FABRIC_HOME/services/core/cards-publication/src/main/bin/push_card_loop.sh --publisher BUNDLE_TEST --process tests
+$OPERATOR_FABRIC_HOME/services/core/cards-publication/src/main/bin/push_card_loop.sh
 ....
 
 where:

--- a/src/docs/asciidoc/reference_doc/thirds_service.adoc
+++ b/src/docs/asciidoc/reference_doc/thirds_service.adoc
@@ -6,9 +6,8 @@
 // SPDX-License-Identifier: CC-BY-4.0
 
 
-
-
-= Thirds service
+//TODO OC-979
+= Thirds Service
 
 As stated above, third-party applications (or "thirds" for short) interact with OperatorFabric by sending cards.
 The Thirds service allows them to tell OperatorFabric
@@ -20,6 +19,6 @@ The Thirds service allows them to tell OperatorFabric
 In addition, it lets third-party applications define additional menu entries for the navbar (for example linking back
 to the third-party application) that can be integrated either as iframe or external links.
 
-include::publisher_definition.adoc[leveloffset=+1]
+include::process_definition.adoc[leveloffset=+1]
 
 include::bundle_technical_overview.adoc[leveloffset=+1]

--- a/src/docs/asciidoc/resources/index.adoc
+++ b/src/docs/asciidoc/resources/index.adoc
@@ -11,3 +11,5 @@
 = Resources
 
 include::mock_pipeline.adoc[leveloffset=+1]
+
+include::migration_guide.adoc[leveloffset=+1]

--- a/src/docs/asciidoc/resources/migration_guide.adoc
+++ b/src/docs/asciidoc/resources/migration_guide.adoc
@@ -1,6 +1,15 @@
-= Refactoring of configuration management (publisher->process) OC-979 (Temporary document)
+// Copyright (c) 2020 RTE (http://www.rte-france.com)
+// See AUTHORS.txt
+// This document is subject to the terms of the Creative Commons Attribution 4.0 International license.
+// If a copy of the license was not distributed with this
+// file, You can obtain one at https://creativecommons.org/licenses/by/4.0/.
+// SPDX-License-Identifier: CC-BY-4.0
 
-== Motivation for the change
+= Migration Guide
+
+== Refactoring of configuration management (publisher->process) OC-979 (Temporary document)
+
+=== Motivation for the change
 
 The initial situation was to have a `Thirds` concept that was meant to represent third-party applications that publish
 content (cards) to OperatorFabric.
@@ -18,12 +27,12 @@ But now that we're aiming for cards to be sent by entities, users (see Free Mess
 doesn't make sense to tie the rendering of the card ("Which configuration bundle should I take the templates and
 details from?") to its publisher ("Who/What emitted this card and who/where should I reply?").
 
-== Changes to the model
+=== Changes to the model
 
 To do this, we decided that the `publisher` of a card would now have the sole meaning of `emitter`, and that the link
 to the configuration bundle to use to render a card would now be based on its `process` field.
 
-=== On the Thirds model
+==== On the Thirds model
 
 We used to have a `Third` object which had an array of `Process` objects as one of its properties.
 Now, the `Process` object replaces the `Third` object and this new object combines the properties of the old `Third`
@@ -154,7 +163,7 @@ Here is an example of a simple config.json file:
 You should also make sure that the new i18n label keys that you introduce match what is defined in the i18n
 folder of the bundle.
 
-=== On the Cards model
+==== On the Cards model
 
 |===
 |Field before |Field after |Usage
@@ -176,13 +185,17 @@ publishers
 
 These changes impact both current cards from the feed and archived cards.
 
-== Changes to the endpoints
+=== Changes to the endpoints
 
 The `/thirds` endpoint becomes `thirds/processes` in preparation of OC-978.
 
-== Migration guide
+=== Migration guide
 
 This section outlines the necessary steps to migrate existing data.
+
+[IMPORTANT]
+You need to perform these steps before starting up the OperatorFabric instance because starting up services with the new
+version while there are still "old" bundles in the thirds storage will cause the thirds service to crash.
 
 . Backup your existing bundles and existing Mongo data.
 //TODO Add details?
@@ -251,3 +264,6 @@ $set: { "process": "SOME_PROCESS"}
 }
 )
 ----
+
+. If you have any code or scripts that push bundles, you should update it to point to the new endpoint.
+

--- a/ui/main/src/app/modules/cards/components/card/card.component.ts
+++ b/ui/main/src/app/modules/cards/components/card/card.component.ts
@@ -33,7 +33,6 @@ export class CardComponent implements OnInit, OnDestroy {
     currentPath: any;
     protected _i18nPrefix: string;
     dateToDisplay: string;
-    actionsUrlPath: string;
 
     private ngUnsubscribe: Subject<void> = new Subject<void>();
 
@@ -59,8 +58,6 @@ export class CardComponent implements OnInit, OnDestroy {
             .pipe(map(config => this.computeDisplayedDates(config, card)))
             .pipe(takeUntil(this.ngUnsubscribe))
             .subscribe(computedDate => this.dateToDisplay = computedDate);
-
-        this.actionsUrlPath = `/publisher/${card.publisher}/process/${card.processInstanceId}/states/${card.state}/actions`; //TODO OC-979 THis should be removed ?
     }
 
     computeDisplayedDates(config: string, lightCard: LightCard): string {

--- a/ui/main/src/app/modules/cards/components/detail/detail.component.ts
+++ b/ui/main/src/app/modules/cards/components/detail/detail.component.ts
@@ -14,7 +14,7 @@ import {Card, Detail} from '@ofModel/card.model';
 import {ProcessesService} from '@ofServices/processes.service';
 import {HandlebarsService} from '../../services/handlebars.service';
 import {DomSanitizer, SafeHtml, SafeResourceUrl} from '@angular/platform-browser';
-import {Process, Response} from '@ofModel/processes.model';
+import {Response} from '@ofModel/processes.model';
 import {DetailContext} from '@ofModel/detail-context.model';
 import {Store} from '@ngrx/store';
 import {AppState} from '@ofStore/index';

--- a/ui/main/src/app/modules/cards/services/handlebars.service.spec.ts
+++ b/ui/main/src/app/modules/cards/services/handlebars.service.spec.ts
@@ -30,7 +30,7 @@ import {DetailContext} from "@ofModel/detail-context.model";
 
 function computeTemplateUri(templateName) {
     return `${environment.urls.processes}/testProcess/templates/${templateName}`;
-    //TODO OC-979 Why is the publisher (now the process) hardcoded? It needs to match the one set by default in getOneRandomCard.
+    //TODO OC-1009 Why is the publisher (now the process) hardcoded? It needs to match the one set by default in getOneRandomCard.
 }
 
 describe('Handlebars Services', () => {


### PR DESCRIPTION
Documentation update accompanying OC-979.
2 files are left to update, signalled by a "TODO OC-979" comment, but we have to decide whether we want to keep them or not.