### PR TITLE
[OC-981] Change way of creating card id

### DIFF
--- a/services/core/cards-consultation/src/test/java/org/lfenergy/operatorfabric/cards/consultation/TestUtilities.java
+++ b/services/core/cards-consultation/src/test/java/org/lfenergy/operatorfabric/cards/consultation/TestUtilities.java
@@ -152,7 +152,7 @@ public class TestUtilities {
     public static void prepareCard(CardConsultationData card, Instant publishDate) {
         card.setUid(UUID.randomUUID().toString());
         card.setPublishDate(publishDate);
-        card.setId(card.getPublisher() + "_" + card.getProcessInstanceId());
+        card.setId(card.getProcess() + "." + card.getProcessInstanceId());
         card.setShardKey(Math.toIntExact(card.getStartDate().toEpochMilli() % 24 * 1000));
     }
 

--- a/services/core/cards-consultation/src/test/java/org/lfenergy/operatorfabric/cards/consultation/controllers/CardOperationsControllerShould.java
+++ b/services/core/cards-consultation/src/test/java/org/lfenergy/operatorfabric/cards/consultation/controllers/CardOperationsControllerShould.java
@@ -218,8 +218,8 @@ public class CardOperationsControllerShould {
                 .assertNext(op->{
                     assertThat(op.getCards().size()).isEqualTo(2);
                     assertThat(op.getPublishDate()).isEqualTo(nowPlusOne);
-                    assertThat(op.getCards().get(0).getId()).isEqualTo("PUBLISHER_PROCESSnotif1");
-                    assertThat(op.getCards().get(1).getId()).isEqualTo("PUBLISHER_PROCESSnotif2");
+                    assertThat(op.getCards().get(0).getId()).isEqualTo("PROCESS.PROCESSnotif1");
+                    assertThat(op.getCards().get(1).getId()).isEqualTo("PROCESS.PROCESSnotif2");
                 })
            .thenCancel()
            .verify();
@@ -241,12 +241,12 @@ public class CardOperationsControllerShould {
                 .assertNext(op->{
                     assertThat(op.getCards().size()).isEqualTo(6);
                     assertThat(op.getPublishDate()).isEqualTo(nowMinusThree);
-                    assertThat(op.getCards().get(0).getId()).isEqualTo("PUBLISHER_PROCESS6");
-                    assertThat(op.getCards().get(1).getId()).isEqualTo("PUBLISHER_PROCESS7");
-                    assertThat(op.getCards().get(2).getId()).isEqualTo("PUBLISHER_PROCESS2");
-                    assertThat(op.getCards().get(3).getId()).isEqualTo("PUBLISHER_PROCESS4");
-                    assertThat(op.getCards().get(4).getId()).isEqualTo("PUBLISHER_PROCESS5");
-                    assertThat(op.getCards().get(5).getId()).isEqualTo("PUBLISHER_PROCESS8");
+                    assertThat(op.getCards().get(0).getId()).isEqualTo("PROCESS.PROCESS6");
+                    assertThat(op.getCards().get(1).getId()).isEqualTo("PROCESS.PROCESS7");
+                    assertThat(op.getCards().get(2).getId()).isEqualTo("PROCESS.PROCESS2");
+                    assertThat(op.getCards().get(3).getId()).isEqualTo("PROCESS.PROCESS4");
+                    assertThat(op.getCards().get(4).getId()).isEqualTo("PROCESS.PROCESS5");
+                    assertThat(op.getCards().get(5).getId()).isEqualTo("PROCESS.PROCESS8");
                 })
                 .expectComplete()
                 .verify();
@@ -267,27 +267,27 @@ public class CardOperationsControllerShould {
                 .assertNext(op->{
                     assertThat(op.getCards().size()).isEqualTo(6);
                     assertThat(op.getPublishDate()).isEqualTo(nowMinusThree);
-                    assertThat(op.getCards().get(0).getId()).isEqualTo("PUBLISHER_PROCESS6");
-                    assertThat(op.getCards().get(1).getId()).isEqualTo("PUBLISHER_PROCESS7");
-                    assertThat(op.getCards().get(2).getId()).isEqualTo("PUBLISHER_PROCESS2");
-                    assertThat(op.getCards().get(3).getId()).isEqualTo("PUBLISHER_PROCESS4");
-                    assertThat(op.getCards().get(4).getId()).isEqualTo("PUBLISHER_PROCESS5");
-                    assertThat(op.getCards().get(5).getId()).isEqualTo("PUBLISHER_PROCESS8");
+                    assertThat(op.getCards().get(0).getId()).isEqualTo("PROCESS.PROCESS6");
+                    assertThat(op.getCards().get(1).getId()).isEqualTo("PROCESS.PROCESS7");
+                    assertThat(op.getCards().get(2).getId()).isEqualTo("PROCESS.PROCESS2");
+                    assertThat(op.getCards().get(3).getId()).isEqualTo("PROCESS.PROCESS4");
+                    assertThat(op.getCards().get(4).getId()).isEqualTo("PROCESS.PROCESS5");
+                    assertThat(op.getCards().get(5).getId()).isEqualTo("PROCESS.PROCESS8");
                 })
                 .then(createSendMessageTask())
                 .assertNext(op->{
                     assertThat(op.getCards().size()).isEqualTo(2);
                     assertThat(op.getPublishDate()).isEqualTo(nowPlusOne);
-                    assertThat(op.getCards().get(0).getId()).isEqualTo("PUBLISHER_PROCESSnotif1");
-                    assertThat(op.getCards().get(1).getId()).isEqualTo("PUBLISHER_PROCESSnotif2");
+                    assertThat(op.getCards().get(0).getId()).isEqualTo("PROCESS.PROCESSnotif1");
+                    assertThat(op.getCards().get(1).getId()).isEqualTo("PROCESS.PROCESSnotif2");
                 })
                 .then(createUpdateSubscriptionTask())
                 .assertNext(op->{
                     assertThat(op.getCards().size()).isEqualTo(3);
                     assertThat(op.getPublishDate()).isEqualTo(nowMinusThree);
-                    assertThat(op.getCards().get(0).getId()).isEqualTo("PUBLISHER_PROCESS6");
-                    assertThat(op.getCards().get(1).getId()).isEqualTo("PUBLISHER_PROCESS7");
-                    assertThat(op.getCards().get(2).getId()).isEqualTo("PUBLISHER_PROCESS0");
+                    assertThat(op.getCards().get(0).getId()).isEqualTo("PROCESS.PROCESS6");
+                    assertThat(op.getCards().get(1).getId()).isEqualTo("PROCESS.PROCESS7");
+                    assertThat(op.getCards().get(2).getId()).isEqualTo("PROCESS.PROCESS0");
 
                 })
                 .thenCancel()
@@ -340,11 +340,11 @@ public class CardOperationsControllerShould {
         StepVerifier.FirstStep<CardOperation> verifier = StepVerifier.create(publisher.map(s -> TestUtilities.readCardOperation(mapper, s)).doOnNext(TestUtilities::logCardOperation));
         verifier
                 .assertNext(op->{
-                	assertThat(op.getCards().get(2).getId()).isEqualTo("PUBLISHER_PROCESS0");
+                	assertThat(op.getCards().get(2).getId()).isEqualTo("PROCESS.PROCESS0");
                 	assertThat(op.getCards().get(2).getHasBeenAcknowledged()).isTrue();
-                	assertThat(op.getCards().get(3).getId()).isEqualTo("PUBLISHER_PROCESS2");
+                	assertThat(op.getCards().get(3).getId()).isEqualTo("PROCESS.PROCESS2");
                 	assertThat(op.getCards().get(3).getHasBeenAcknowledged()).isFalse();
-                	assertThat(op.getCards().get(4).getId()).isEqualTo("PUBLISHER_PROCESS4");
+                	assertThat(op.getCards().get(4).getId()).isEqualTo("PROCESS.PROCESS4");
                 	assertThat(op.getCards().get(4).getHasBeenAcknowledged()).isFalse();
                 })
                 .expectComplete()

--- a/services/core/cards-consultation/src/test/java/org/lfenergy/operatorfabric/cards/consultation/repositories/CardRepositoryShould.java
+++ b/services/core/cards-consultation/src/test/java/org/lfenergy/operatorfabric/cards/consultation/repositories/CardRepositoryShould.java
@@ -134,21 +134,21 @@ public class CardRepositoryShould {
 
         StepVerifier.create(repository.findNextCardWithUser(nowMinusTwo, currentUserWithPerimeters))
                 .assertNext(card -> {
-                    assertThat(card.getId()).isEqualTo(card.getPublisher() + "_PROCESS0");
+                    assertThat(card.getId()).isEqualTo(card.getProcess() + ".PROCESS0");
                     assertThat(card.getStartDate()).isEqualTo(nowMinusTwo);
                 })
                 .expectComplete()
                 .verify();
         StepVerifier.create(repository.findNextCardWithUser(nowMinusTwo.minusMillis(1000), currentUserWithPerimeters))
                 .assertNext(card -> {
-                    assertThat(card.getId()).isEqualTo(card.getPublisher() + "_PROCESS0");
+                    assertThat(card.getId()).isEqualTo(card.getProcess() + ".PROCESS0");
                     assertThat(card.getStartDate()).isEqualTo(nowMinusTwo);
                 })
                 .expectComplete()
                 .verify();
         StepVerifier.create(repository.findNextCardWithUser(nowMinusTwo.plusMillis(1000), currentUserWithPerimeters))
                 .assertNext(card -> {
-                    assertThat(card.getId()).isEqualTo(card.getPublisher() + "_PROCESS2");
+                    assertThat(card.getId()).isEqualTo(card.getProcess() + ".PROCESS2");
                     assertThat(card.getStartDate()).isEqualTo(nowMinusOne);
                 })
                 .expectComplete()
@@ -170,21 +170,21 @@ public class CardRepositoryShould {
 
         StepVerifier.create(repository.findPreviousCardWithUser(nowMinusTwo, currentUserWithPerimeters))
                 .assertNext(card -> {
-                    assertThat(card.getId()).isEqualTo(card.getPublisher() + "_PROCESS0");
+                    assertThat(card.getId()).isEqualTo(card.getProcess() + ".PROCESS0");
                     assertThat(card.getStartDate()).isEqualTo(nowMinusTwo);
                 })
                 .expectComplete()
                 .verify();
         StepVerifier.create(repository.findPreviousCardWithUser(nowMinusTwo.plusMillis(1000), currentUserWithPerimeters))
                 .assertNext(card -> {
-                    assertThat(card.getId()).isEqualTo(card.getPublisher() + "_PROCESS0");
+                    assertThat(card.getId()).isEqualTo(card.getProcess() + ".PROCESS0");
                     assertThat(card.getStartDate()).isEqualTo(nowMinusTwo);
                 })
                 .expectComplete()
                 .verify();
         StepVerifier.create(repository.findPreviousCardWithUser(nowMinusTwo.minusMillis(1000), currentUserWithPerimeters))
                 .assertNext(card -> {
-                    assertThat(card.getId()).isEqualTo(card.getPublisher() + "_PROCESS6");
+                    assertThat(card.getId()).isEqualTo(card.getProcess() + ".PROCESS6");
                     assertThat(card.getStartDate()).isEqualTo(nowMinusThree);
                 })
                 .expectComplete()
@@ -231,7 +231,7 @@ public class CardRepositoryShould {
                 .expectComplete()
                 .verify();
 
-        StepVerifier.create(repository.findById("PUBLISHER_PROCESS_ID"))
+        StepVerifier.create(repository.findById("PROCESS.PROCESS_ID"))
                 .expectNextMatches(computeCardPredicate(card))
                 .expectComplete()
                 .verify();
@@ -247,7 +247,7 @@ public class CardRepositoryShould {
                 .assertNext(op -> {
                     assertThat(op.getCards().size()).isEqualTo(1);
                     assertThat(op.getPublishDate()).isEqualTo(nowMinusThree);
-                    assertCard(op, 0, "PUBLISHER_PROCESS0", "PUBLISHER", "0");
+                    assertCard(op, 0, "PROCESS.PROCESS0", "PUBLISHER", "0");
                 })
                 .expectComplete()
                 .verify();
@@ -258,7 +258,7 @@ public class CardRepositoryShould {
                 .assertNext(op -> {
                     assertThat(op.getCards().size()).isEqualTo(1);
                     assertThat(op.getPublishDate()).isEqualTo(nowMinusThree);
-                    assertCard(op, 0, "PUBLISHER_PROCESS0", "PUBLISHER", "0");
+                    assertCard(op, 0, "PROCESS.PROCESS0", "PUBLISHER", "0");
                 })
                 .expectComplete()
                 .verify();
@@ -270,9 +270,9 @@ public class CardRepositoryShould {
                 .assertNext(op -> {
                     assertThat(op.getCards().size()).isEqualTo(3);
                     assertThat(op.getPublishDate()).isEqualTo(nowMinusThree);
-                    assertCard(op, 0, "PUBLISHER_PROCESS0", "PUBLISHER", "0");
-                    assertCard(op, 1, "PUBLISHER_PROCESS2", "PUBLISHER", "0");
-                    assertCard(op, 2, "PUBLISHER_PROCESS4", "PUBLISHER", "0");
+                    assertCard(op, 0, "PROCESS.PROCESS0", "PUBLISHER", "0");
+                    assertCard(op, 1, "PROCESS.PROCESS2", "PUBLISHER", "0");
+                    assertCard(op, 2, "PROCESS.PROCESS4", "PUBLISHER", "0");
                 })
                 .expectComplete()
                 .verify();
@@ -282,13 +282,13 @@ public class CardRepositoryShould {
                 .doOnNext(TestUtilities::logCardOperation))
                 .assertNext(op -> {
                     assertThat(op.getPublishDate()).isEqualTo(nowMinusThree);
-                    assertCard(op, 0, "PUBLISHER_PROCESS0", "PUBLISHER", "0");
+                    assertCard(op, 0, "PROCESS.PROCESS0", "PUBLISHER", "0");
                 })
                 .assertNext(op -> {
                     assertThat(op.getCards().size()).isEqualTo(2);
                     assertThat(op.getPublishDate()).isEqualTo(nowPlusOne);
-                    assertCard(op, 0, "PUBLISHER_PROCESS1", "PUBLISHER", "0");
-                    assertCard(op, 1, "PUBLISHER_PROCESS9", "PUBLISHER", "0");
+                    assertCard(op, 0, "PROCESS.PROCESS1", "PUBLISHER", "0");
+                    assertCard(op, 1, "PROCESS.PROCESS9", "PUBLISHER", "0");
                 })
                 .expectComplete()
                 .verify();
@@ -309,9 +309,9 @@ public class CardRepositoryShould {
                 .assertNext(op -> {
                     assertThat(op.getCards().size()).isEqualTo(3);
                     assertThat(op.getPublishDate()).isEqualTo(nowMinusThree);
-                    assertThat(op.getCards().get(0).getId()).isEqualTo("PUBLISHER_PROCESS4");
-                    assertThat(op.getCards().get(1).getId()).isEqualTo("PUBLISHER_PROCESS5");
-                    assertThat(op.getCards().get(2).getId()).isEqualTo("PUBLISHER_PROCESS8");
+                    assertThat(op.getCards().get(0).getId()).isEqualTo("PROCESS.PROCESS4");
+                    assertThat(op.getCards().get(1).getId()).isEqualTo("PROCESS.PROCESS5");
+                    assertThat(op.getCards().get(2).getId()).isEqualTo("PROCESS.PROCESS8");
                 })
                 .expectComplete()
                 .verify();
@@ -322,10 +322,10 @@ public class CardRepositoryShould {
                 .assertNext(op -> {
                     assertThat(op.getCards().size()).isEqualTo(4);
                     assertThat(op.getPublishDate()).isEqualTo(nowMinusThree);
-                    assertThat(op.getCards().get(0).getId()).isEqualTo("PUBLISHER_PROCESS2");
-                    assertThat(op.getCards().get(1).getId()).isEqualTo("PUBLISHER_PROCESS4");
-                    assertThat(op.getCards().get(2).getId()).isEqualTo("PUBLISHER_PROCESS5");
-                    assertThat(op.getCards().get(3).getId()).isEqualTo("PUBLISHER_PROCESS8");
+                    assertThat(op.getCards().get(0).getId()).isEqualTo("PROCESS.PROCESS2");
+                    assertThat(op.getCards().get(1).getId()).isEqualTo("PROCESS.PROCESS4");
+                    assertThat(op.getCards().get(2).getId()).isEqualTo("PROCESS.PROCESS5");
+                    assertThat(op.getCards().get(3).getId()).isEqualTo("PROCESS.PROCESS8");
                 })
                 .expectComplete()
                 .verify();
@@ -336,16 +336,16 @@ public class CardRepositoryShould {
                 .assertNext(op -> {
                     assertThat(op.getCards().size()).isEqualTo(4);
                     assertThat(op.getPublishDate()).isEqualTo(nowMinusThree);
-                    assertThat(op.getCards().get(0).getId()).isEqualTo("PUBLISHER_PROCESS2");
-                    assertThat(op.getCards().get(1).getId()).isEqualTo("PUBLISHER_PROCESS4");
-                    assertThat(op.getCards().get(2).getId()).isEqualTo("PUBLISHER_PROCESS5");
-                    assertThat(op.getCards().get(3).getId()).isEqualTo("PUBLISHER_PROCESS8");
+                    assertThat(op.getCards().get(0).getId()).isEqualTo("PROCESS.PROCESS2");
+                    assertThat(op.getCards().get(1).getId()).isEqualTo("PROCESS.PROCESS4");
+                    assertThat(op.getCards().get(2).getId()).isEqualTo("PROCESS.PROCESS5");
+                    assertThat(op.getCards().get(3).getId()).isEqualTo("PROCESS.PROCESS8");
                 })
                 .assertNext(op -> {
                     assertThat(op.getCards().size()).isEqualTo(2);
                     assertThat(op.getPublishDate()).isEqualTo(nowPlusOne);
-                    assertThat(op.getCards().get(0).getId()).isEqualTo("PUBLISHER_PROCESS3");
-                    assertThat(op.getCards().get(1).getId()).isEqualTo("PUBLISHER_PROCESS10");
+                    assertThat(op.getCards().get(0).getId()).isEqualTo("PROCESS.PROCESS3");
+                    assertThat(op.getCards().get(1).getId()).isEqualTo("PROCESS.PROCESS10");
                 })
                 .expectComplete()
                 .verify();
@@ -361,11 +361,11 @@ public class CardRepositoryShould {
                 .assertNext(op -> {
                     assertThat(op.getCards().size()).isEqualTo(5);
                     assertThat(op.getPublishDate()).isEqualTo(nowMinusThree);
-                    assertThat(op.getCards().get(0).getId()).isEqualTo("PUBLISHER_PROCESS6");
-                    assertThat(op.getCards().get(1).getId()).isEqualTo("PUBLISHER_PROCESS7");
-                    assertThat(op.getCards().get(2).getId()).isEqualTo("PUBLISHER_PROCESS0");
-                    assertThat(op.getCards().get(3).getId()).isEqualTo("PUBLISHER_PROCESS2");
-                    assertThat(op.getCards().get(4).getId()).isEqualTo("PUBLISHER_PROCESS4");
+                    assertThat(op.getCards().get(0).getId()).isEqualTo("PROCESS.PROCESS6");
+                    assertThat(op.getCards().get(1).getId()).isEqualTo("PROCESS.PROCESS7");
+                    assertThat(op.getCards().get(2).getId()).isEqualTo("PROCESS.PROCESS0");
+                    assertThat(op.getCards().get(3).getId()).isEqualTo("PROCESS.PROCESS2");
+                    assertThat(op.getCards().get(4).getId()).isEqualTo("PROCESS.PROCESS4");
                 })
                 .expectComplete()
                 .verify();
@@ -379,11 +379,11 @@ public class CardRepositoryShould {
                                                     new String[]{"entity1"}, Collections.emptyList())
                 .doOnNext(TestUtilities::logCardOperation))
                 .assertNext(op -> {
-                	assertThat(op.getCards().get(0).getId()).isEqualTo("PUBLISHER_PROCESS0");
+                	assertThat(op.getCards().get(0).getId()).isEqualTo("PROCESS.PROCESS0");
                 	assertThat(op.getCards().get(0).getHasBeenAcknowledged()).isFalse();
-                	assertThat(op.getCards().get(1).getId()).isEqualTo("PUBLISHER_PROCESS2");
+                	assertThat(op.getCards().get(1).getId()).isEqualTo("PROCESS.PROCESS2");
                 	assertThat(op.getCards().get(1).getHasBeenAcknowledged()).isFalse();
-                	assertThat(op.getCards().get(2).getId()).isEqualTo("PUBLISHER_PROCESS4");
+                	assertThat(op.getCards().get(2).getId()).isEqualTo("PROCESS.PROCESS4");
                 	assertThat(op.getCards().get(2).getHasBeenAcknowledged()).isTrue();
                 })
                 .expectComplete()
@@ -397,11 +397,11 @@ public class CardRepositoryShould {
                                                       new String[]{"entity2"}, Collections.emptyList())
                 .doOnNext(TestUtilities::logCardOperation))
                 .assertNext(op -> {
-                	assertThat(op.getCards().get(0).getId()).isEqualTo("PUBLISHER_PROCESS2");
+                	assertThat(op.getCards().get(0).getId()).isEqualTo("PROCESS.PROCESS2");
                 	assertThat(op.getCards().get(0).getHasBeenAcknowledged()).isFalse();
-                	assertThat(op.getCards().get(1).getId()).isEqualTo("PUBLISHER_PROCESS4");
+                	assertThat(op.getCards().get(1).getId()).isEqualTo("PROCESS.PROCESS4");
                 	assertThat(op.getCards().get(1).getHasBeenAcknowledged()).isTrue();
-                	assertThat(op.getCards().get(2).getId()).isEqualTo("PUBLISHER_PROCESS5");
+                	assertThat(op.getCards().get(2).getId()).isEqualTo("PROCESS.PROCESS5");
                 	assertThat(op.getCards().get(2).getHasBeenAcknowledged()).isFalse();
                 })
                 .expectComplete()
@@ -415,11 +415,11 @@ public class CardRepositoryShould {
         StepVerifier.create(repository.findUrgent(now, nowMinusOne, nowPlusOne, "rte-operator", new String[]{"rte", "operator"}, new String[]{"entity1"}, Collections.emptyList())
                 .doOnNext(TestUtilities::logCardOperation))
                 .assertNext(op -> {
-                	assertThat(op.getCards().get(2).getId()).isEqualTo("PUBLISHER_PROCESS0");
+                	assertThat(op.getCards().get(2).getId()).isEqualTo("PROCESS.PROCESS0");
                 	assertThat(op.getCards().get(2).getHasBeenAcknowledged()).isFalse();
-                	assertThat(op.getCards().get(3).getId()).isEqualTo("PUBLISHER_PROCESS2");
+                	assertThat(op.getCards().get(3).getId()).isEqualTo("PROCESS.PROCESS2");
                 	assertThat(op.getCards().get(3).getHasBeenAcknowledged()).isFalse();
-                	assertThat(op.getCards().get(4).getId()).isEqualTo("PUBLISHER_PROCESS4");
+                	assertThat(op.getCards().get(4).getId()).isEqualTo("PROCESS.PROCESS4");
                 	assertThat(op.getCards().get(4).getHasBeenAcknowledged()).isTrue();
                 })
                 .expectComplete()

--- a/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/model/CardPublicationData.java
+++ b/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/model/CardPublicationData.java
@@ -120,7 +120,7 @@ public class CardPublicationData implements Card {
 
     public void prepare(Instant publishDate) {
         this.publishDate = publishDate;
-        this.id = publisher + "_" + processInstanceId;
+        this.id = process + "." + processInstanceId;
         if (null == this.uid)
         	this.uid = UUID.randomUUID().toString();
         this.setShardKey(Math.toIntExact(this.getStartDate().toEpochMilli() % 24 * 1000));

--- a/services/core/cards-publication/src/test/java/org/lfenergy/operatorfabric/cards/publication/controllers/CardControllerShouldBase.java
+++ b/services/core/cards-publication/src/test/java/org/lfenergy/operatorfabric/cards/publication/controllers/CardControllerShouldBase.java
@@ -119,7 +119,7 @@ public abstract class CardControllerShouldBase {
                         .summary(I18nPublicationData.builder().key("summary").build())
                         .startDate(Instant.now())
                         .recipient(RecipientPublicationData.builder().type(DEADEND).build())
-                        .process("process5")
+                        .process("process1")
                         .state("state5")
                         .build()
         );

--- a/services/core/cards-publication/src/test/java/org/lfenergy/operatorfabric/cards/publication/services/CardProcessServiceShould.java
+++ b/services/core/cards-publication/src/test/java/org/lfenergy/operatorfabric/cards/publication/services/CardProcessServiceShould.java
@@ -456,7 +456,7 @@ class CardProcessServiceShould {
                 .withFailMessage("The number of registered cards should be '%d' but is '%d", 1, block)
                 .isEqualTo(1);
 
-        String computedCardId = publishedCard.getPublisher() + "_" + publishedCard.getProcessInstanceId();
+        String computedCardId = publishedCard.getProcess() + "." + publishedCard.getProcessInstanceId();
         CardPublicationData cardToDelete = cardRepositoryService.findCardToDelete(computedCardId);
 
         Assertions.assertThat(cardToDelete).isNotNull();

--- a/src/docs/asciidoc/reference_doc/card_structure.adoc
+++ b/src/docs/asciidoc/reference_doc/card_structure.adoc
@@ -121,7 +121,7 @@ Unique identifier of the card in the OperatorFabric system. This attribute can b
 
 ==== id (`id`)
 
-State id of the associated process, determined by `OperatorFabric` can be set arbitrarily by the `publisher`.
+State id of the associated process, determined by `OperatorFabric` can be set arbitrarily by the `publisher`. The id is determined by 'OperatorFabric' as follow : process.processIntanceId
 
 
 === Other technical attributes

--- a/src/docs/asciidoc/resources/migration_guide.adoc
+++ b/src/docs/asciidoc/resources/migration_guide.adoc
@@ -185,7 +185,10 @@ publishers
 
 These changes impact both current cards from the feed and archived cards.
 
-=== Changes to the endpoints
+[IMPORTANT]
+The id of the card is now build as process.processInstanceId an not anymore publisherID_process.
+
+== Changes to the endpoints
 
 The `/thirds` endpoint becomes `thirds/processes` in preparation of OC-978.
 

--- a/src/test/api/karate/cards/cards.feature
+++ b/src/test/api/karate/cards/cards.feature
@@ -70,7 +70,7 @@ Feature: Cards
     And match response.count == 1
 
 #get card with user tso1-operator
-    Given url opfabUrl + 'cards/cards/api_test_process1'
+    Given url opfabUrl + 'cards/cards/api_test.process1'
     And header Authorization = 'Bearer ' + authToken
     When method get
     Then status 200
@@ -78,7 +78,7 @@ Feature: Cards
     And def cardUid = response.uid
 
     #get card without  authentication
-    Given url opfabUrl + 'cards/cards/api_test_process1'
+    Given url opfabUrl + 'cards/cards/api_test.process1'
     When method get
     Then status 401
 
@@ -86,14 +86,14 @@ Feature: Cards
   Scenario: Delete the card
 
 #get card with user tso1-operator
-    Given url opfabUrl + 'cards/cards/api_test_process1'
+    Given url opfabUrl + 'cards/cards/api_test.process1'
     And header Authorization = 'Bearer ' + authToken
     When method get
     Then status 200
     And def cardUid = response.uid
 
 # delete card
-    Given url opfabPublishCardUrl + 'cards/api_test_process1'
+    Given url opfabPublishCardUrl + 'cards/api_test.process1'
     When method delete
     Then status 200
 
@@ -224,7 +224,7 @@ Feature: Cards
     And match response.count == 1
 
 #get card with user tso1-operator and new attribute externalRecipients
-    Given url opfabUrl + 'cards/cards/api_test_process1'
+    Given url opfabUrl + 'cards/cards/api_test.process1'
     And header Authorization = 'Bearer ' + authToken
     When method get
     Then status 200
@@ -291,7 +291,7 @@ Scenario:  Post card with parentCardId not correct
 Scenario:  Post card with correct parentCardId
 
     #get parent card uid
-    Given url opfabUrl + 'cards/cards/api_test_process1'
+    Given url opfabUrl + 'cards/cards/api_test.process1'
     And header Authorization = 'Bearer ' + authToken
     When method get
     Then status 200
@@ -357,7 +357,7 @@ Scenario: Push card and its two child cards, then get the parent card
     And match response.message == "All pushedCards were successfully handled"
 
 #get parent card uid
-    Given url opfabUrl + 'cards/cards/api_test_process1'
+    Given url opfabUrl + 'cards/cards/api_test.process1'
     And header Authorization = 'Bearer ' + authToken
     When method get
     Then status 200
@@ -424,7 +424,7 @@ Scenario: Push card and its two child cards, then get the parent card
 
 # Get the parent card with its two child cards
 
-    Given url opfabUrl + 'cards/cards/api_test_process1'
+    Given url opfabUrl + 'cards/cards/api_test.process1'
     And header Authorization = 'Bearer ' + authToken
     When method get
     Then status 200
@@ -461,7 +461,7 @@ Scenario: Push a card for a user with no group and no entity
     And match response.count == 1
 
 #get card with user userwithnogroupnoentity
-    Given url opfabUrl + 'cards/cards/api_test_processForUserWithNoGroupNoEntity'
+    Given url opfabUrl + 'cards/cards/api_test.processForUserWithNoGroupNoEntity'
     And header Authorization = 'Bearer ' + authTokenUserWithNoGroupNoEntity
     When method get
     Then status 200

--- a/src/test/api/karate/cards/cardsUserAcks.feature
+++ b/src/test/api/karate/cards/cardsUserAcks.feature
@@ -41,7 +41,7 @@ Feature: CardsUserAcknowledgement
     And match response.count == 1
     
 #get card with user tso1-operator and check not containing userAcks items
-    Given url opfabUrl + 'cards/cards/api_test_process1'
+    Given url opfabUrl + 'cards/cards/api_test.process1'
     And header Authorization = 'Bearer ' + authToken
     When method get
     Then status 200
@@ -57,7 +57,7 @@ Feature: CardsUserAcknowledgement
     Then status 201
 
 #get card with user tso1-operator and check containing his ack
-    Given url opfabUrl + 'cards/cards/api_test_process1'
+    Given url opfabUrl + 'cards/cards/api_test.process1'
     And header Authorization = 'Bearer ' + authToken
     When method get
     Then status 200
@@ -65,7 +65,7 @@ Feature: CardsUserAcknowledgement
     And match response.card.uid == uid
 
 #get card with user tso2-operator and check containing no ack for him
-    Given url opfabUrl + 'cards/cards/api_test_process1'
+    Given url opfabUrl + 'cards/cards/api_test.process1'
     And header Authorization = 'Bearer ' + authToken2
     When method get
     Then status 200
@@ -81,7 +81,7 @@ Feature: CardsUserAcknowledgement
     Then status 201
 
 #get card with user tso1-operator and check containing his ack
-    Given url opfabUrl + 'cards/cards/api_test_process1'
+    Given url opfabUrl + 'cards/cards/api_test.process1'
     And header Authorization = 'Bearer ' + authToken
     When method get
     Then status 200
@@ -89,7 +89,7 @@ Feature: CardsUserAcknowledgement
     And match response.card.uid == uid
 
 #get card with user tso2-operator and check containing his ack
-    Given url opfabUrl + 'cards/cards/api_test_process1'
+    Given url opfabUrl + 'cards/cards/api_test.process1'
     And header Authorization = 'Bearer ' + authToken2
     When method get
     Then status 200
@@ -111,7 +111,7 @@ Feature: CardsUserAcknowledgement
     When method delete
     Then status 200
 
-    Given url opfabUrl + 'cards/cards/api_test_process1'
+    Given url opfabUrl + 'cards/cards/api_test.process1'
     And header Authorization = 'Bearer ' + authToken
     When method get
     Then status 200
@@ -132,6 +132,6 @@ Feature: CardsUserAcknowledgement
   Scenario: Delete the test card
 
     delete card
-    Given url opfabPublishCardUrl + 'cards/api_test_process1'
+    Given url opfabPublishCardUrl + 'cards/api_test.process1'
     When method delete
     Then status 200

--- a/src/test/api/karate/cards/delete3BigCards.feature
+++ b/src/test/api/karate/cards/delete3BigCards.feature
@@ -5,14 +5,14 @@ Scenario: Delete cards sent via post3BigCards.feature
 
 
 # delete cards
-Given url opfabPublishCardUrl + 'cards/APOGEESEA_SEA0'
+Given url opfabPublishCardUrl + 'cards/APOGEESEA.SEA0'
 When method delete
 Then status 200
 
-Given url opfabPublishCardUrl + 'cards/APOGEESEA_SEA1'
+Given url opfabPublishCardUrl + 'cards/APOGEESEA.SEA1'
 When method delete
 Then status 200
 
-Given url opfabPublishCardUrl + 'cards/APOGEESEA_SEA2'
+Given url opfabPublishCardUrl + 'cards/APOGEESEA.SEA2'
 When method delete
 Then status 200

--- a/src/test/api/karate/cards/deleteCardFor3Users.feature
+++ b/src/test/api/karate/cards/deleteCardFor3Users.feature
@@ -4,6 +4,6 @@ Feature: Cards
 Scenario: Delete cards sent via postCardFor3Users.feature
 
 # delete cards
-Given url opfabPublishCardUrl + 'cards/api_test_process3users'
+Given url opfabPublishCardUrl + 'cards/api_test.process3users'
 When method delete
 Then status 200

--- a/src/test/api/karate/cards/fetchArchivedCard.feature
+++ b/src/test/api/karate/cards/fetchArchivedCard.feature
@@ -39,7 +39,7 @@ Feature: fetchArchive
 
 
 #get card with user tso1-operator
-    Given url opfabUrl + 'cards/cards/api_test_process_archive_1'
+    Given url opfabUrl + 'cards/cards/api_test.process_archive_1'
     And header Authorization = 'Bearer ' + authToken
     When method get
     Then status 200
@@ -103,7 +103,7 @@ Feature: fetchArchive
 
 
 #get card with user tso1-operator
-        Given url opfabUrl + 'cards/cards/api_test123_process1'
+        Given url opfabUrl + 'cards/cards/api_test.process1'
         And header Authorization = 'Bearer ' + authToken
         When method get
         Then status 200

--- a/src/test/api/karate/cards/post1BigCards.feature
+++ b/src/test/api/karate/cards/post1BigCards.feature
@@ -20,7 +20,7 @@ And match response.count == 1
 
 
 #get card with user tso1-operator
-Given url opfabUrl + 'cards/cards/APOGEESEA_SEA0' 
+Given url opfabUrl + 'cards/cards/APOGEESEA.SEA0' 
 And header Authorization = 'Bearer ' + authToken 
 When method get
 Then status 200

--- a/src/test/api/karate/cards/post1CardThenUpdateThenDelete.feature
+++ b/src/test/api/karate/cards/post1CardThenUpdateThenDelete.feature
@@ -37,7 +37,7 @@ Then status 201
 And match response.count == 1
 
 #get card with user tso1-operator
-Given url opfabUrl + 'cards/cards/api_test_process1' 
+Given url opfabUrl + 'cards/cards/api_test.process1' 
 And header Authorization = 'Bearer ' + authToken 
 When method get
 Then status 200
@@ -82,7 +82,7 @@ Then status 201
 And match response.count == 1
 
 #get card with user tso1-operator
-Given url opfabUrl + 'cards/cards/api_test_process1' 
+Given url opfabUrl + 'cards/cards/api_test.process1' 
 And header Authorization = 'Bearer ' + authToken 
 When method get
 Then status 200
@@ -102,19 +102,19 @@ Scenario: Delete the card
 
 
 #get card with user tso1-operator
-Given url opfabUrl + 'cards/cards/api_test_process1' 
+Given url opfabUrl + 'cards/cards/api_test.process1' 
 And header Authorization = 'Bearer ' + authToken 
 When method get
 Then status 200
 And def cardUid = response.card.uid
 
 # delete card
-Given url opfabPublishCardUrl + 'cards/api_test_process1'
+Given url opfabPublishCardUrl + 'cards/api_test.process1'
 When method delete
 Then status 200
 
 #get card with user tso1-operator should return 404
-Given url opfabUrl + 'cards/cards/api_test_process1' 
+Given url opfabUrl + 'cards/cards/api_test.process1' 
 And header Authorization = 'Bearer ' + authToken 
 When method get
 Then status 404

--- a/src/test/api/karate/cards/post2CardsGroupRouting.feature
+++ b/src/test/api/karate/cards/post2CardsGroupRouting.feature
@@ -40,7 +40,7 @@ Then status 201
 And match response.count == 1
 
 #get card with user tso1-operator
-Given url opfabUrl + 'cards/cards/api_test_process2' 
+Given url opfabUrl + 'cards/cards/api_test.process2' 
 And header Authorization = 'Bearer ' + authTokenTso1 
 When method get
 Then status 200
@@ -57,7 +57,7 @@ And match response.data.message == 'a message for group TSO1'
 
 
 #get card with user tso2-operator should not be possible
-Given url opfabUrl + 'cards/cards/api_test_process2' 
+Given url opfabUrl + 'cards/cards/api_test.process2' 
 And header Authorization = 'Bearer ' + authTokenTso2 
 When method get
 Then status 404
@@ -105,7 +105,7 @@ Then status 201
 And match response.count == 1
 
 #get card with user tso1-operator
-Given url opfabUrl + 'cards/cards/api_test_process2tso' 
+Given url opfabUrl + 'cards/cards/api_test.process2tso' 
 And header Authorization = 'Bearer ' + authTokenTso1 
 When method get
 Then status 200
@@ -122,7 +122,7 @@ And match response.data.message == 'a message for groups TSO1 and TSO2'
 
 
 #get card with user tso2-operator should be possible
-Given url opfabUrl + 'cards/cards/api_test_process2tso' 
+Given url opfabUrl + 'cards/cards/api_test.process2tso' 
 And header Authorization = 'Bearer ' + authTokenTso2 
 When method get
 Then status 200

--- a/src/test/api/karate/cards/postCardFor3Users.feature
+++ b/src/test/api/karate/cards/postCardFor3Users.feature
@@ -54,7 +54,7 @@ Then status 201
 And match response.count == 1
 
 #get card with user tso1-operator
-Given url opfabUrl + 'cards/cards/api_test_process3users' 
+Given url opfabUrl + 'cards/cards/api_test.process3users' 
 And header Authorization = 'Bearer ' + authToken 
 When method get
 Then status 200

--- a/src/test/api/karate/cards/userAcknowledgmentUpdateCheck.feature
+++ b/src/test/api/karate/cards/userAcknowledgmentUpdateCheck.feature
@@ -38,7 +38,7 @@ Feature: CardsUserAcknowledgementUpdateCheck
     Then status 201
     And match response.count == 1
 
-    Given url opfabUrl + 'cards/cards/api_test_process1'
+    Given url opfabUrl + 'cards/cards/api_test.process1'
     And header Authorization = 'Bearer ' + authToken
     When method get
     Then status 200
@@ -53,7 +53,7 @@ Feature: CardsUserAcknowledgementUpdateCheck
     Then status 201
 
 #get card with user tso1-operator and check containing his ack
-    Given url opfabUrl + 'cards/cards/api_test_process1'
+    Given url opfabUrl + 'cards/cards/api_test.process1'
     And header Authorization = 'Bearer ' + authToken
     When method get
     Then status 200
@@ -91,7 +91,7 @@ Feature: CardsUserAcknowledgementUpdateCheck
     And match response.count == 1
 
     #get card with user tso1-operator and check containing any ack
-    Given url opfabUrl + 'cards/cards/api_test_process1'
+    Given url opfabUrl + 'cards/cards/api_test.process1'
     And header Authorization = 'Bearer ' + authToken
     When method get
     Then status 200
@@ -102,6 +102,6 @@ Feature: CardsUserAcknowledgementUpdateCheck
   Scenario: Delete the test card
 
     delete card
-    Given url opfabPublishCardUrl + 'cards/api_test_process1'
+    Given url opfabPublishCardUrl + 'cards/api_test.process1'
     When method delete
     Then status 200

--- a/src/test/api/karate/users/perimeters/postCardRoutingPerimeters.feature
+++ b/src/test/api/karate/users/perimeters/postCardRoutingPerimeters.feature
@@ -204,7 +204,7 @@ Feature: CreatePerimeters (endpoint tested : POST /perimeters)
 
 
   Scenario: Get the card 'cardForGroup'
-    Given url opfabUrl + 'cards/cards/api_test_cardForGroup'
+    Given url opfabUrl + 'cards/cards/api_test.cardForGroup'
     And header Authorization = 'Bearer ' + authTokenAsTSO
     When method get
     Then status 200
@@ -212,14 +212,14 @@ Feature: CreatePerimeters (endpoint tested : POST /perimeters)
 
 
   Scenario: Get the card 'cardForEntityWithoutPerimeter'
-    Given url opfabUrl + 'cards/cards/api_test_cardForEntityWithoutPerimeter'
+    Given url opfabUrl + 'cards/cards/api_test.cardForEntityWithoutPerimeter'
     And header Authorization = 'Bearer ' + authTokenAsTSO
     When method get
     Then status 404
 
 
   Scenario: Get the card 'cardForEntityAndPerimeter'
-    Given url opfabUrl + 'cards/cards/api_test_cardForEntityAndPerimeter'
+    Given url opfabUrl + 'cards/cards/process1.cardForEntityAndPerimeter'
     And header Authorization = 'Bearer ' + authTokenAsTSO
     When method get
     Then status 200
@@ -227,7 +227,7 @@ Feature: CreatePerimeters (endpoint tested : POST /perimeters)
 
 
   Scenario: Get the card 'cardForEntityAndGroup'
-    Given url opfabUrl + 'cards/cards/api_test_cardForEntityAndGroup'
+    Given url opfabUrl + 'cards/cards/api_test.cardForEntityAndGroup'
     And header Authorization = 'Bearer ' + authTokenAsTSO
     When method get
     Then status 200
@@ -235,7 +235,7 @@ Feature: CreatePerimeters (endpoint tested : POST /perimeters)
 
 
   Scenario: Get the card 'cardForEntityAndOtherGroupAndPerimeter'
-    Given url opfabUrl + 'cards/cards/api_test_cardForEntityAndOtherGroupAndPerimeter'
+    Given url opfabUrl + 'cards/cards/process1.cardForEntityAndOtherGroupAndPerimeter'
     And header Authorization = 'Bearer ' + authTokenAsTSO
     When method get
     Then status 200

--- a/src/test/utils/karate/cards/delete6CardsSeverity.feature
+++ b/src/test/utils/karate/cards/delete6CardsSeverity.feature
@@ -5,26 +5,26 @@ Scenario: Delete cards sent via postCardsSeverity.feature
 
 
 # delete cards
-Given url opfabPublishCardUrl + 'cards/api_test_process2'
+Given url opfabPublishCardUrl + 'cards/api_test.process1'
 When method delete
 Then status 200
 
-Given url opfabPublishCardUrl + 'cards/api_test_process2b'
+Given url opfabPublishCardUrl + 'cards/api_test.process2'
 When method delete
 Then status 200
 
-Given url opfabPublishCardUrl + 'cards/api_test_process3'
+Given url opfabPublishCardUrl + 'cards/api_test.process3'
 When method delete
 Then status 200
 
-Given url opfabPublishCardUrl + 'cards/api_test_process4'
+Given url opfabPublishCardUrl + 'cards/api_test.process4'
 When method delete
 Then status 200
 
-Given url opfabPublishCardUrl + 'cards/api_test_process5'
+Given url opfabPublishCardUrl + 'cards/api_test.process5'
 When method delete
 Then status 200
 
-Given url opfabPublishCardUrl + 'cards/api_test_process5b'
+Given url opfabPublishCardUrl + 'cards/api_test.process6'
 When method delete
 Then status 200

--- a/src/test/utils/karate/cards/post6CardsSeverity.feature
+++ b/src/test/utils/karate/cards/post6CardsSeverity.feature
@@ -20,7 +20,7 @@ Scenario: Post 6 Cards (2 INFORMATION, 1 COMPLIANT, 1 ACTION, 2 ALARM)
 			"publisher" : "api_test",
 			"processVersion" : "1",
 			"process"  :"api_test",
-			"processInstanceId" : "process2",
+			"processInstanceId" : "process1",
 			"state": "messageState",
 			"tags":["test","test2"],
 			"recipient" : {
@@ -72,7 +72,7 @@ And match response.count == 1
 			"publisher" : "api_test",
 			"processVersion" : "1",
 			"process"  :"api_test",
-			"processInstanceId" : "process2b",
+			"processInstanceId" : "process2",
 			"state": "chartState",
 			"tags" : ["test2"],
 			"recipient" : {
@@ -119,7 +119,7 @@ And match response.count == 1
 			"publisher" : "api_test",
 			"processVersion" : "1",
 			"process"  :"api_test",
-			"processInstanceId" : "processProcess",
+			"processInstanceId" : "process3",
 			"state": "processState",
 			"recipient" : {
 						"type" : "GROUP",
@@ -247,7 +247,7 @@ And match response.count == 1
 			"publisher" : "api_test",
 			"processVersion" : "1",
 			"process"  :"api_test",
-			"processInstanceId" : "process5b",
+			"processInstanceId" : "process6",
 			"state": "messageState",
 			"recipient" : {
 						"type" : "GROUP",

--- a/src/test/utils/karate/operatorfabric-getting-started/message_delete.feature
+++ b/src/test/utils/karate/operatorfabric-getting-started/message_delete.feature
@@ -5,11 +5,11 @@ Scenario: Delete 2 cards sent via message1.feature and message2.feature
 
 
 # delete cards
-Given url opfabPublishCardUrl + 'cards/message-publisher_hello-world-1'
+Given url opfabPublishCardUrl + 'cards/message-publisher.hello-world-1'
 When method delete
 Then status 200
 
-Given url opfabPublishCardUrl + 'cards/message-publisher_hello-world-2'
+Given url opfabPublishCardUrl + 'cards/message-publisher.hello-world-2'
 When method delete
 Then status 200
 


### PR DESCRIPTION

RELEASE NOTE :
[OC-981]Change way of creating card id . The id of the card is now build as process.processInstanceId and not anymore publisherID_process.

[OC-981]: https://opfab.atlassian.net/browse/OC-981