### PR TITLE
[OC-1035] docker mode : cards and archivedCards in "test" instead of …

### DIFF
--- a/config/docker/common-docker.yml
+++ b/config/docker/common-docker.yml
@@ -17,6 +17,7 @@ spring:
           jwk-set-uri: http://keycloak:8080/auth/realms/dev/protocol/openid-connect/certs
   data:
     mongodb:
+      database: operator-fabric
       uris:
         - mongodb://root:password@mongodb:27017/operator-fabric?authSource=admin&authMode=scram-sha1
 


### PR DESCRIPTION
Release note : 
[OC-1035](https://opfab.atlassian.net/browse/OC-1035) : docker mode : cards and archivedCards in "test" instead of "operator-fabric"