### PR TITLE
[OC-992] Fixing doc generation warnings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ import com.github.jk1.license.render.*
 plugins {
     id "com.github.jk1.dependency-license-report" version "1.6"
     id "com.moowork.node" version "1.2.0"
-    id "org.asciidoctor.convert" version "1.5.9.2"
+    id "org.asciidoctor.convert" version "1.5.10"
     id "maven-publish"
     id "signing"
     id "org.owasp.dependencycheck" version "5.2.0"

--- a/src/docs/asciidoc/CICD/release_process.adoc
+++ b/src/docs/asciidoc/CICD/release_process.adoc
@@ -138,13 +138,13 @@ IMPORTANT: If you also want the new docker images to be tagged `latest` (as shou
 versions), you should add the keyword `ci_latest` to the merge commit message.
 
 ----
-git tag X.X.X.RELEASE <4>
-git push <5>
-git push origin X.X.X.RELEASE <6>
+git tag X.X.X.RELEASE <1>
+git push <2>
+git push origin X.X.X.RELEASE <3>
 ----
-<4> Tag the commit with the `X.X.X.RELEASE` tag
-<5> Push the commits to update the remote `master` branch
-<6> Push the tag
+<1> Tag the commit with the `X.X.X.RELEASE` tag
+<2> Push the commits to update the remote `master` branch
+<3> Push the tag
 
 . Check that the build is correctly triggered
 +

--- a/src/docs/asciidoc/dev_env/index.adoc
+++ b/src/docs/asciidoc/dev_env/index.adoc
@@ -38,4 +38,4 @@ include::troubleshooting.adoc[leveloffset=+1]
 
 include::keycloak-configuration.adoc[leveloffset=+1]
 
-include::token.adoc[leveloffsets=+1]
+include::token.adoc[leveloffset=+1]


### PR DESCRIPTION
Tested by generating documentation locally and comparing using Git, no changes to output files.
No mention necessary in release notes I think.