### PR TITLE
[OC-862] Removing last container name from infra

### DIFF
--- a/config/docker/docker-compose.yml
+++ b/config/docker/docker-compose.yml
@@ -8,7 +8,6 @@ services:
       MONGO_INITDB_ROOT_USERNAME: root
       MONGO_INITDB_ROOT_PASSWORD: password
   rabbitmq:
-    container_name: rabbitmq
     image: rabbitmq:3-management
     ports:
       - "5672:5672"


### PR DESCRIPTION
There was only one instance left of container_name being used for an "infra" service, so I removed it for consistency.
Given that it's rabbitmq (so no data in persisted there) there shouldn't be any impact for users so I don't know if it's worth mentioning in the release notes, they are quite long as it is.