### PR TITLE
[OC-1066] Remove use of 18n key object

### DIFF
--- a/services/core/businessconfig/src/main/docker/volume/businessconfig-storage/TEST/1/config.json
+++ b/services/core/businessconfig/src/main/docker/volume/businessconfig-storage/TEST/1/config.json
@@ -1,9 +1,7 @@
 {
   "id": "TEST",
   "version": "1",
-  "name": {
-    "key": "process.label"
-  },
+  "name": "process.label",
   "defaultLocale": "fr",
   "templates": [
     "security",
@@ -34,9 +32,7 @@
   ],
   "states": {
     "firstState": {
-      "name": {
-        "key": "process.label"
-      },
+      "name":  "state.label",
       "color": "blue",
       "details": [
         {
@@ -45,7 +41,8 @@
           },
           "templateName": "operation"
         }
-      ]
+      ],
+      "acknowledgementAllowed": false
     }
   }
 }

--- a/services/core/businessconfig/src/main/docker/volume/businessconfig-storage/TEST/1/i18n/en.json
+++ b/services/core/businessconfig/src/main/docker/volume/businessconfig-storage/TEST/1/i18n/en.json
@@ -24,6 +24,9 @@
   "process": {
     "label": "Test Process"
   },
+  "state": {
+    "label": "Test State"
+  },
   "menu": {
     "label": "Test Process Menu",
     "first": "First Entry",
@@ -31,6 +34,5 @@
   },
   "template": {
     "title": "Asset details"
-  },
-  "state": "First State"
+  }
 }

--- a/services/core/businessconfig/src/main/docker/volume/businessconfig-storage/TEST/1/i18n/fr.json
+++ b/services/core/businessconfig/src/main/docker/volume/businessconfig-storage/TEST/1/i18n/fr.json
@@ -24,6 +24,9 @@
   "process":{
     "label": "Processus de test"
   },
+  "state": {
+    "label": "State de test"
+  },
   "menu":{
     "label": "Menu du Processus de Test",
     "first":"Premier item",
@@ -32,5 +35,4 @@
   "template": {
     "title": "Onglet TEST"
   },
-  "state": "État premier"
 }

--- a/services/core/businessconfig/src/main/docker/volume/businessconfig-storage/TEST/config.json
+++ b/services/core/businessconfig/src/main/docker/volume/businessconfig-storage/TEST/config.json
@@ -1,9 +1,7 @@
 {
   "id": "TEST",
   "version": "1",
-  "name": {
-    "key": "TEST.1.process.label"
-  },
+  "name": "process.label",
   "defaultLocale": "fr",
   "templates": [
     "security",
@@ -34,9 +32,7 @@
   ],
   "states": {
     "firstState": {
-      "name": {
-        "key": "process.label"
-      },
+      "name":  "state.label",
       "color": "blue",
       "details": [
         {

--- a/services/core/businessconfig/src/main/java/org/lfenergy/operatorfabric/businessconfig/model/ProcessData.java
+++ b/services/core/businessconfig/src/main/java/org/lfenergy/operatorfabric/businessconfig/model/ProcessData.java
@@ -33,7 +33,7 @@ import java.util.Map;
 public class ProcessData implements Process {
 
   private String id;
-  private I18n name;
+  private String name;
   private String version;
   @Singular
   private List<String> templates;

--- a/services/core/businessconfig/src/main/java/org/lfenergy/operatorfabric/businessconfig/model/ProcessStatesData.java
+++ b/services/core/businessconfig/src/main/java/org/lfenergy/operatorfabric/businessconfig/model/ProcessStatesData.java
@@ -25,7 +25,7 @@ public class ProcessStatesData implements ProcessStates {
     private ResponseData responseData;
     private Boolean acknowledgementAllowed;
     private String color;
-    private I18n name;
+    private String name;
 
     @Override
     public void setDetails(List<? extends Detail> details) {

--- a/services/core/businessconfig/src/main/modeling/swagger.yaml
+++ b/services/core/businessconfig/src/main/modeling/swagger.yaml
@@ -367,7 +367,7 @@ definitions:
         type: string
         description: Identifier referencing this process. It should be unique across the OperatorFabric instance.
       name:
-        $ref: '#/definitions/I18n'
+        type: string
         description: >-
           i18n key for the label of this process
           The value attached to this key should be defined in each XX.json file in the i18n folder of the bundle (where
@@ -403,7 +403,7 @@ definitions:
               type: boolean
               description: This flag indicates the possibility for a card of this kind to be acknowledged on user basis
             name:
-              $ref: '#/definitions/I18n'
+              type: string
               description: i18n key for UI
             color:
               type: string

--- a/services/core/businessconfig/src/test/data/bundles/second/2.0/config.json
+++ b/services/core/businessconfig/src/test/data/bundles/second/2.0/config.json
@@ -1,6 +1,6 @@
 {
   "id": "second",
-  "name": {"key":"process.title"},
+  "name": "process.title",
   "version": "2.0",
   "templates": [
     "template"
@@ -14,7 +14,7 @@
   ],
   "states": {
     "firstState": {
-      "name": {"key": "process.title"},
+      "name": "process.title",
       "details": [
         {
           "title": {

--- a/services/core/businessconfig/src/test/data/bundles/second/2.1/config.json
+++ b/services/core/businessconfig/src/test/data/bundles/second/2.1/config.json
@@ -1,6 +1,6 @@
 {
   "id": "second",
-  "name": {"key": "process.title"},
+  "name": "process.title",
   "version": "2.1",
   "templates": [
     "template"
@@ -16,7 +16,7 @@
     "testProcess": {
       "states": {
         "firstState": {
-          "name": {"key": "process.title"},
+          "name": "process.title",
           "details": [
             {
               "title": {

--- a/services/core/businessconfig/src/test/java/org/lfenergy/operatorfabric/businessconfig/controllers/GivenAdminUserThirdControllerShould.java
+++ b/services/core/businessconfig/src/test/java/org/lfenergy/operatorfabric/businessconfig/controllers/GivenAdminUserThirdControllerShould.java
@@ -268,7 +268,7 @@ class GivenAdminUserBusinessconfigControllerShould {
                     .andExpect(header().string("Location", "/businessconfig/processes/second"))
                     .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                     .andExpect(jsonPath("$.id", is("second")))
-                    .andExpect(jsonPath("$.name.key", is("process.title")))
+                    .andExpect(jsonPath("$.name", is("process.title")))
                     .andExpect(jsonPath("$.version", is("2.1")))
             ;
 

--- a/src/docs/asciidoc/resources/migration_guide.adoc
+++ b/src/docs/asciidoc/resources/migration_guide.adoc
@@ -60,7 +60,11 @@ Below is a summary of the changes to the `config.json` file that all this entail
 
 |
 |name
-|I18n key for process display name. Will probably be used for Free Message and maybe filters
+|I18n key for process display name. 
+
+|
+|states.mystate.name
+|I18n key for state display name. 
 
 |i18nLabelKey
 |menuLabel
@@ -148,6 +152,7 @@ Here is an example of a simple config.json file:
   ],
   "states": {
     "firstState": {
+      "name" :"mystate.label",
       "details": [
         {
           "title": {

--- a/src/test/api/karate/businessconfig/resources/bundle_api_test/i18n/en.json
+++ b/src/test/api/karate/businessconfig/resources/bundle_api_test/i18n/en.json
@@ -1,5 +1,9 @@
 {
 	"detail":{
 		"title":"Message"
+	},
+	"defaultProcess": {
+		"title" : "card Title",
+		"title2" : "card Title II"
 	}
 }

--- a/src/test/api/karate/businessconfig/resources/bundle_api_test/i18n/fr.json
+++ b/src/test/api/karate/businessconfig/resources/bundle_api_test/i18n/fr.json
@@ -1,5 +1,9 @@
 {
 	"detail":{
 		"title":"Message"
+	},
+	"defaultProcess": {
+		"title" : "Titre de la carte",
+		"title2" : "Titre de la carte II"
 	}
 }

--- a/src/test/utils/karate/businessconfig/resources/bundle_defaultProcess/config.json
+++ b/src/test/utils/karate/businessconfig/resources/bundle_defaultProcess/config.json
@@ -1,8 +1,6 @@
 {
   "id": "defaultProcess",
-  "name": {
-    "key": "Test api"
-  },
+  "name": "Test api",
   "version": "1",
   "templates": [
     "template",
@@ -16,9 +14,7 @@
   ],
   "states": {
     "messageState": {
-      "name": {
-        "key": "defaultProcess.title"
-      },
+      "name":  "defaultProcess.title",
       "color": "#FAF0AF",
       "details": [
         {
@@ -34,9 +30,7 @@
       "acknowledgementAllowed": true
     },
     "chartState": {
-      "name": {
-        "key": "chartDetail.title"
-      },
+      "name": "chartDetail.title",
       "color": "#f1c5c5",
       "details": [
         {
@@ -52,9 +46,7 @@
       "acknowledgementAllowed": true
     },
     "chartLineState": {
-      "name": {
-        "key": "chartLine.title"
-      },
+      "name": "chartLine.title",
       "color": "#e5edb7",
       "details": [
         {
@@ -70,9 +62,7 @@
       "acknowledgementAllowed": true
     },
     "processState": {
-      "name": {
-        "key": "process.title"
-      },
+      "name": "process.title",
       "color": "#8bcdcd",
       "details": [
         {
@@ -88,9 +78,7 @@
       "acknowledgementAllowed": true
     },
     "questionState": {
-      "name": {
-        "key": "question.title"
-      },
+      "name": "question.title",
       "color": "#8bcdcd",
       "response": {
         "lock": true,

--- a/ui/main/src/app/model/processes.model.ts
+++ b/ui/main/src/app/model/processes.model.ts
@@ -17,16 +17,14 @@ export class Process {
     constructor(
         readonly id: string,
         readonly version: string,
-        readonly name?: I18n | string,
+        readonly name?: string,
         readonly templates?: string[],
         readonly csses?: string[],
         readonly locales?: string[],
         readonly menuLabel?: string,
         readonly menuEntries?: MenuEntry[],
         readonly states?: OfMap<State>
-    ) { if ( !(name instanceof I18n)) {
-            name = new I18n(name);
-    }
+    ) { 
     }
 
     public extractState(card: Card): State {
@@ -38,7 +36,7 @@ export class Process {
     }
 }
 
-export const unfouundProcess: Process = new Process('', '', new I18n('process.not-found'),
+export const unfouundProcess: Process = new Process('', '', 'process.not-found',
      [], [], [], '', [], null);
 
 export class MenuEntry {
@@ -77,7 +75,7 @@ export class State {
         readonly details?: Detail[],
         readonly response?: Response,
         readonly acknowledgementAllowed?: boolean,
-        readonly name?: I18n,
+        readonly name?: string,
         readonly color?: string
     ) {
     }

--- a/ui/main/src/app/modules/monitoring/monitoring.component.ts
+++ b/ui/main/src/app/modules/monitoring/monitoring.component.ts
@@ -71,7 +71,7 @@ export class MonitoringComponent implements OnInit, OnDestroy, AfterViewInit {
                     }
                     return cards.map(card => {
                             let color = 'white';
-                            let name: I18n;
+                            let name: string;
                             const procId = card.process;
                             if (!!this.mapOfProcesses && this.mapOfProcesses.has(procId)) {
                                 const currentProcess = this.mapOfProcesses.get(procId);
@@ -95,7 +95,7 @@ export class MonitoringComponent implements OnInit, OnDestroy, AfterViewInit {
                                     summary: this.prefixI18nKey(card, 'summary'),
                                     trigger: 'source ?',
                                     coordinationStatusColor: color,
-                                    coordinationStatus: this.prefixForTranslation(card, name.key),
+                                    coordinationStatus: this.prefixForTranslation(card, name),
                                     cardId: card.id
 
                                 } as LineOfMonitoringResult);


### PR DESCRIPTION
Instead of using i18n objects in the config.json of the bundles
to represent  the name of the processes (json field "name" in the bundle)
and the name of states (json field "name" in the state definition)
, use  a string representing the i18 key .

RELEASE NOTE : nothing to add as this objects was not existing in previous release