### PR TITLE
[OC-1098] Add day/night mode information in requests

### DIFF
--- a/src/docs/asciidoc/reference_doc/ui_customization.adoc
+++ b/src/docs/asciidoc/reference_doc/ui_customization.adoc
@@ -84,3 +84,15 @@ Here a sample with 3 menu entries.
 		}]
 }
 ....
+
+=== Operator Fabric theme
+
+If the page opened via the menu is in a iframe, the current theme of operator fabric will be passed as a parameter in the request send to the web site. The parameter is named opfab_theme and has the value of the current theme : DAY, NIGHT or LEGACY. 
+
+Example : 
+
+....
+ http://mysite.com/index.htm?opfab_theme=NIGHT 
+....
+
+When user is switching theme and the iframe is opened, the iframe will be reloaded.

--- a/ui/main/src/app/modules/businessconfigparty/iframedisplay.component.ts
+++ b/ui/main/src/app/modules/businessconfigparty/iframedisplay.component.ts
@@ -9,12 +9,16 @@
 
 
 
-import {Component, OnInit} from '@angular/core';
-import {DomSanitizer, SafeUrl} from "@angular/platform-browser";
-import {ActivatedRoute} from '@angular/router';
+import { Component, OnInit, OnDestroy } from '@angular/core';
+import { DomSanitizer, SafeUrl } from '@angular/platform-browser';
+import { ActivatedRoute } from '@angular/router';
 import { ProcessesService } from '@ofServices/processes.service';
-import { concatMap, map } from 'rxjs/operators';
-import { Observable } from 'rxjs';
+import { concatMap, map, takeUntil, skip } from 'rxjs/operators';
+import { Observable, Subject } from 'rxjs';
+import { Store } from '@ngrx/store';
+import { AppState } from '@ofStore/index';
+import { selectGlobalStyleState } from '@ofSelectors/global-style.selectors';
+import { GlobalStyleService } from '@ofServices/global-style.service';
 
 
 @Component({
@@ -22,22 +26,55 @@ import { Observable } from 'rxjs';
   templateUrl: './iframedisplay.component.html',
   styleUrls: ['./iframedisplay.component.scss']
 })
-export class IframeDisplayComponent implements OnInit {
+export class IframeDisplayComponent implements OnInit, OnDestroy {
 
   public iframeURL: Observable<SafeUrl>;
+  unsubscribe$: Subject<void> = new Subject<void>();
 
   constructor(
-              private sanitizer: DomSanitizer,
-              private route: ActivatedRoute,
-              private businessconfigService : ProcessesService
-  ) { }
+    private sanitizer: DomSanitizer,
+    private route: ActivatedRoute,
+    private businessconfigService: ProcessesService,
+    private store: Store<AppState>,
+    private globalStyleService: GlobalStyleService
+  ) {
+   }
 
   ngOnInit() {
-    this.iframeURL = this.route.paramMap.pipe(concatMap( paramMap =>
-      this.businessconfigService.queryMenuEntryURL(paramMap.get("menu_id"),paramMap.get("menu_version"),paramMap.get("menu_entry_id"))
-    )).pipe(map( this.sanitizer.bypassSecurityTrustResourceUrl ));
-    
-  
+    this.loadIframe();
+    this.reloadIframeWhenGlobalStyleChange();
+  }
+
+
+  private loadIframe() {
+    this.iframeURL = this.route.paramMap.pipe(
+    concatMap(paramMap =>
+      this.businessconfigService.queryMenuEntryURL(paramMap.get("menu_id"), paramMap.get("menu_version"), paramMap.get("menu_entry_id"))
+    ),
+    map((url) => this.addOpfabThemeParamToUrl(url)),
+    map(this.sanitizer.bypassSecurityTrustResourceUrl));
+  }
+
+
+  private addOpfabThemeParamToUrl(url: string ): string {
+    this.globalStyleService.getStyle();
+    url += (url.includes('?')) ? '&' : '?';
+    url += 'opfab_theme=';
+    url += this.globalStyleService.getStyle();
+    return url;
+  }
+
+
+  private reloadIframeWhenGlobalStyleChange() {
+    this.store.select(selectGlobalStyleState)
+      .pipe(takeUntil(this.unsubscribe$), skip(1))
+      .subscribe(() => this.loadIframe());
+  }
+
+
+  ngOnDestroy() {
+    this.unsubscribe$.next();
+    this.unsubscribe$.complete();
   }
 
 }


### PR DESCRIPTION
When opening an external app in an iframe from the menu ,
 the night/day mode (or style) is passed in the request
  via a param in the GET Request .

Release note :

Features :
[OC-1098] When opening an external app in an iframe from business menu ,the night/day mode (or style) is passed in the request  via a param in the GET Request . When the user switch the mode, the iframe is reloaded.

[OC-1098]: https://opfab.atlassian.net/browse/OC-1098