### PR TITLE
[OC-1118] displayes entity as sender in logging page

### DIFF
--- a/client/cards/src/main/java/org/lfenergy/operatorfabric/cards/model/PublisherTypeEnum.java
+++ b/client/cards/src/main/java/org/lfenergy/operatorfabric/cards/model/PublisherTypeEnum.java
@@ -1,0 +1,26 @@
+/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
+ */
+
+
+
+package org.lfenergy.operatorfabric.cards.model;
+
+/**
+ * Define the kind of the card sender
+ * <dl>
+ *     <dt>THIRD_PARTY</dt><dd>The sender is an external service</dd>
+ *     <dt>SYSTEM</dt><dd>The sender of the card is OperatorFabric itself</dd>
+ * </dl>
+ * Note : This enum is created by hand because Swagger can't handle enums. It should match the corresponding enum definition in the Cards API.
+ *
+ */
+public enum PublisherTypeEnum {
+    EXTERNAL,
+    SYSTEM
+}

--- a/client/cards/src/main/java/org/lfenergy/operatorfabric/cards/model/PublisherTypeEnum.java
+++ b/client/cards/src/main/java/org/lfenergy/operatorfabric/cards/model/PublisherTypeEnum.java
@@ -15,12 +15,12 @@ package org.lfenergy.operatorfabric.cards.model;
  * Define the kind of the card sender
  * <dl>
  *     <dt>THIRD_PARTY</dt><dd>The sender is an external service</dd>
- *     <dt>SYSTEM</dt><dd>The sender of the card is OperatorFabric itself</dd>
+ *     <dt>ENTITY</dt><dd>The sender of the card is a user on behalf of the entity</dd>
  * </dl>
  * Note : This enum is created by hand because Swagger can't handle enums. It should match the corresponding enum definition in the Cards API.
  *
  */
 public enum PublisherTypeEnum {
     EXTERNAL,
-    SYSTEM
+    ENTITY
 }

--- a/client/cards/src/main/modeling/config.json
+++ b/client/cards/src/main/modeling/config.json
@@ -19,6 +19,7 @@
     "TitlePositionEnum": "org.lfenergy.operatorfabric.cards.model.TitlePositionEnum",
     "RecipientEnum": "org.lfenergy.operatorfabric.cards.model.RecipientEnum",
     "TimeSpanDisplayModeEnum": "org.lfenergy.operatorfabric.cards.model.TimeSpanDisplayModeEnum",
-    "EpochDate": "java.time.Instant"
+    "EpochDate": "java.time.Instant",
+    "PublisherTypeEnum": "org.lfenergy.operatorfabric.cards.model.PublisherTypeEnum"
   }
 }

--- a/services/core/cards-consultation/src/main/java/org/lfenergy/operatorfabric/cards/consultation/configuration/mongo/LightCardReadConverter.java
+++ b/services/core/cards-consultation/src/main/java/org/lfenergy/operatorfabric/cards/consultation/configuration/mongo/LightCardReadConverter.java
@@ -15,6 +15,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.bson.Document;
 import org.lfenergy.operatorfabric.cards.consultation.model.LightCard;
 import org.lfenergy.operatorfabric.cards.consultation.model.LightCardConsultationData;
+import org.lfenergy.operatorfabric.cards.consultation.model.PublisherTypeEnum;
 import org.lfenergy.operatorfabric.cards.consultation.model.TimeSpanConsultationData;
 import org.lfenergy.operatorfabric.cards.model.SeverityEnum;
 import org.springframework.core.convert.converter.Converter;
@@ -47,7 +48,9 @@ public class LightCardReadConverter implements Converter<Document, LightCardCons
                 .endDate(source.getDate("endDate") == null ? null : source.getDate("endDate").toInstant())
                 .publishDate(source.getDate("publishDate") == null ? null : source.getDate("publishDate").toInstant())
                 .severity(SeverityEnum.valueOf(source.getString("severity")))
-                .usersAcks(source.getList("usersAcks", String.class));
+                .usersAcks(source.getList("usersAcks", String.class))
+                .publisherType(PublisherTypeEnum.valueOf(source.getString("publisherType")))
+        ;
 
         Document titleDoc = (Document) source.get("title");
         if(titleDoc!=null)

--- a/services/core/cards-consultation/src/main/java/org/lfenergy/operatorfabric/cards/consultation/model/ArchivedCardConsultationData.java
+++ b/services/core/cards-consultation/src/main/java/org/lfenergy/operatorfabric/cards/consultation/model/ArchivedCardConsultationData.java
@@ -100,4 +100,5 @@ public class ArchivedCardConsultationData implements Card {
     @JsonIgnore
     @Transient
     private Boolean hasBeenRead;
+    private PublisherTypeEnum publisherType;
 }

--- a/services/core/cards-consultation/src/main/java/org/lfenergy/operatorfabric/cards/consultation/model/CardConsultationData.java
+++ b/services/core/cards-consultation/src/main/java/org/lfenergy/operatorfabric/cards/consultation/model/CardConsultationData.java
@@ -100,6 +100,7 @@ public class CardConsultationData implements Card {
     private Boolean hasBeenAcknowledged;
     @Transient
     private Boolean hasBeenRead;
+    private PublisherTypeEnum publisherType;
     
     
 }

--- a/services/core/cards-consultation/src/main/java/org/lfenergy/operatorfabric/cards/consultation/model/LightCardConsultationData.java
+++ b/services/core/cards-consultation/src/main/java/org/lfenergy/operatorfabric/cards/consultation/model/LightCardConsultationData.java
@@ -73,6 +73,7 @@ public class LightCardConsultationData implements LightCard {
 
     private List<String> entitiesAllowedToRespond;
 
+    private PublisherTypeEnum publisherType;
 
     /**
      * return timespans, may return null
@@ -113,8 +114,9 @@ public class LightCardConsultationData implements LightCard {
                 .summary(I18nConsultationData.copy(other.getSummary()))
                 .hasBeenAcknowledged(other.getHasBeenAcknowledged())
                 .hasBeenRead(other.getHasBeenRead())
-                .entitiesAllowedToRespond(other.getEntitiesAllowedToRespond());
-                
+                .entitiesAllowedToRespond(other.getEntitiesAllowedToRespond())
+                .publisherType(other.getPublisherType())
+                ;
         if(other.getTags()!=null && ! other.getTags().isEmpty())
             builder.tags(other.getTags());
         if(other.getTimeSpans()!=null && !other.getTimeSpans().isEmpty())

--- a/services/core/cards-consultation/src/test/java/org/lfenergy/operatorfabric/cards/consultation/TestUtilities.java
+++ b/services/core/cards-consultation/src/test/java/org/lfenergy/operatorfabric/cards/consultation/TestUtilities.java
@@ -188,7 +188,9 @@ public class TestUtilities {
                 .severity(SeverityEnum.ALARM)
                 .title(I18nConsultationData.builder().key("title").build())
                 .summary(I18nConsultationData.builder().key("summary").build())
-                .recipient(computeRecipient(login, groups));
+                .recipient(computeRecipient(login, groups))
+                .publisherType(PublisherTypeEnum.EXTERNAL)
+                ;
 
         if (groups != null && groups.length > 0)
             archivedCardBuilder.groupRecipients(Arrays.asList(groups));

--- a/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/controllers/CardController.java
+++ b/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/controllers/CardController.java
@@ -59,7 +59,7 @@ public class CardController {
         OpFabJwtAuthenticationToken jwtPrincipal = (OpFabJwtAuthenticationToken) principal;
         CurrentUserWithPerimeters user = (CurrentUserWithPerimeters) jwtPrincipal.getPrincipal();
         return cardProcessingService.processUserCards(cards.map(card -> {
-            card.setPublisherType(PublisherTypeEnum.SYSTEM);
+            card.setPublisherType(PublisherTypeEnum.ENTITY);
             return card;
         }), user);
 

--- a/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/controllers/CardController.java
+++ b/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/controllers/CardController.java
@@ -8,12 +8,12 @@
  */
 
 
-
 package org.lfenergy.operatorfabric.cards.publication.controllers;
 
 import org.lfenergy.operatorfabric.aop.process.mongo.models.UserActionTraceData;
 import org.lfenergy.operatorfabric.cards.publication.model.CardCreationReportData;
 import org.lfenergy.operatorfabric.cards.publication.model.CardPublicationData;
+import org.lfenergy.operatorfabric.cards.publication.model.PublisherTypeEnum;
 import org.lfenergy.operatorfabric.cards.publication.services.CardProcessingService;
 import org.lfenergy.operatorfabric.springtools.configuration.oauth.OpFabJwtAuthenticationToken;
 import org.lfenergy.operatorfabric.users.model.CurrentUserWithPerimeters;
@@ -30,7 +30,6 @@ import java.util.Optional;
 
 /**
  * Synchronous controller
- *
  */
 @RestController
 @RequestMapping("/cards")
@@ -41,96 +40,103 @@ public class CardController {
     private CardProcessingService cardProcessingService;
 
 
-
     /**
      * POST cards to create/update new cards
+     *
      * @param cards cards to create publisher
      * @return contains number of cards created and optional message
      */
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    public @Valid Mono<CardCreationReportData> createCards(@Valid @RequestBody Flux<CardPublicationData> cards){
+    public @Valid Mono<CardCreationReportData> createCards(@Valid @RequestBody Flux<CardPublicationData> cards) {
         return cardProcessingService.processCards(cards);
 
     }
 
     @PostMapping("/userCard")
     @ResponseStatus(HttpStatus.CREATED)
-    public @Valid Mono<CardCreationReportData> createUserCards(@Valid @RequestBody Flux<CardPublicationData> cards, Principal principal){
+    public @Valid Mono<CardCreationReportData> createUserCards(@Valid @RequestBody Flux<CardPublicationData> cards, Principal principal) {
         OpFabJwtAuthenticationToken jwtPrincipal = (OpFabJwtAuthenticationToken) principal;
         CurrentUserWithPerimeters user = (CurrentUserWithPerimeters) jwtPrincipal.getPrincipal();
-        return cardProcessingService.processUserCards(cards, user);
+        return cardProcessingService.processUserCards(cards.map(card -> {
+            card.setPublisherType(PublisherTypeEnum.SYSTEM);
+            return card;
+        }), user);
 
     }
 
     @DeleteMapping("/{processInstanceId}")
     @ResponseStatus(HttpStatus.OK)
-    public Mono<Void> deleteCards(@PathVariable String processInstanceId, ServerHttpResponse response){
+    public Mono<Void> deleteCards(@PathVariable String processInstanceId, ServerHttpResponse response) {
         Optional<CardPublicationData> deletedCard = cardProcessingService.deleteCard(processInstanceId);
         return Mono.just(deletedCard).doOnNext(dc -> {
-        if (!dc.isPresent()) {
-        	response.setStatusCode(HttpStatus.NOT_FOUND);
-        }}).then();
+            if (!dc.isPresent()) {
+                response.setStatusCode(HttpStatus.NOT_FOUND);
+            }
+        }).then();
     }
-    
+
     /**
      * POST userAcknowledgement for a card updating the card
-     * @param card Id to create publisher
+     *
+     * @param cardUid Id to create publisher
      */
     @PostMapping("/userAcknowledgement/{cardUid}")
     @ResponseStatus(HttpStatus.CREATED)
     public Mono<Void> postUserAcknowledgement(Principal principal,
-			@PathVariable("cardUid") String cardUid, ServerHttpResponse response) {
+                                              @PathVariable("cardUid") String cardUid, ServerHttpResponse response) {
         OpFabJwtAuthenticationToken jwtPrincipal = (OpFabJwtAuthenticationToken) principal;
         CurrentUserWithPerimeters user = (CurrentUserWithPerimeters) jwtPrincipal.getPrincipal();
         return cardProcessingService.processUserAcknowledgement(Mono.just(cardUid), user.getUserData()).doOnNext(result -> {
-    		if (!result.isCardFound()) {
-    			response.setStatusCode(HttpStatus.NOT_FOUND);
-    		} else if (!result.getOperationDone()) {
-    			response.setStatusCode(HttpStatus.OK);
-    		}
-		}).then();
+            if (!result.isCardFound()) {
+                response.setStatusCode(HttpStatus.NOT_FOUND);
+            } else if (!result.getOperationDone()) {
+                response.setStatusCode(HttpStatus.OK);
+            }
+        }).then();
     }
-    
+
     /**
      * POST userCardRead for a card
+     *
      * @param cardUid of the card that has been read
      */
     @PostMapping("/userCardRead/{cardUid}")
     @ResponseStatus(HttpStatus.CREATED)
     public Mono<Void> postUserCardRead(Principal principal,
-			@PathVariable("cardUid") String cardUid, ServerHttpResponse response) {
-    	return cardProcessingService.processUserRead(Mono.just(cardUid), principal.getName()).doOnNext(result -> {
-    		if (!result.isCardFound()) {
-    			response.setStatusCode(HttpStatus.NOT_FOUND);
-    		} else if (!result.getOperationDone()) {
-    			response.setStatusCode(HttpStatus.OK);
-    		}
-		}).then();
+                                       @PathVariable("cardUid") String cardUid, ServerHttpResponse response) {
+        return cardProcessingService.processUserRead(Mono.just(cardUid), principal.getName()).doOnNext(result -> {
+            if (!result.isCardFound()) {
+                response.setStatusCode(HttpStatus.NOT_FOUND);
+            } else if (!result.getOperationDone()) {
+                response.setStatusCode(HttpStatus.OK);
+            }
+        }).then();
     }
 
     /**
      * DELETE userAcknowledgement for a card to updating that card
-     * @param card Id to create publisher
+     *
+     * @param cardUid Id to create publisher
      */
-	@DeleteMapping("/userAcknowledgement/{cardUid}")
-	@ResponseStatus(HttpStatus.OK)
-	public Mono<Void> deleteUserAcknowledgement(Principal principal, @PathVariable("cardUid") String cardUid,
-			ServerHttpResponse response) {		
-		return cardProcessingService.deleteUserAcknowledgement(Mono.just(cardUid),
-					principal.getName()).doOnNext(result -> {
-			if (!result.isCardFound()) {
-				response.setStatusCode(HttpStatus.NOT_FOUND);
-			} else if (!result.getOperationDone()) {
-				response.setStatusCode(HttpStatus.NO_CONTENT);
-			}
-		} ).then();
-	}
+    @DeleteMapping("/userAcknowledgement/{cardUid}")
+    @ResponseStatus(HttpStatus.OK)
+    public Mono<Void> deleteUserAcknowledgement(Principal principal, @PathVariable("cardUid") String cardUid,
+                                                ServerHttpResponse response) {
+        return cardProcessingService.deleteUserAcknowledgement(Mono.just(cardUid),
+                principal.getName()).doOnNext(result -> {
+            if (!result.isCardFound()) {
+                response.setStatusCode(HttpStatus.NOT_FOUND);
+            } else if (!result.getOperationDone()) {
+                response.setStatusCode(HttpStatus.NO_CONTENT);
+            }
+        }).then();
+    }
 
     @GetMapping("traces/ack/{cardUid}")
     @ResponseStatus(HttpStatus.OK)
-    public @Valid Mono<UserActionTraceData> searchTraces(Principal principal, @PathVariable String cardUid){
-        return cardProcessingService.findTraceByCardUid(principal.getName(),cardUid);
+    public @Valid Mono<UserActionTraceData> searchTraces(Principal principal, @PathVariable String cardUid) {
+        return cardProcessingService.findTraceByCardUid(principal.getName(), cardUid);
 
     }
 

--- a/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/model/ArchivedCardPublicationData.java
+++ b/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/model/ArchivedCardPublicationData.java
@@ -84,6 +84,8 @@ public class ArchivedCardPublicationData implements Card {
     @Indexed
     private String processStateKey;
 
+    private PublisherTypeEnum publisherType;
+
     public ArchivedCardPublicationData(CardPublicationData card){
         this.id = card.getUid();
         this.parentCardUid = card.getParentCardUid();
@@ -110,6 +112,7 @@ public class ArchivedCardPublicationData implements Card {
         this.externalRecipients = card.getExternalRecipients() == null ? null : new ArrayList<>(card.getExternalRecipients());
         this.entitiesAllowedToRespond = card.getEntitiesAllowedToRespond() == null ? null : new ArrayList<>(card.getEntitiesAllowedToRespond());
         this.processStateKey = process + "." + state;
+        this.publisherType = card.getPublisherType();
     }
 
 }

--- a/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/model/CardPublicationData.java
+++ b/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/model/CardPublicationData.java
@@ -119,6 +119,7 @@ public class CardPublicationData implements Card {
     private Boolean hasBeenRead;
     @Indexed
     private String processStateKey;
+    private PublisherTypeEnum publisherType = PublisherTypeEnum.EXTERNAL;
 
     public void prepare(Instant publishDate) {
         this.publishDate = publishDate;
@@ -151,7 +152,9 @@ public class CardPublicationData implements Card {
                 .tags(this.getTags())
                 .entitiesAllowedToRespond(this.getEntitiesAllowedToRespond())
                 .title(((I18nPublicationData) this.getTitle()).copy())
-                .summary(((I18nPublicationData) this.getSummary()).copy());
+                .summary(((I18nPublicationData) this.getSummary()).copy())
+                .publisherType(this.getPublisherType())
+                ;
         if(this.getTimeSpans()!=null)
             result.timeSpansSet(new HashSet<>(this.getTimeSpans()));
         return result.build();

--- a/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/model/LightCardPublicationData.java
+++ b/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/model/LightCardPublicationData.java
@@ -71,6 +71,8 @@ public class LightCardPublicationData implements LightCard {
 
     private List<String> entitiesAllowedToRespond;
 
+    private PublisherTypeEnum publisherType;
+
     /**
      * return timespans, may be null
      * @return

--- a/services/core/cards-publication/src/main/modeling/swagger.yaml
+++ b/services/core/cards-publication/src/main/modeling/swagger.yaml
@@ -630,10 +630,10 @@ definitions:
     description: |-
       Publisher type >
       * EXTERNAL - The sender is an external service
-      * SYSTEM - The sender of the card is OperatorFabric itself
+      * ENTITY - The sender of the card is the user on behalf of the entity
     enum:
       - EXTERNAL
-      - SYSTEM
+      - ENTITY
     example: EXTERNAL
 paths:
   /async/cards:

--- a/services/core/cards-publication/src/main/modeling/swagger.yaml
+++ b/services/core/cards-publication/src/main/modeling/swagger.yaml
@@ -391,7 +391,9 @@ definitions:
         description: Is true if the card was acknowledged by current user
       hasBeenRead:
         type: boolean
-        description: Is true if the card was read by current user  
+        description: Is true if the card was read by current user
+      publisherType:
+          $ref: '#/definitions/PublisherTypeEnum'
     required:
       - publisher
       - process
@@ -553,6 +555,8 @@ definitions:
       parentCardUid:
         type: string
         description: The uid of its parent card if it's a child card
+      publisherType:
+        $ref: '#/definitions/PublisherTypeEnum'
     required:
       - uid
       - id
@@ -621,6 +625,16 @@ definitions:
         type: number
         description: >-
           Page number
+  PublisherTypeEnum:
+    type: string
+    description: |-
+      Publisher type >
+      * EXTERNAL - The sender is an external service
+      * SYSTEM - The sender of the card is OperatorFabric itself
+    enum:
+      - EXTERNAL
+      - SYSTEM
+    example: EXTERNAL
 paths:
   /async/cards:
     post:

--- a/services/core/cards-publication/src/test/java/org/lfenergy/operatorfabric/cards/publication/services/CardProcessServiceShould.java
+++ b/services/core/cards-publication/src/test/java/org/lfenergy/operatorfabric/cards/publication/services/CardProcessServiceShould.java
@@ -348,6 +348,7 @@ class CardProcessServiceShould {
                 .timeSpan(TimeSpanPublicationData.builder().start(Instant.ofEpochMilli(123l)).build())
                 .process("process1")
                 .state("state1")
+                .publisherType(PublisherTypeEnum.EXTERNAL)
                 .build();
         cardProcessingService.processCards(Flux.just(newCard)).subscribe();
         CardPublicationData persistedCard = cardRepository.findById(newCard.getId()).block();

--- a/src/test/api/karate/cards/cards.feature
+++ b/src/test/api/karate/cards/cards.feature
@@ -76,6 +76,7 @@ Feature: Cards
     Then status 200
     And match response.card.data.message == 'new message'
     And def cardUid = response.uid
+	And match response.card.publisherType == "EXTERNAL"
 
     #get card without  authentication
     Given url opfabUrl + 'cards/cards/api_test.process1'

--- a/src/test/api/karate/cards/userCards.feature
+++ b/src/test/api/karate/cards/userCards.feature
@@ -188,6 +188,15 @@ Feature: UserCards tests
     Then status 201
     And match response.count == 1
 
+
+#get card with user tso1-operator
+    Given url opfabUrl + 'cards/cards/process_1.process_id_w'
+    And header Authorization = 'Bearer ' + authTokenAsTSO
+    When method get
+    Then status 200
+    And match response.card.publisherType == "ENTITY"
+
+
     * def card =
 """
 {

--- a/ui/main/src/app/model/light-card.model.ts
+++ b/ui/main/src/app/model/light-card.model.ts
@@ -78,5 +78,5 @@ export class TimeSpan {
 
 export enum PublisherType {
     EXTERNAL,
-    SYSTEM
+    ENTITY
 }

--- a/ui/main/src/app/model/light-card.model.ts
+++ b/ui/main/src/app/model/light-card.model.ts
@@ -31,7 +31,8 @@ export class LightCard {
         readonly process?: string,
         readonly state?: string,
         readonly parentCardUid?: string,
-        readonly entitiesAllowedToRespond?: string[]
+        readonly entitiesAllowedToRespond?: string[],
+        readonly publisherType?: PublisherType | string
     ) {
     }
 }
@@ -73,4 +74,9 @@ export class TimeSpan {
         readonly end?: number,
         readonly display = Display.BUBBLE) {
     }
+}
+
+export enum PublisherType {
+    EXTERNAL,
+    SYSTEM
 }

--- a/ui/main/src/app/modules/logging/logging.component.ts
+++ b/ui/main/src/app/modules/logging/logging.component.ts
@@ -48,7 +48,7 @@ export class LoggingComponent implements  AfterViewInit, OnDestroy {
                 Array.prototype.forEach.call(allProcesses, (proc: Process) => {
                     const id = proc.id;
 
-                    if (proc.uiVisibility && proc.uiVisibility.logging === true) {
+                    if (proc.uiVisibility && !! proc.uiVisibility.logging) {
                         filterValue.push({value: id, label: proc.name});
                     }
                 });


### PR DESCRIPTION
Signed-off-by: LE-GALL Ronan Ext <43667786+rlg-rte@users.noreply.github.com>

Tasks:
- [OC-1118] adds publisher type to cards and sets it to `SYSTEM` when user card end point called ;
- [OC-1119] displays `entity` as sender in `logging page` for `SYSTEM` publisher type.

[OC-1118]: https://opfab.atlassian.net/browse/OC-1118
[OC-1119]: https://opfab.atlassian.net/browse/OC-1119