### PR TITLE
[OC-1155] Optimize loading card from the UI

### DIFF
--- a/services/core/cards-consultation/src/main/java/org/lfenergy/operatorfabric/cards/consultation/repositories/CardCustomRepositoryImpl.java
+++ b/services/core/cards-consultation/src/main/java/org/lfenergy/operatorfabric/cards/consultation/repositories/CardCustomRepositoryImpl.java
@@ -96,12 +96,18 @@ public class CardCustomRepositoryImpl implements CardCustomRepository {
 	private Criteria getCriteriaForRange(Instant rangeStart,Instant rangeEnd)
 	{
 		
-		if (rangeStart==null) return where(END_DATE_FIELD).lt(rangeEnd);
-		if (rangeEnd==null) return where(START_DATE_FIELD).gt(rangeStart);
-		return new Criteria().orOperator(where(START_DATE_FIELD).gte(rangeStart).lte(rangeEnd),
-		where(END_DATE_FIELD).gte(rangeStart).lte(rangeEnd),
-		new Criteria().andOperator(where(START_DATE_FIELD).lt(rangeStart), new Criteria()
-				.orOperator(where(END_DATE_FIELD).is(null), where(END_DATE_FIELD).gt(rangeEnd))));
+		if (rangeStart==null) return where(END_DATE_FIELD).lte(rangeEnd);
+		if (rangeEnd==null) return where(START_DATE_FIELD).gte(rangeStart);
+		return new Criteria().orOperator(
+			where(START_DATE_FIELD).gte(rangeStart).lte(rangeEnd),
+			where(END_DATE_FIELD).gte(rangeStart).lte(rangeEnd),
+			new Criteria().andOperator(
+							where(START_DATE_FIELD).lte(rangeStart), 
+							new Criteria().orOperator(
+									where(END_DATE_FIELD).is(null), 
+									where(END_DATE_FIELD).gte(rangeEnd))
+							)
+			);
 	}
 
 

--- a/ui/main/src/app/services/card.service.ts
+++ b/ui/main/src/app/services/card.service.ts
@@ -51,6 +51,10 @@ export class CardService {
     private firstSubscriptionInitDone = false;
     public initSubscription = new Subject<void>();
 
+    private startOfAlreadyLoadedPeriod: number;
+    private endOfAlreadyLoadedPeriod: number;
+
+
     constructor(private httpClient: HttpClient,
                 private notifyService: NotifyService,
                 private guidService: GuidService,
@@ -171,12 +175,38 @@ export class CardService {
 
     }
 
-    public setSubscriptionDates(rangeStart: number, rangeEnd: number) {
+    public setSubscriptionDates(start: number, end: number) {
+        console.log(new Date().toISOString(), 'CardService - Set subscription date', new Date(start), ' -', new Date(end));
+        if (!this.startOfAlreadyLoadedPeriod) { // First loading , no card loaded yet
+            this.askCardsForPeriod(start, end);
+            return;
+        }
+        if ((start < this.startOfAlreadyLoadedPeriod) && (end > this.endOfAlreadyLoadedPeriod)) {
+            this.askCardsForPeriod(start, end);
+            return;
+        }
+        if (start < this.startOfAlreadyLoadedPeriod) {
+            this.askCardsForPeriod(start, this.startOfAlreadyLoadedPeriod);
+            return;
+        }
+        if (end > this.endOfAlreadyLoadedPeriod) {
+            this.askCardsForPeriod(this.endOfAlreadyLoadedPeriod, end);
+            return;
+        }
+        console.log(new Date().toISOString(), 'CardService - Card already loaded for the chosen period');
+    }
 
-        console.log(new Date().toISOString(), 'CardService - Set subscription date', new Date(rangeStart), ' -', new Date(rangeEnd));
+    private askCardsForPeriod(start: number, end: number) {
+        console.log(new Date().toISOString(), 'CardService - Need to load card for period '
+            , new Date(start), ' -', new Date(end));
         this.httpClient.post<any>(
             `${this.cardOperationsUrl}`,
-            {rangeStart: rangeStart, rangeEnd: rangeEnd}).subscribe();
+            { rangeStart: start, rangeEnd: end }).subscribe(result => {
+                if ((!this.startOfAlreadyLoadedPeriod) || (start < this.startOfAlreadyLoadedPeriod))
+                    this.startOfAlreadyLoadedPeriod = start;
+                if ((!this.endOfAlreadyLoadedPeriod) || (end > this.endOfAlreadyLoadedPeriod)) this.endOfAlreadyLoadedPeriod = end;
+
+            });
 
     }
 


### PR DESCRIPTION
Each time we change period of visibility on UI, we get all the card
of the period from the back even if we already have downloaded
previously this period. To avoid that we now memorize the period
already loaded and load only new period from the back

Release note :

Tasks: 
[OC-1155] Optimize loading card from the UI



[OC-1155]: https://opfab.atlassian.net/browse/OC-1155