### PR TITLE
[OC-1187] Set the external recipient in the business process definition

### DIFF
--- a/config/dev/cards-publication-dev.yml
+++ b/config/dev/cards-publication-dev.yml
@@ -12,7 +12,9 @@ users:
 externalRecipients-url: "{\
            processAction: \"http://localhost:8090/test\", \
            api_test_externalRecipient1: \"http://localhost:8090/test\", \
-           api_test_externalRecipient2: \"http://localhost:8090/test\" \
+           api_test_externalRecipient2: \"http://localhost:8090/test\", \
+           externalRecipient1: \"http://localhost:8090/test\", \
+           externalRecipient2: \"http://localhost:8090/test\" \
            }"
 
 # WARNING : If you set this parameter to false , all users have the rights to respond to all cards

--- a/config/docker/cards-publication-docker.yml
+++ b/config/docker/cards-publication-docker.yml
@@ -12,7 +12,9 @@ users:
 externalRecipients-url: "{\
            processAction: \"http://localhost:8090/test\", \
            api_test_externalRecipient1: \"http://localhost:8090/test\", \
-           api_test_externalRecipient2: \"http://localhost:8090/test\" \
+           api_test_externalRecipient2: \"http://localhost:8090/test\", \
+           externalRecipient1: \"http://localhost:8090/test\", \
+           externalRecipient2: \"http://localhost:8090/test\" \
            }"
 
 # WARNING : If you set this parameter to false , all users have the rights to respond to all cards

--- a/services/core/businessconfig/src/main/java/org/lfenergy/operatorfabric/businessconfig/model/ResponseData.java
+++ b/services/core/businessconfig/src/main/java/org/lfenergy/operatorfabric/businessconfig/model/ResponseData.java
@@ -12,6 +12,10 @@ package org.lfenergy.operatorfabric.businessconfig.model;
 
 import lombok.*;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
 /**
  * <p>Please use builder to instantiate</p>
  *
@@ -31,4 +35,17 @@ public class ResponseData implements Response {
     private String state;
     private ResponseBtnColorEnum btnColor;
     private I18n btnText;
+    private List<String> externalRecipients;
+
+    @Override
+    public void setExternalRecipients(List<String> externalRecipients) {
+        this.externalRecipients = new ArrayList<>(externalRecipients);
+    }
+
+    @Override
+    public List<String> getExternalRecipients() {
+        if (externalRecipients == null)
+            return Collections.emptyList();
+        return externalRecipients;
+    }
 }

--- a/services/core/businessconfig/src/main/modeling/swagger.yaml
+++ b/services/core/businessconfig/src/main/modeling/swagger.yaml
@@ -564,6 +564,11 @@ definitions:
       state:
         description: The state of the card triggered by the action
         type: string
+      externalRecipients:
+        description: The recipients that should receive the response card
+        type: array
+        items:
+          type: string
   ResponseBtnColorEnum:
     type: string
     description: |-

--- a/services/core/businessconfig/src/test/data/bundles/second/2.0/config.json
+++ b/services/core/businessconfig/src/test/data/bundles/second/2.0/config.json
@@ -9,6 +9,15 @@
   "states": {
     "firstState": {
       "name": "process.title",
+      "response": {
+        "lock": true,
+        "state": "responseState",
+        "btnColor": "GREEN",
+        "btnText": {
+          "key": "question.button.text"
+        },
+        "externalRecipients": ["externalRecipient1", "externalRecipient2"]
+      },
       "details": [
         {
           "title": {

--- a/services/core/businessconfig/src/test/data/bundles/second/2.1/config.json
+++ b/services/core/businessconfig/src/test/data/bundles/second/2.1/config.json
@@ -11,6 +11,15 @@
       "states": {
         "firstState": {
           "name": "process.title",
+          "response": {
+            "lock": true,
+            "state": "responseState",
+            "btnColor": "GREEN",
+            "btnText": {
+              "key": "question.button.text"
+            },
+            "externalRecipients": ["externalRecipient1", "externalRecipient2"]
+          },
           "details": [
             {
               "title": {

--- a/services/core/businessconfig/src/test/java/org/lfenergy/operatorfabric/businessconfig/services/ProcessesServiceShould.java
+++ b/services/core/businessconfig/src/test/java/org/lfenergy/operatorfabric/businessconfig/services/ProcessesServiceShould.java
@@ -214,6 +214,7 @@ class ProcessesServiceShould {
         assertThat(process).hasFieldOrPropertyWithValue("version", "2.0");
         assertThat(process.getStates().size()).isEqualTo(1);
         assertThat(process.getStates().get("firstState").getDetails().size()).isEqualTo(1);
+        assertThat(process.getStates().get("firstState").getResponse().getExternalRecipients().size()).isEqualTo(2);
         assertThat(service.listProcesses()).hasSize(3);
       } catch (IOException e) {
         log.trace("rethrowing exception");

--- a/src/docs/asciidoc/reference_doc/response_cards.adoc
+++ b/src/docs/asciidoc/reference_doc/response_cards.adoc
@@ -59,6 +59,7 @@ A card can have a response only if it's in a process/state that is configured fo
       "color": "#8bcdcd",
       "response": {
         "state": "responseState",
+        "externalRecipients":["externalRecipient1", "externalRecipient2"],
         "btnColor": "GREEN",
         "btnText": {
           "key": "question.button.text"
@@ -84,6 +85,7 @@ A card can have a response only if it's in a process/state that is configured fo
 We define here a state name "questionState" with a response field. Now, if we send a card with process "defaultProcess" and state "questionState" , the user will have the possibility to respond if he has the good privileges. 
 
 - The field "state" in the response field is used to define the state to use for the response (the child card).
+- The field "externalRecipients" define the recipients of the response card. These recipients are keys referenced in the config file of cards-publication service, in "externalRecipients-url" element. This field is optional.
 - The field "btnColor" define the color of the submit button for the response, it is optional and there is 3 possibilities : RED , GREEN , YELLOW 
 - The field "btnText"is the i18n key of the title of the submit button, it is optional.
 

--- a/src/test/api/karate/businessconfig/getResponseBusinessconfig.feature
+++ b/src/test/api/karate/businessconfig/getResponseBusinessconfig.feature
@@ -7,7 +7,7 @@ Feature: getResponseBusinessconfig
     * def signInAsTSO = call read('../common/getToken.feature') { username: 'tso1-operator'}
     * def authTokenAsTSO = signInAsTSO.authToken
 
-    * def process = 'test_action'
+    * def process = 'processAction'
     * def state = 'response_full'
     * def version = 1
 
@@ -18,7 +18,7 @@ Feature: getResponseBusinessconfig
       When method get
       Then print response
       And status 200
-      And match response == {"btnText":{"parameters":null,"key":"action.text"},"btnColor":"RED","lock":true,"state":"responseState"}
+      And match response == {"btnText":{"parameters":null,"key":"action.text"},"btnColor":"RED","lock":true,"state":"responseState","externalRecipients":["externalRecipient1","externalRecipient2"]}
 
 
 

--- a/src/test/api/karate/businessconfig/resources/bundle_test_action/config.json
+++ b/src/test/api/karate/businessconfig/resources/bundle_test_action/config.json
@@ -32,7 +32,8 @@
         "btnColor": "RED",
         "btnText": {
           "key": "action.text"
-        }
+        },
+        "externalRecipients": ["externalRecipient1", "externalRecipient2"]
       },
       "details": [
         {

--- a/src/test/api/karate/launchAllBusinessconfig.sh
+++ b/src/test/api/karate/launchAllBusinessconfig.sh
@@ -29,4 +29,5 @@ java -jar karate.jar                      \
       businessconfig/getBusinessconfigTemplate.feature    \
       businessconfig/getProcessGroups.feature             \
       businessconfig/uploadProcessGroupsFile.feature      \
+      businessconfig/getResponseBusinessconfig.feature    \
       businessconfig/security.feature

--- a/ui/main/src/app/model/processes.model.ts
+++ b/ui/main/src/app/model/processes.model.ts
@@ -97,7 +97,8 @@ export class Response {
         readonly lock?: boolean,
         readonly state?: string,
         readonly btnColor?: ResponseBtnColorEnum,
-        readonly btnText?: I18n
+        readonly btnText?: I18n,
+        readonly externalRecipients?: string[]
     ) {
     }
 }

--- a/ui/main/src/app/modules/cards/components/detail/detail.component.ts
+++ b/ui/main/src/app/modules/cards/components/detail/detail.component.ts
@@ -294,7 +294,7 @@ export class DetailComponent implements OnChanges, OnInit, OnDestroy, AfterViewC
                 hasBeenAcknowledged: false,
                 hasBeenRead: false,
                 entityRecipients: this.card.entityRecipients,
-                externalRecipients: [this.card.publisher],
+                externalRecipients: this._responseData.externalRecipients,
                 title: this.card.title,
                 summary: this.card.summary,
                 data: formResult.formData,


### PR DESCRIPTION
Release note : 

In Tasks section : 

[OC-1187](https://opfab.atlassian.net/browse/OC-1187) : Set the external recipient in the business process definition. You can find more information in the documentation : https://opfab.github.io/documentation/current/reference_doc/#_configure_the_response_in_config_json
