### PR TITLE
[OC-1190] Add an option in card to keep child card

### DIFF
--- a/services/core/cards-consultation/src/main/java/org/lfenergy/operatorfabric/cards/consultation/model/ArchivedCardConsultationData.java
+++ b/services/core/cards-consultation/src/main/java/org/lfenergy/operatorfabric/cards/consultation/model/ArchivedCardConsultationData.java
@@ -45,6 +45,8 @@ public class ArchivedCardConsultationData implements Card {
     private String id;
     private String parentCardId;
     private String initialParentCardUid;
+    @Builder.Default
+    private Boolean keepChildCards = false;
     private String publisher;
     private String processVersion;
     private String process;

--- a/services/core/cards-consultation/src/main/java/org/lfenergy/operatorfabric/cards/consultation/model/CardConsultationData.java
+++ b/services/core/cards-consultation/src/main/java/org/lfenergy/operatorfabric/cards/consultation/model/CardConsultationData.java
@@ -45,6 +45,8 @@ public class CardConsultationData implements Card {
     private String id;
     private String parentCardId;
     private String initialParentCardUid;
+    @Builder.Default
+    private Boolean keepChildCards = false;
     private String publisher;
     private String processVersion;
     private String process;

--- a/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/model/ArchivedCardPublicationData.java
+++ b/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/model/ArchivedCardPublicationData.java
@@ -43,6 +43,7 @@ public class ArchivedCardPublicationData implements Card {
     private String id;
     private String parentCardId;
     private String initialParentCardUid;
+    private Boolean keepChildCards = false;
     private String publisher;
     private String processVersion;
     private String process;
@@ -89,6 +90,7 @@ public class ArchivedCardPublicationData implements Card {
         this.id = card.getUid();
         this.parentCardId = card.getParentCardId();
         this.initialParentCardUid = card.getInitialParentCardUid();
+        this.keepChildCards = card.getKeepChildCards();
         this.publisher = card.getPublisher();
         this.processVersion = card.getProcessVersion();
         this.publishDate = card.getPublishDate();

--- a/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/model/CardPublicationData.java
+++ b/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/model/CardPublicationData.java
@@ -54,6 +54,9 @@ public class CardPublicationData implements Card {
 
     private String initialParentCardUid;
 
+    @Builder.Default
+    private Boolean keepChildCards = false;
+
     private String publisher;
     
     private String processVersion;
@@ -140,6 +143,7 @@ public class CardPublicationData implements Card {
                 .uid(this.getUid())
                 .parentCardId(this.getParentCardId())
                 .initialParentCardUid(this.getInitialParentCardUid())
+                .keepChildCards(this.getKeepChildCards())
                 .publisher(this.getPublisher())
                 .processVersion(this.getProcessVersion())
                 .process(this.getProcess())

--- a/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/model/LightCardPublicationData.java
+++ b/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/model/LightCardPublicationData.java
@@ -71,6 +71,9 @@ public class LightCardPublicationData implements LightCard {
 
     private String initialParentCardUid;
 
+    @Builder.Default
+    private Boolean keepChildCards = false;
+
     private List<String> entitiesAllowedToRespond;
 
     private PublisherTypeEnum publisherType;

--- a/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/services/CardProcessingService.java
+++ b/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/services/CardProcessingService.java
@@ -91,11 +91,14 @@ public class CardProcessingService {
     }
 
     private Flux<CardPublicationData> deleteChildCardsProcess(Flux<CardPublicationData> cards) {
-        return cards.doOnNext(card->{
-            String idCard= card.getProcess()+"."+card.getProcessInstanceId();
-            Optional<List<CardPublicationData>> childCard=cardRepositoryService.findChildCard(cardRepositoryService.findCardById(idCard));
-            if(childCard.isPresent()){
-                deleteCards(childCard.get());
+        return cards.doOnNext(card -> {
+
+            if (! card.getKeepChildCards()) {
+                String idCard = card.getProcess() + "." + card.getProcessInstanceId();
+                Optional<List<CardPublicationData>> childCard = cardRepositoryService.findChildCard(cardRepositoryService.findCardById(idCard));
+                if (childCard.isPresent()) {
+                    deleteCards(childCard.get());
+                }
             }
         });
     }

--- a/services/core/cards-publication/src/main/modeling/swagger.yaml
+++ b/services/core/cards-publication/src/main/modeling/swagger.yaml
@@ -296,6 +296,9 @@ definitions:
         type: string
         description: The uid of the initial parent card if it's a child card (optional). When a card is updated, its id is still the same but not its uid, that's why we store this field initialParentCardUid.
         readOnly: true
+      keepChildCards:
+        type: boolean
+        description: Is true if OperatorFabric must not delete child cards when their parent card is updated
       publisher:
         type: string
         description: Unique ID of the entity or service publishing the card

--- a/src/docs/asciidoc/reference_doc/response_cards.adoc
+++ b/src/docs/asciidoc/reference_doc/response_cards.adoc
@@ -10,9 +10,9 @@
 
 Within your template, you can allow the user to perform some action (respond to a form, answer a question, ...). The user fills these information and then clicks on a submit button. When he submits this action, a new card is created and emitted to a third-party tool.
 
-This card is called "a child card" as it is attached to the card where the question came from : "the parent card". This child card is also send to the users that have received the parent card. From the ui point of view, the information of the child cards can be integrated in real time in the parent card if configured. 
+This card is called "a child card" as it is attached to the card where the question came from : "the parent card". This child card is also sent to the users that have received the parent card. From the ui point of view, the information of the child cards can be integrated in real time in the parent card if configured.
 
-The process can be represented as follow : 
+The process can be represented as follows :
 
 image::ResponseCardSequence.jpg[,align="center"]
 
@@ -142,6 +142,9 @@ The question card is like a usual card except that you have the field "entitiesA
 ...
 
 ....
+
+NOTE: By default, OperatorFabric considers that if the parent card (question card) is modified, then the child cards are deleted. If you want to keep the child cards when the parent card is changed, then you must add in the parent card the field "keepChildCards" and set it to true.
+
 
 
 == Integrate child cards 


### PR DESCRIPTION
Release note : 

In Tasks section : 

[[OC-1190](https://opfab.atlassian.net/browse/OC-1190)] Add an option in card to keep child card. You can find more information in the documentation : https://opfab.github.io/documentation/current/reference_doc/#_send_a_question_card