### PR TITLE
[OC-1226] Correct bug in date format when timeline is hidden

### DIFF
--- a/config/dev/web-ui.json
+++ b/config/dev/web-ui.json
@@ -126,6 +126,8 @@
       "description": true
     },
     "locale": "en",
+    "dateTimeFormat": "HH:mm DD/MM/YYYY",
+    "dateFormat": "DD/MM/YYYY",
     "nightDayMode": true,
     "styleWhenNightDayModeDesactivated" : "NIGHT"
   },

--- a/config/docker/web-ui.json
+++ b/config/docker/web-ui.json
@@ -125,6 +125,8 @@
       "description": true
     },
     "locale": "en",
+    "dateTimeFormat": "HH:mm DD/MM/YYYY",
+    "dateFormat": "DD/MM/YYYY",
     "nightDayMode": false,
     "styleWhenNightDayModeDesactivated" : "NIGHT"
   },

--- a/ui/main/src/app/modules/feed/components/time-line/init-chart/init-chart.component.ts
+++ b/ui/main/src/app/modules/feed/components/time-line/init-chart/init-chart.component.ts
@@ -196,19 +196,19 @@ export class InitChartComponent implements OnInit, OnDestroy {
         const date = moment(value);
         switch (this.domainId) {
             case 'TR':
-                return date.format('L LT');
+                return this.time.formatDateTime(value);
             case 'J':
-                return date.format('L');
+                return this.time.formatDate(value);
             case '7D':
-                return date.format('L LT');
+                return this.time.formatDateTime(value);
             case 'W':
-                return date.format('L');
+                return this.time.formatDate(value);;
             case 'M':
-                return date.format('L');
+                return this.time.formatDate(value);;
             case 'Y':
                 return date.format('yyyy');
             default:
-                return date.format('L LT');
+                return this.time.formatDate(value);
         }
     }
 


### PR DESCRIPTION

Release note : 
BUG 
[OC-1226] When the timeline is hide by the user, dates displayed shall take
into account the date format configured in web-ui.json. It applies
only for the mode TR and 7D

[OC-1226]: https://opfab.atlassian.net/browse/OC-1226