### PR TITLE
[OC-1233] Add prometheus monitoring endpoint

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ ext {
             starterWeb              : "org.springframework.boot:spring-boot-starter-web:${versions['spring.boot']}",
             starterWebflux          : "org.springframework.boot:spring-boot-starter-webflux:${versions['spring.boot']}",
             actuator                : "org.springframework.boot:spring-boot-starter-actuator:${versions['spring.boot']}",
+            micrometer              : "io.micrometer:micrometer-registry-prometheus:latest.release",
             starterAop              : "org.springframework.boot:spring-boot-starter-aop:${versions['spring.boot']}",
             starterJetty            : "org.springframework.boot:spring-boot-starter-jetty:${versions['spring.boot']}",
             starterRabbitmq         : "org.springframework.boot:spring-boot-starter-amqp:${versions['spring.boot']}",

--- a/config/monitoring/prometheus.yml
+++ b/config/monitoring/prometheus.yml
@@ -1,0 +1,9 @@
+global:
+  scrape_interval: 10s
+
+scrape_configs:
+  - job_name: 'spring_micrometer'
+    metrics_path: '/actuator/prometheus'
+    scrape_interval: 5s
+    static_configs:
+      - targets: ['172.17.0.1:2100','172.17.0.1:2102','172.17.0.1:2103','172.17.0.1:2104']

--- a/config/monitoring/startPrometheus.sh
+++ b/config/monitoring/startPrometheus.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+docker run --name prometheus -d -p 9090:9090 -v $PWD/prometheus.yml:/etc/prometheus/prometheus.yml prom/prometheus

--- a/config/monitoring/stopPrometheus.sh
+++ b/config/monitoring/stopPrometheus.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+docker stop prometheus
+docker rm  prometheus

--- a/services/core/businessconfig/src/main/java/org/lfenergy/operatorfabric/businessconfig/configuration/oauth2/WebSecurityConfiguration.java
+++ b/services/core/businessconfig/src/main/java/org/lfenergy/operatorfabric/businessconfig/configuration/oauth2/WebSecurityConfiguration.java
@@ -30,6 +30,7 @@ import org.springframework.security.oauth2.jwt.Jwt;
 @Slf4j
 public class WebSecurityConfiguration extends WebSecurityConfigurerAdapter {
 
+    public static final String PROMETHEUS_PATH ="/actuator/prometheus**";
     public static final String ADMIN_ROLE = "ADMIN";
     public static final String THIRDS_PATH = "/businessconfig/**";
     private static final String STYLE_URL_PATTERN = "/businessconfig/processes/*/css/*";
@@ -49,6 +50,7 @@ public class WebSecurityConfiguration extends WebSecurityConfigurerAdapter {
     public static void configureCommon(final HttpSecurity http) throws Exception {
         http
                 .authorizeRequests()
+                .antMatchers(HttpMethod.GET,PROMETHEUS_PATH).permitAll() 
                 .antMatchers(STYLE_URL_PATTERN).permitAll() // Style is called via <style> , so no token is provided  (Static ressource)
                 .antMatchers(HttpMethod.POST, THIRDS_PATH).hasRole(ADMIN_ROLE)
                 .antMatchers(HttpMethod.PUT, THIRDS_PATH).hasRole(ADMIN_ROLE)

--- a/services/core/cards-consultation/src/main/java/org/lfenergy/operatorfabric/cards/consultation/configuration/webflux/WebSecurityConfiguration.java
+++ b/services/core/cards-consultation/src/main/java/org/lfenergy/operatorfabric/cards/consultation/configuration/webflux/WebSecurityConfiguration.java
@@ -20,6 +20,7 @@ import org.springframework.security.config.annotation.web.reactive.EnableWebFlux
 import org.springframework.security.config.web.server.ServerHttpSecurity;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.web.server.SecurityWebFilterChain;
+import org.springframework.http.HttpMethod;
 import reactor.core.publisher.Mono;
 
 
@@ -32,6 +33,8 @@ import reactor.core.publisher.Mono;
 @EnableWebFluxSecurity
 public class WebSecurityConfiguration {
 
+
+    public static final String PROMETHEUS_PATH ="/actuator/prometheus**";
     /**
      * Secures access (all uris are secured)
      *
@@ -61,6 +64,7 @@ public class WebSecurityConfiguration {
                 .headers().frameOptions().disable()
                 .and()
                 .authorizeExchange()
+                .pathMatchers(HttpMethod.GET,PROMETHEUS_PATH).permitAll() 
                 .anyExchange().authenticated();
     }
 }

--- a/services/core/users/src/main/java/org/lfenergy/operatorfabric/users/configuration/oauth2/WebSecurityConfiguration.java
+++ b/services/core/users/src/main/java/org/lfenergy/operatorfabric/users/configuration/oauth2/WebSecurityConfiguration.java
@@ -31,6 +31,7 @@ import org.springframework.security.oauth2.jwt.Jwt;
 @Slf4j
 public class WebSecurityConfiguration extends WebSecurityConfigurerAdapter {
 
+    public static final String PROMETHEUS_PATH ="/actuator/prometheus**";
     public static final String USER_PATH = "/users/{login}";
     public static final String USERS_SETTINGS_PATH = "/users/{login}/settings";
     public static final String USERS_PERIMETERS_PATH = "/users/{login}/perimeters";
@@ -42,6 +43,7 @@ public class WebSecurityConfiguration extends WebSecurityConfigurerAdapter {
     public static final String ADMIN_ROLE = "ADMIN";
     public static final String IS_ADMIN_OR_OWNER = "hasRole('ADMIN') or @webSecurityChecks.checkUserLogin(authentication,#login)";
     public static final String IS_ADMIN_AND_NOT_OWNER = "hasRole('ADMIN') and ! @webSecurityChecks.checkUserLogin(authentication,#login)";
+    
     @Autowired
     WebSecurityChecks webSecurityChecks;
 
@@ -64,6 +66,7 @@ public class WebSecurityConfiguration extends WebSecurityConfigurerAdapter {
         http.sessionManagement().sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED)
                 .and()
                 .authorizeRequests()
+                .antMatchers(HttpMethod.GET,PROMETHEUS_PATH).permitAll() 
                 .antMatchers(HttpMethod.GET, USER_PATH).access(IS_ADMIN_OR_OWNER)
                 .antMatchers(HttpMethod.PUT, USER_PATH).access(IS_ADMIN_OR_OWNER)
                 .antMatchers(HttpMethod.DELETE, USER_PATH).access(IS_ADMIN_AND_NOT_OWNER)

--- a/services/services.gradle
+++ b/services/services.gradle
@@ -38,6 +38,7 @@ subprojects {
 
         dependencies {
             compile boot.actuator
+            compile boot.micrometer
             annotationProcessor misc.lombok
             implementation misc.lombok
 

--- a/src/docs/asciidoc/deployment/index.adoc
+++ b/src/docs/asciidoc/deployment/index.adoc
@@ -32,10 +32,16 @@ include::configuration/configuration.adoc[leveloffset=+1]
 
 include::RABBITMQ.adoc[leveloffset=+1]
 
+== Monitoring
+
+Operator Fabric provides end points for monitoring via link:https://prometheus.io/[prometheus]. The monitoring is available for the four following services: user, businessconfig, cards-consultation, cards-publication. You can start a test prometheus instance via `config/monitoring/startPrometheus.sh` , the monitoring will be accessible on http://localhost:9090/
+
 include::users_groups_admin.adoc[leveloffset=+1]
 
 
 include::port_table.adoc[leveloffset=+1]
+
+
 
 == Restricted operations (administration)
 

--- a/src/test/api/karate/admin/getPrometheusMonitoring.feature
+++ b/src/test/api/karate/admin/getPrometheusMonitoring.feature
@@ -1,0 +1,25 @@
+Feature: get prometheus monitoring
+
+  Scenario: get monitoring for users
+    Given url opfabUserUrl + 'actuator/prometheus'
+    When method get
+    Then print response
+    And status 200
+
+  Scenario: get monitoring for businessConfig
+    Given url opfabBusinessConfigUrl + 'actuator/prometheus'
+    When method get
+    Then print response
+    And status 200
+
+  Scenario: get monitoring for cards-publication
+    Given url opfabCardsPublicationUrl + 'actuator/prometheus'
+    When method get
+    Then print response
+    And status 200
+
+  Scenario: get monitoring for cards-consultation
+    Given url opfabCardsConsultationUrl + 'actuator/prometheus'
+    When method get
+    Then print response
+    And status 200

--- a/src/test/api/karate/buildAndLaunchAll.sh
+++ b/src/test/api/karate/buildAndLaunchAll.sh
@@ -32,5 +32,6 @@ cd ../../src/test/api/karate
 ./launchAllBusinessconfig.sh
 ./launchAllUsers.sh
 ./launchAllCards.sh
+./launchAllAdmin.sh
 google-chrome target/cucumber-html-reports/overview-features.html &
 )

--- a/src/test/api/karate/karate-config.js
+++ b/src/test/api/karate/karate-config.js
@@ -7,9 +7,17 @@ function fn() {
  * SPDX-License-Identifier: MPL-2.0
  * This file is part of the OperatorFabric project.
  */ 
+
+    var  opfab_server = "http://localhost"
+    var opfab_port = "2002"
     var config = { // base config JSON
-      opfabUrl: 'http://localhost:2002/',
-      opfabPublishCardUrl: 'http://localhost:2102/'
+     
+      opfabUrl: opfab_server + ":" + opfab_port + "/",
+      opfabPublishCardUrl: opfab_server +":2102/",
+      opfabUserUrl: opfab_server +":2103/",
+      opfabBusinessConfigUrl: opfab_server +":2100/",
+      opfabCardsConsultationUrl: opfab_server +":2104/",
+      opfabCardsPublicationUrl: opfab_server +":2102/"
     };
 
     karate.log('url opfab :' + config.opfabUrl );

--- a/src/test/api/karate/launchAllAdmin.sh
+++ b/src/test/api/karate/launchAllAdmin.sh
@@ -1,0 +1,11 @@
+#/bin/sh
+
+# Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+# See AUTHORS.txt
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# SPDX-License-Identifier: MPL-2.0
+# This file is part of the OperatorFabric project.
+
+java -jar karate.jar  admin/getPrometheusMonitoring.feature


### PR DESCRIPTION

Release note:

Features:
[OC-1233] Add prometheus monitoring endpoint (see documenation https://opfab.github.io/documentation/current/deployment/#_monitoring) 

[OC-1233]: https://opfab.atlassian.net/browse/OC-1233