### PR TITLE
[OC-1231] Response card via Kafka topic

### DIFF
--- a/client/cards/src/main/avro/cardCommand.avsc
+++ b/client/cards/src/main/avro/cardCommand.avsc
@@ -8,7 +8,7 @@
         {
           "name": "CommandType",
           "type": "enum",
-          "symbols" : ["UNKNOWN","CREATE_CARD", "UPDATE_CARD", "DELETE_CARD"],
+          "symbols" : ["UNKNOWN","CREATE_CARD", "UPDATE_CARD", "DELETE_CARD", "RESPONSE_CARD"],
           "default": "UNKNOWN"
         }
     },

--- a/config/dev/cards-publication-dev.yml
+++ b/config/dev/cards-publication-dev.yml
@@ -6,17 +6,17 @@ spring:
   deserializer:
     value:
       delegate:
-        class: org.lfenergy.operatorfabric.cards.publication.kafka.consumer.KafkaAvroWithoutRegistryDeserializer
-#        class: io.confluent.kafka.serializers.KafkaAvroDeserializer
+        class: io.confluent.kafka.serializers.KafkaAvroDeserializer
+#        class: org.lfenergy.operatorfabric.cards.publication.kafka.consumer.KafkaAvroWithoutRegistryDeserializer
   serializer:
     value:
       delegate:
         class: io.confluent.kafka.serializers.KafkaAvroSerializer
-
+#        class: org.lfenergy.operatorfabric.cards.publication.kafka.producer.KafkaAvroWithoutRegistrySerializer
 # uncomment kafka.consumer.group-id to enable Kafka
-  kafka:
-    consumer:
-      group-id: opfab-command
+#  kafka:
+#    consumer:
+#      group-id: opfab-command
 
 opfab:
   kafka:
@@ -43,4 +43,4 @@ externalRecipients-url: "{\
            }"
 
 # WARNING : If you set this parameter to false , all users have the rights to respond to all cards
-checkPerimeterForResponseCard: false
+checkPerimeterForResponseCard: true

--- a/config/dev/cards-publication-dev.yml
+++ b/config/dev/cards-publication-dev.yml
@@ -3,14 +3,19 @@ server:
 spring:
   application:
     name: cards-publication
+  deserializer:
+    value:
+      delegate:
+        class: io.confluent.kafka.serializers.KafkaAvroDeserializer
+  serializer:
+    value:
+      delegate:
+        class: io.confluent.kafka.serializers.KafkaAvroSerializer
 
-  # uncomment kafka.consumer.group-id to enable Kafka
-  kafka:
-    consumer:
+# uncomment kafka.consumer.group-id to enable Kafka
+#  kafka:
+#    consumer:
 #      group-id: opfab-command
-      value-deserializer: io.confluent.kafka.serializers.KafkaAvroDeserializer
-    producer:
-      value-serializer: io.confluent.kafka.serializers.KafkaAvroSerializer
 
 opfab:
   kafka:

--- a/config/dev/cards-publication-dev.yml
+++ b/config/dev/cards-publication-dev.yml
@@ -6,21 +6,25 @@ spring:
   deserializer:
     value:
       delegate:
-        class: io.confluent.kafka.serializers.KafkaAvroDeserializer
+        class: org.lfenergy.operatorfabric.cards.publication.kafka.consumer.KafkaAvroWithoutRegistryDeserializer
+#        class: io.confluent.kafka.serializers.KafkaAvroDeserializer
   serializer:
     value:
       delegate:
         class: io.confluent.kafka.serializers.KafkaAvroSerializer
 
 # uncomment kafka.consumer.group-id to enable Kafka
-#  kafka:
-#    consumer:
-#      group-id: opfab-command
+  kafka:
+    consumer:
+      group-id: opfab-command
 
 opfab:
   kafka:
     topics:
-      topicname: opfab
+      card:
+        topicname: opfab
+      response-card:
+        topicname: opfab-response
     schema:
       registry:
         url: http://localhost:8081
@@ -39,4 +43,4 @@ externalRecipients-url: "{\
            }"
 
 # WARNING : If you set this parameter to false , all users have the rights to respond to all cards
-checkPerimeterForResponseCard: true
+checkPerimeterForResponseCard: false

--- a/config/dev/cards-publication-dev.yml
+++ b/config/dev/cards-publication-dev.yml
@@ -3,28 +3,22 @@ server:
 spring:
   application:
     name: cards-publication
-  deserializer:
-    value:
-      delegate:
-        class: io.confluent.kafka.serializers.KafkaAvroDeserializer
-  serializer:
-    value:
-      delegate:
-        class: io.confluent.kafka.serializers.KafkaAvroSerializer
 
-  # uncomment to enable Kafka
-#  kafka:
-#    consumer:
+  # uncomment kafka.consumer.group-id to enable Kafka
+  kafka:
+    consumer:
 #      group-id: opfab-command
-
-schema:
-  registry:
-    url: http://localhost:8081
+      value-deserializer: io.confluent.kafka.serializers.KafkaAvroDeserializer
+    producer:
+      value-serializer: io.confluent.kafka.serializers.KafkaAvroSerializer
 
 opfab:
   kafka:
     topics:
       topicname: opfab
+    schema:
+      registry:
+        url: http://localhost:8081
 
 #here we put urls for all feign clients
 users:

--- a/config/dev/cards-publication-dev.yml
+++ b/config/dev/cards-publication-dev.yml
@@ -7,6 +7,11 @@ spring:
     value:
       delegate:
         class: io.confluent.kafka.serializers.KafkaAvroDeserializer
+  serializer:
+    value:
+      delegate:
+        class: io.confluent.kafka.serializers.KafkaAvroSerializer
+
   # uncomment to enable Kafka
 #  kafka:
 #    consumer:

--- a/config/docker/cards-publication-docker.yml
+++ b/config/docker/cards-publication-docker.yml
@@ -6,19 +6,27 @@ spring:
     value:
       delegate:
         class: io.confluent.kafka.serializers.KafkaAvroDeserializer
-  # uncomment to enable Kafka
+#        class: org.lfenergy.operatorfabric.cards.publication.kafka.consumer.KafkaAvroWithoutRegistryDeserializer
+  serializer:
+    value:
+      delegate:
+        class: io.confluent.kafka.serializers.KafkaAvroSerializer
+#        class: org.lfenergy.operatorfabric.cards.publication.kafka.producer.KafkaAvroWithoutRegistrySerializer
+# uncomment kafka.consumer.group-id to enable Kafka
 #  kafka:
 #    consumer:
 #      group-id: opfab-command
 
-schema:
-  registry:
-    url: http://localhost:8081
-
 opfab:
   kafka:
     topics:
-      topicname: opfab
+      card:
+        topicname: opfab
+      response-card:
+        topicname: opfab-response
+    schema:
+      registry:
+        url: http://localhost:8081
 
 #here we put urls for all feign clients
 users:

--- a/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/configuration/kafka/ConsumerFactoryAutoConfiguration.java
+++ b/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/configuration/kafka/ConsumerFactoryAutoConfiguration.java
@@ -40,7 +40,7 @@ public class ConsumerFactoryAutoConfiguration {
 
     private String deserializerKeyClass = "org.apache.kafka.common.serialization.StringDeserializer";
 
-    @Value("${spring.kafka.consumer.value-deserializer}")
+    @Value("${spring.deserializer.value.delegate.class}")
     private String valueDeserializer;
 
     private Map<String,Object> consumerConfig() {

--- a/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/configuration/kafka/ConsumerFactoryAutoConfiguration.java
+++ b/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/configuration/kafka/ConsumerFactoryAutoConfiguration.java
@@ -1,3 +1,12 @@
+/* Copyright (c) 2020, Alliander (http://www.alliander.com)
+ * See AUTHORS.txt
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
+ */
+
 package org.lfenergy.operatorfabric.cards.publication.configuration.kafka;
 
 import io.confluent.kafka.serializers.KafkaAvroDeserializerConfig;

--- a/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/configuration/kafka/ConsumerFactoryAutoConfiguration.java
+++ b/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/configuration/kafka/ConsumerFactoryAutoConfiguration.java
@@ -14,7 +14,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.lfenergy.operatorfabric.avro.CardCommand;
-import org.lfenergy.operatorfabric.cards.publication.kafka.consumer.SchemaRegistryProperties;
+import org.lfenergy.operatorfabric.cards.publication.kafka.SchemaRegistryProperties;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
@@ -40,8 +40,8 @@ public class ConsumerFactoryAutoConfiguration {
 
     private String deserializerKeyClass = "org.apache.kafka.common.serialization.StringDeserializer";
 
-    @Value("${spring.deserializer.value.delegate.class}")
-    private String deserializerValueClass;
+    @Value("${spring.kafka.consumer.value-deserializer}")
+    private String valueDeserializer;
 
     private Map<String,Object> consumerConfig() {
         log.info("bootstrapServers: " + kafkaProperties.getBootstrapServers());
@@ -49,7 +49,7 @@ public class ConsumerFactoryAutoConfiguration {
         props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ErrorHandlingDeserializer.class);
         props.put(ErrorHandlingDeserializer.KEY_DESERIALIZER_CLASS, deserializerKeyClass);
         props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ErrorHandlingDeserializer.class);
-        props.put(ErrorHandlingDeserializer.VALUE_DESERIALIZER_CLASS, deserializerValueClass);
+        props.put(ErrorHandlingDeserializer.VALUE_DESERIALIZER_CLASS, valueDeserializer);
         props.put("specific.avro.reader", "true");
         return props;
     }

--- a/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/configuration/kafka/KafkaListenerContainerFactoryConfiguration.java
+++ b/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/configuration/kafka/KafkaListenerContainerFactoryConfiguration.java
@@ -1,3 +1,12 @@
+/* Copyright (c) 2020, Alliander (http://www.alliander.com)
+ * See AUTHORS.txt
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
+ */
+
 package org.lfenergy.operatorfabric.cards.publication.configuration.kafka;
 
 import lombok.RequiredArgsConstructor;

--- a/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/configuration/kafka/ProducerFactoryAutoConfiguration.java
+++ b/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/configuration/kafka/ProducerFactoryAutoConfiguration.java
@@ -5,7 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.lfenergy.operatorfabric.avro.CardCommand;
-import org.lfenergy.operatorfabric.cards.publication.kafka.consumer.SchemaRegistryProperties;
+import org.lfenergy.operatorfabric.cards.publication.kafka.SchemaRegistryProperties;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
@@ -23,8 +23,8 @@ import java.util.Map;
 @EnableConfigurationProperties(SchemaRegistryProperties.class)
 @Configuration
 public class ProducerFactoryAutoConfiguration {
-    @Value("${spring.serializer.value.delegate.class}")
-    private String serializerValueClass;
+    @Value("${spring.kafka.producer.value-serializer}")
+    private String valueDeserializer;
 
     private final KafkaProperties kafkaProperties;
 
@@ -32,7 +32,7 @@ public class ProducerFactoryAutoConfiguration {
         Map<String,Object> props = kafkaProperties.buildProducerProperties();
         props.put(ProducerConfig.CLIENT_ID_CONFIG, "opfab-producer");
         props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
-        props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, serializerValueClass);
+        props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, valueDeserializer);
         return props;
     }
 

--- a/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/configuration/kafka/ProducerFactoryAutoConfiguration.java
+++ b/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/configuration/kafka/ProducerFactoryAutoConfiguration.java
@@ -1,0 +1,52 @@
+package org.lfenergy.operatorfabric.cards.publication.configuration.kafka;
+
+import io.confluent.kafka.serializers.KafkaAvroSerializerConfig;
+import lombok.RequiredArgsConstructor;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.lfenergy.operatorfabric.avro.CardCommand;
+import org.lfenergy.operatorfabric.cards.publication.kafka.consumer.SchemaRegistryProperties;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+
+import java.util.Map;
+
+@RequiredArgsConstructor
+@ConditionalOnProperty("spring.kafka.consumer.group-id")
+@EnableConfigurationProperties(SchemaRegistryProperties.class)
+@Configuration
+public class ProducerFactoryAutoConfiguration {
+    @Value("${spring.serializer.value.delegate.class}")
+    private String serializerValueClass;
+
+    private final KafkaProperties kafkaProperties;
+
+    private Map<String, Object> producerConfigs() {
+        Map<String,Object> props = kafkaProperties.buildProducerProperties();
+        props.put(ProducerConfig.CLIENT_ID_CONFIG, "opfab-producer");
+        props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+        props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, serializerValueClass);
+        return props;
+    }
+
+    private ProducerFactory<String, CardCommand> producerFactory(SchemaRegistryProperties schemaRegistryProperties) {
+        Map<String,Object> props = producerConfigs();
+        if (schemaRegistryProperties.getUrl() != null && !schemaRegistryProperties.getUrl().isEmpty()) {
+            props.put(KafkaAvroSerializerConfig.SCHEMA_REGISTRY_URL_CONFIG, schemaRegistryProperties.getUrl());
+        }
+        return new DefaultKafkaProducerFactory<>(props);
+    }
+
+    @Bean
+    public KafkaTemplate<String, CardCommand> kafkaTemplate(SchemaRegistryProperties schemaRegistryProperties) {
+        return new KafkaTemplate<>(producerFactory(schemaRegistryProperties));
+    }
+}
+

--- a/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/configuration/kafka/ProducerFactoryAutoConfiguration.java
+++ b/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/configuration/kafka/ProducerFactoryAutoConfiguration.java
@@ -23,7 +23,7 @@ import java.util.Map;
 @EnableConfigurationProperties(SchemaRegistryProperties.class)
 @Configuration
 public class ProducerFactoryAutoConfiguration {
-    @Value("${spring.kafka.producer.value-serializer}")
+    @Value("${spring.serializer.value.delegate.class}")
     private String valueDeserializer;
 
     private final KafkaProperties kafkaProperties;

--- a/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/kafka/CardObjectMapper.java
+++ b/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/kafka/CardObjectMapper.java
@@ -11,6 +11,7 @@ package org.lfenergy.operatorfabric.cards.publication.kafka;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
@@ -35,12 +36,16 @@ public class CardObjectMapper {
         objectMapper.registerModule(new JavaTimeModule());
         objectMapper.registerModule(new CardsModule());
         objectMapper.registerModule(new InstantModule());
+        objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     }
 
-    public String writeValueAsString(Card kafkaCard) throws JsonProcessingException {
-        return objectMapper.writeValueAsString(kafkaCard);
+    public String writeValueAsString(Object value) throws JsonProcessingException {
+        return objectMapper.writeValueAsString(value);
     }
 
+    public Card readCardValue(String writeValueAsString, Class<Card> clazz) throws JsonProcessingException {
+        return objectMapper.readValue(writeValueAsString, clazz);
+    }
     public CardPublicationData readValue(String writeValueAsString, Class<CardPublicationData> clazz) throws JsonProcessingException {
         return objectMapper.readValue(writeValueAsString, clazz);
     }

--- a/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/kafka/CardObjectMapper.java
+++ b/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/kafka/CardObjectMapper.java
@@ -1,3 +1,12 @@
+/* Copyright (c) 2020, Alliander (http://www.alliander.com)
+ * See AUTHORS.txt
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
+ */
+
 package org.lfenergy.operatorfabric.cards.publication.kafka;
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/kafka/SchemaRegistryProperties.java
+++ b/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/kafka/SchemaRegistryProperties.java
@@ -7,13 +7,13 @@
  * This file is part of the OperatorFabric project.
  */
 
-package org.lfenergy.operatorfabric.cards.publication.kafka.consumer;
+package org.lfenergy.operatorfabric.cards.publication.kafka;
 
 import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @Data
-@ConfigurationProperties(prefix="schema.registry")
+@ConfigurationProperties(prefix="opfab.kafka.schema.registry")
 public class SchemaRegistryProperties {
 
     private String url;

--- a/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/kafka/card/CardCommandFactory.java
+++ b/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/kafka/card/CardCommandFactory.java
@@ -1,0 +1,39 @@
+package org.lfenergy.operatorfabric.cards.publication.kafka.card;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.lfenergy.operatorfabric.avro.Card;
+import org.lfenergy.operatorfabric.avro.CardCommand;
+import org.lfenergy.operatorfabric.avro.CommandType;
+import org.lfenergy.operatorfabric.cards.publication.kafka.CardObjectMapper;
+import org.lfenergy.operatorfabric.cards.publication.model.CardPublicationData;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class CardCommandFactory {
+    private final CardObjectMapper objectMapper;
+
+    public CardCommand create(CardPublicationData cardPublicationData) {
+        CardCommand cardCommand = new CardCommand();
+        Card kafkaCard;
+        try {
+            Object cardData = cardPublicationData.getData();
+            cardPublicationData.setData(null); // Prevent Jackson errors
+
+            kafkaCard = objectMapper.readCardValue(objectMapper.writeValueAsString(cardPublicationData), Card.class);
+            cardCommand.setCommand(CommandType.RESPONSE_CARD);
+            cardCommand.setCard(kafkaCard);
+            cardCommand.setProcess(cardPublicationData.getProcess());
+            cardCommand.setProcessInstanceId(cardPublicationData.getProcessInstanceId());
+
+            String cardDataString = objectMapper.writeValueAsString(cardData);
+            kafkaCard.setData(cardDataString);
+        } catch (JsonProcessingException e) {
+            log.error("Unable to serialize CardPublicationData {} into CardCommand. Message: {}", cardPublicationData, e.getMessage());
+        }
+        return cardCommand;
+    }
+}

--- a/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/kafka/card/CardCommandFactory.java
+++ b/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/kafka/card/CardCommandFactory.java
@@ -1,3 +1,12 @@
+/* Copyright (c) 2020, Alliander (http://www.alliander.com)
+ * See AUTHORS.txt
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
+ */
+
 package org.lfenergy.operatorfabric.cards.publication.kafka.card;
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/kafka/command/BaseCommandHandler.java
+++ b/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/kafka/command/BaseCommandHandler.java
@@ -1,3 +1,12 @@
+/* Copyright (c) 2020, Alliander (http://www.alliander.com)
+ * See AUTHORS.txt
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
+ */
+
 package org.lfenergy.operatorfabric.cards.publication.kafka.command;
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/kafka/command/CommandHandler.java
+++ b/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/kafka/command/CommandHandler.java
@@ -1,3 +1,12 @@
+/* Copyright (c) 2020, Alliander (http://www.alliander.com)
+ * See AUTHORS.txt
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
+ */
+
 package org.lfenergy.operatorfabric.cards.publication.kafka.command;
 
 import org.lfenergy.operatorfabric.avro.CardCommand;

--- a/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/kafka/command/CreateCardCommandHandler.java
+++ b/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/kafka/command/CreateCardCommandHandler.java
@@ -1,3 +1,12 @@
+/* Copyright (c) 2020, Alliander (http://www.alliander.com)
+ * See AUTHORS.txt
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
+ */
+
 package org.lfenergy.operatorfabric.cards.publication.kafka.command;
 
 import lombok.RequiredArgsConstructor;

--- a/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/kafka/command/DeleteCardCommandHandler.java
+++ b/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/kafka/command/DeleteCardCommandHandler.java
@@ -1,3 +1,12 @@
+/* Copyright (c) 2020, Alliander (http://www.alliander.com)
+ * See AUTHORS.txt
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
+ */
+
 package org.lfenergy.operatorfabric.cards.publication.kafka.command;
 
 import lombok.RequiredArgsConstructor;

--- a/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/kafka/command/UpdateCardCommandHandler.java
+++ b/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/kafka/command/UpdateCardCommandHandler.java
@@ -1,3 +1,12 @@
+/* Copyright (c) 2020, Alliander (http://www.alliander.com)
+ * See AUTHORS.txt
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
+ */
+
 package org.lfenergy.operatorfabric.cards.publication.kafka.command;
 
 import lombok.RequiredArgsConstructor;

--- a/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/kafka/consumer/CardCommandConsumerListener.java
+++ b/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/kafka/consumer/CardCommandConsumerListener.java
@@ -31,7 +31,7 @@ public class CardCommandConsumerListener {
                 .collect(Collectors.toMap(CommandHandler::getCommandType, it -> it));
     }
 
-    @KafkaListener(topics = "${opfab.kafka.topics.card.topicname}", containerFactory = "kafkaListenerContainerFactory")
+    @KafkaListener(topics = "${opfab.kafka.topics.card.topicname:opfab}", containerFactory = "kafkaListenerContainerFactory")
     public void receivedCommand(@Payload ConsumerRecord<String, CardCommand> record) {
         log.info("Key: {}, Value: {}, Partition: {}, Offset: {}",
                 record.key(), record.value(), record.partition(), record.offset());

--- a/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/kafka/consumer/CardCommandConsumerListener.java
+++ b/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/kafka/consumer/CardCommandConsumerListener.java
@@ -1,3 +1,12 @@
+/* Copyright (c) 2020, Alliander (http://www.alliander.com)
+ * See AUTHORS.txt
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
+ */
+
 package org.lfenergy.operatorfabric.cards.publication.kafka.consumer;
 
 import lombok.extern.slf4j.Slf4j;

--- a/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/kafka/consumer/CardCommandConsumerListener.java
+++ b/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/kafka/consumer/CardCommandConsumerListener.java
@@ -31,7 +31,7 @@ public class CardCommandConsumerListener {
                 .collect(Collectors.toMap(CommandHandler::getCommandType, it -> it));
     }
 
-    @KafkaListener(topics = "${opfab.kafka.topics.topicname:opfab}", containerFactory = "kafkaListenerContainerFactory")
+    @KafkaListener(topics = "${opfab.kafka.topics.card.topicname}", containerFactory = "kafkaListenerContainerFactory")
     public void receivedCommand(@Payload ConsumerRecord<String, CardCommand> record) {
         log.info("Key: {}, Value: {}, Partition: {}, Offset: {}",
                 record.key(), record.value(), record.partition(), record.offset());

--- a/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/kafka/consumer/KafkaAvroWithoutRegistryDeserializer.java
+++ b/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/kafka/consumer/KafkaAvroWithoutRegistryDeserializer.java
@@ -1,3 +1,12 @@
+/* Copyright (c) 2020, Alliander (http://www.alliander.com)
+ * See AUTHORS.txt
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
+ */
+
 package org.lfenergy.operatorfabric.cards.publication.kafka.consumer;
 
 import org.apache.avro.io.BinaryDecoder;

--- a/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/kafka/consumer/SchemaRegistryProperties.java
+++ b/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/kafka/consumer/SchemaRegistryProperties.java
@@ -1,3 +1,12 @@
+/* Copyright (c) 2020, Alliander (http://www.alliander.com)
+ * See AUTHORS.txt
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
+ */
+
 package org.lfenergy.operatorfabric.cards.publication.kafka.consumer;
 
 import lombok.Data;

--- a/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/kafka/producer/KafkaAvroWithoutRegistrySerializer.java
+++ b/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/kafka/producer/KafkaAvroWithoutRegistrySerializer.java
@@ -1,0 +1,51 @@
+/* Copyright (c) 2020, Alliander (http://www.alliander.com)
+ * See AUTHORS.txt
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
+ */
+
+package org.lfenergy.operatorfabric.cards.publication.kafka.producer;
+
+import org.apache.avro.Schema;
+import org.apache.avro.io.BinaryEncoder;
+import org.apache.avro.io.DatumWriter;
+import org.apache.avro.io.EncoderFactory;
+import org.apache.avro.specific.SpecificDatumWriter;
+import org.apache.avro.specific.SpecificRecord;
+import org.apache.kafka.common.errors.SerializationException;
+import org.apache.kafka.common.serialization.Serializer;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+public class KafkaAvroWithoutRegistrySerializer<T extends SpecificRecord> implements Serializer<T> {
+
+    private final EncoderFactory encoderFactory = EncoderFactory.get();
+
+    public byte[] serialize(String topic, T record) {
+        if (record == null) {
+            return null;
+        } else {
+            try {
+                Schema schema = record.getSchema();
+
+                ByteArrayOutputStream out = new ByteArrayOutputStream();
+                out.write(ByteBuffer.allocate(5).putInt(0).array());    // write first five bytes with 0 value
+                BinaryEncoder encoder = this.encoderFactory.directBinaryEncoder(out, null);
+                DatumWriter<T> writer = new SpecificDatumWriter<>(schema);
+                writer.write(record, encoder);
+                encoder.flush();
+
+                byte[] bytes = out.toByteArray();
+                out.close();
+                return bytes;
+            } catch (RuntimeException | IOException ioEx) {
+                throw new SerializationException("Error serializing Avro message", ioEx);
+            }
+        }
+    }
+}

--- a/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/kafka/producer/KafkaAvroWithoutRegistrySerializer.java
+++ b/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/kafka/producer/KafkaAvroWithoutRegistrySerializer.java
@@ -29,7 +29,7 @@ public class KafkaAvroWithoutRegistrySerializer<T extends SpecificRecord> implem
     @Override
     public byte[] serialize(String topic, T record) {
         if (record == null) {
-            return null;
+            return new byte[0];
         } else {
             try {
                 Schema schema = record.getSchema();

--- a/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/kafka/producer/KafkaAvroWithoutRegistrySerializer.java
+++ b/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/kafka/producer/KafkaAvroWithoutRegistrySerializer.java
@@ -26,6 +26,7 @@ public class KafkaAvroWithoutRegistrySerializer<T extends SpecificRecord> implem
 
     private final EncoderFactory encoderFactory = EncoderFactory.get();
 
+    @Override
     public byte[] serialize(String topic, T record) {
         if (record == null) {
             return null;

--- a/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/kafka/producer/ResponseCardProducer.java
+++ b/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/kafka/producer/ResponseCardProducer.java
@@ -29,7 +29,7 @@ public class ResponseCardProducer {
     private final KafkaTemplate<String, CardCommand> kafkaTemplate;
     private final CardCommandFactory cardCommandFactory;
 
-    @Value("${opfab.kafka.topics.response-card.topicname}")
+    @Value("${opfab.kafka.topics.response-card.topicname:opfab-response}")
     private String topic;
 
     public void send(CardPublicationData cardPublicationData) {

--- a/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/kafka/producer/ResponseCardProducer.java
+++ b/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/kafka/producer/ResponseCardProducer.java
@@ -29,7 +29,7 @@ public class ResponseCardProducer {
     private final KafkaTemplate<String, CardCommand> kafkaTemplate;
     private final CardCommandFactory cardCommandFactory;
 
-    @Value("${spil.kafka.topics.topicname-reponse:opfab-response}")
+    @Value("${opfab.kafka.topics.response-card.topicname}")
     private String topic;
 
     public void send(CardPublicationData cardPublicationData) {

--- a/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/kafka/producer/ResponseCardProducer.java
+++ b/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/kafka/producer/ResponseCardProducer.java
@@ -1,0 +1,61 @@
+/* Copyright (c) 2020, Alliander (http://www.alliander.com)
+ * See AUTHORS.txt
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
+ */
+
+package org.lfenergy.operatorfabric.cards.publication.kafka.producer;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.lfenergy.operatorfabric.avro.CardCommand;
+import org.lfenergy.operatorfabric.cards.publication.kafka.card.CardCommandFactory;
+import org.lfenergy.operatorfabric.cards.publication.model.CardPublicationData;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
+import org.springframework.stereotype.Component;
+import org.springframework.util.concurrent.ListenableFuture;
+import org.springframework.util.concurrent.ListenableFutureCallback;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class ResponseCardProducer {
+    private final KafkaTemplate<String, CardCommand> kafkaTemplate;
+    private final CardCommandFactory cardCommandFactory;
+
+    @Value("${spil.kafka.topics.topicname-reponse:opfab-response}")
+    private String topic;
+
+    public void send(CardPublicationData cardPublicationData) {
+        log.debug("ResponseCard: {}", cardPublicationData.toString());
+
+        CardCommand cardCommand = cardCommandFactory.create(cardPublicationData);
+
+        ListenableFuture<SendResult<String, CardCommand>> future =
+                kafkaTemplate.send(topic, cardCommand.getProcess(), cardCommand);
+        future.addCallback(new ListenableFutureCallback<SendResult<String, CardCommand>>() {
+            @Override
+            public void onFailure(Throwable throwable) {
+                log.error("Failure to send responseCard: {}", throwable.getMessage());
+            }
+
+            @Override
+            public void onSuccess(SendResult<String, CardCommand> sendResult) {
+                RecordMetadata metaData = sendResult.getRecordMetadata();
+                log.debug("Received new metadata. \n" +
+                        "Topic: " + metaData.topic() + "\n" +
+                        "Partition: " + metaData.partition() + "\n" +
+                        "Offset: " + metaData.offset() + "\n" +
+                        "Timestamp: " + metaData.timestamp()
+                );
+                log.debug(sendResult.getProducerRecord().value().toString());
+            }
+        });
+    }
+}

--- a/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/services/clients/impl/ExternalAppClientImpl.java
+++ b/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/services/clients/impl/ExternalAppClientImpl.java
@@ -63,7 +63,7 @@ public class ExternalAppClientImpl implements ExternalAppClient {
     }
 
     private void callExternalApplication(CardPublicationData card, String externalRecipientUrl) {
-        if (externalRecipientUrl.startsWith("kafka://")) {
+        if (externalRecipientUrl.startsWith("kafka:")) {
             callExternalKafkaApplication(card, externalRecipientUrl);
         } else{
             callExternalHttpApplication(card, externalRecipientUrl);

--- a/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/services/clients/impl/ExternalAppClientImpl.java
+++ b/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/services/clients/impl/ExternalAppClientImpl.java
@@ -64,13 +64,13 @@ public class ExternalAppClientImpl implements ExternalAppClient {
 
     private void callExternalApplication(CardPublicationData card, String externalRecipientUrl) {
         if (externalRecipientUrl.startsWith("kafka:")) {
-            callExternalKafkaApplication(card, externalRecipientUrl);
+            callExternalKafkaApplication(card);
         } else{
             callExternalHttpApplication(card, externalRecipientUrl);
         }
     }
 
-    private void callExternalKafkaApplication(CardPublicationData card, String externalRecipientUrl) {
+    private void callExternalKafkaApplication(CardPublicationData card) {
         responseCardProducer.send(card);
     }
 

--- a/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/services/clients/impl/ExternalAppClientImpl.java
+++ b/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/services/clients/impl/ExternalAppClientImpl.java
@@ -1,6 +1,7 @@
 package org.lfenergy.operatorfabric.cards.publication.services.clients.impl;
 
 import lombok.extern.slf4j.Slf4j;
+import org.lfenergy.operatorfabric.cards.publication.kafka.producer.ResponseCardProducer;
 import org.lfenergy.operatorfabric.cards.publication.model.CardPublicationData;
 import org.lfenergy.operatorfabric.cards.publication.services.clients.ExternalAppClient;
 import org.lfenergy.operatorfabric.springtools.error.model.ApiError;
@@ -33,6 +34,9 @@ public class ExternalAppClientImpl implements ExternalAppClient {
     @Autowired
     private RestTemplate restTemplate;
 
+    @Autowired
+    private ResponseCardProducer responseCardProducer;
+
     public void sendCardToExternalApplication(CardPublicationData card) {
 
         Optional<List<String>> externalRecipientsFromCard = Optional.ofNullable(card.getExternalRecipients());
@@ -59,6 +63,18 @@ public class ExternalAppClientImpl implements ExternalAppClient {
     }
 
     private void callExternalApplication(CardPublicationData card, String externalRecipientUrl) {
+        if (externalRecipientUrl.startsWith("kafka://")) {
+            callExternalKafkaApplication(card, externalRecipientUrl);
+        } else{
+            callExternalHttpApplication(card, externalRecipientUrl);
+        }
+    }
+
+    private void callExternalKafkaApplication(CardPublicationData card, String externalRecipientUrl) {
+
+        responseCardProducer.send(card);
+    }
+    private void callExternalHttpApplication(CardPublicationData card, String externalRecipientUrl) {
         try {
             log.debug("Start to Send card {} To {} ", card.getId(), card.getPublisher());
 

--- a/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/services/clients/impl/ExternalAppClientImpl.java
+++ b/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/services/clients/impl/ExternalAppClientImpl.java
@@ -71,9 +71,9 @@ public class ExternalAppClientImpl implements ExternalAppClient {
     }
 
     private void callExternalKafkaApplication(CardPublicationData card, String externalRecipientUrl) {
-
         responseCardProducer.send(card);
     }
+
     private void callExternalHttpApplication(CardPublicationData card, String externalRecipientUrl) {
         try {
             log.debug("Start to Send card {} To {} ", card.getId(), card.getPublisher());

--- a/services/core/cards-publication/src/test/java/org/lfenergy/operatorfabric/cards/publication/configuration/kafka/ConsumerFactoryAutoConfigurationShould.java
+++ b/services/core/cards-publication/src/test/java/org/lfenergy/operatorfabric/cards/publication/configuration/kafka/ConsumerFactoryAutoConfigurationShould.java
@@ -3,7 +3,7 @@ package org.lfenergy.operatorfabric.cards.publication.configuration.kafka;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.lfenergy.operatorfabric.avro.CardCommand;
-import org.lfenergy.operatorfabric.cards.publication.kafka.consumer.SchemaRegistryProperties;
+import org.lfenergy.operatorfabric.cards.publication.kafka.SchemaRegistryProperties;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;

--- a/services/core/cards-publication/src/test/java/org/lfenergy/operatorfabric/cards/publication/configuration/kafka/ConsumerFactoryAutoConfigurationShould.java
+++ b/services/core/cards-publication/src/test/java/org/lfenergy/operatorfabric/cards/publication/configuration/kafka/ConsumerFactoryAutoConfigurationShould.java
@@ -1,3 +1,11 @@
+/* Copyright (c) 2020, Alliander (http://www.alliander.com)
+ * See AUTHORS.txt
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
+ */
 package org.lfenergy.operatorfabric.cards.publication.configuration.kafka;
 
 import org.junit.jupiter.api.Test;

--- a/services/core/cards-publication/src/test/java/org/lfenergy/operatorfabric/cards/publication/configuration/kafka/KafkaListenerContainerFactoryConfigurationShould.java
+++ b/services/core/cards-publication/src/test/java/org/lfenergy/operatorfabric/cards/publication/configuration/kafka/KafkaListenerContainerFactoryConfigurationShould.java
@@ -1,3 +1,11 @@
+/* Copyright (c) 2020, Alliander (http://www.alliander.com)
+ * See AUTHORS.txt
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
+ */
 package org.lfenergy.operatorfabric.cards.publication.configuration.kafka;
 
 import org.junit.jupiter.api.Test;

--- a/services/core/cards-publication/src/test/java/org/lfenergy/operatorfabric/cards/publication/configuration/kafka/ProducerFactoryAutoConfigurationShould.java
+++ b/services/core/cards-publication/src/test/java/org/lfenergy/operatorfabric/cards/publication/configuration/kafka/ProducerFactoryAutoConfigurationShould.java
@@ -1,0 +1,67 @@
+/* Copyright (c) 2020, Alliander (http://www.alliander.com)
+ * See AUTHORS.txt
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
+ */
+package org.lfenergy.operatorfabric.cards.publication.configuration.kafka;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.lfenergy.operatorfabric.avro.CardCommand;
+import org.lfenergy.operatorfabric.cards.publication.kafka.SchemaRegistryProperties;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Map;
+import java.util.Set;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@ActiveProfiles(profiles = {"native", "test"})
+class ProducerFactoryAutoConfigurationShould {
+    @Mock
+    private KafkaProperties kafkaProperties;
+
+    @Mock
+    private SchemaRegistryProperties schemaRegistryProperties;
+
+    @InjectMocks
+    ProducerFactoryAutoConfiguration cut;
+
+    @Test
+    void kafkaTemplateWithSchemaUrl() {
+        String valueDeserializer = "MyValueDeserializer";
+        String schemaUrl = "http://some-url";
+
+        when (schemaRegistryProperties.getUrl()).thenReturn(schemaUrl);
+        ReflectionTestUtils.setField(cut, "valueDeserializer", valueDeserializer);
+        KafkaTemplate<String, CardCommand>  template = cut.kafkaTemplate(schemaRegistryProperties);
+
+        Set<Map.Entry<String, Object>> properties = template.getProducerFactory().getConfigurationProperties().entrySet();
+        assertThat(template.getProducerFactory().getConfigurationProperties().get("value.serializer"), is(valueDeserializer));
+        assertThat(template.getProducerFactory().getConfigurationProperties().get("schema.registry.url"), is(schemaUrl));
+    }
+
+    @Test
+    void kafkaTemplateNoSchemaUrl() {
+        String valueDeserializer = "MyValueDeserializer";
+        ReflectionTestUtils.setField(cut, "valueDeserializer", valueDeserializer);
+
+        KafkaTemplate<String, CardCommand>  template = cut.kafkaTemplate(schemaRegistryProperties);
+        Set<Map.Entry<String, Object>> properties = template.getProducerFactory().getConfigurationProperties().entrySet();
+        assertThat(template.getProducerFactory().getConfigurationProperties().get("value.serializer"), is(valueDeserializer));
+        assertThat(template.getProducerFactory().getConfigurationProperties().get("schema.registry.url"), is(nullValue()));
+    }
+}

--- a/services/core/cards-publication/src/test/java/org/lfenergy/operatorfabric/cards/publication/kafka/card/CardCommandFactoryShould.java
+++ b/services/core/cards-publication/src/test/java/org/lfenergy/operatorfabric/cards/publication/kafka/card/CardCommandFactoryShould.java
@@ -1,3 +1,11 @@
+/* Copyright (c) 2020, Alliander (http://www.alliander.com)
+ * See AUTHORS.txt
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
+ */
 package org.lfenergy.operatorfabric.cards.publication.kafka.card;
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/services/core/cards-publication/src/test/java/org/lfenergy/operatorfabric/cards/publication/kafka/card/CardCommandFactoryShould.java
+++ b/services/core/cards-publication/src/test/java/org/lfenergy/operatorfabric/cards/publication/kafka/card/CardCommandFactoryShould.java
@@ -1,0 +1,67 @@
+package org.lfenergy.operatorfabric.cards.publication.kafka.card;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.lfenergy.operatorfabric.avro.CardCommand;
+import org.lfenergy.operatorfabric.avro.CommandType;
+import org.lfenergy.operatorfabric.cards.model.SeverityEnum;
+import org.lfenergy.operatorfabric.cards.publication.kafka.CardObjectMapper;
+import org.lfenergy.operatorfabric.cards.publication.model.CardPublicationData;
+import org.lfenergy.operatorfabric.cards.publication.model.I18nPublicationData;
+import org.lfenergy.operatorfabric.cards.publication.model.RecipientPublicationData;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.Instant;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.nullValue;
+import static org.lfenergy.operatorfabric.cards.model.RecipientEnum.DEADEND;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@ActiveProfiles(profiles = {"native", "test"})
+class CardCommandFactoryShould {
+
+    @InjectMocks
+    CardCommandFactory cut;
+    @Test
+    void create() {
+        ReflectionTestUtils.setField(cut, "objectMapper", new CardObjectMapper());
+
+        CardPublicationData cardPublicationData = createCardPublicationData();
+        CardCommand cardCommand = cut.create(cardPublicationData);
+
+        assertThat (cardCommand.getCommand(), is (CommandType.RESPONSE_CARD));
+        assertThat (cardCommand.getProcess(), is (cardPublicationData.getProcess()));
+        assertThat (cardCommand.getCard().getState(), is(cardPublicationData.getState()));
+    }
+
+    @Test
+    void createFailure() throws JsonProcessingException {
+        CardObjectMapper failMapper = mock (CardObjectMapper.class);
+        when (failMapper.readCardValue(any(), any())).thenThrow(JsonProcessingException.class);
+        ReflectionTestUtils.setField(cut, "objectMapper", failMapper);
+
+        CardCommand cardCommand = cut.create(createCardPublicationData());
+        assertThat(cardCommand.getCommand(), is(nullValue()));
+    }
+
+    private CardPublicationData createCardPublicationData() {
+        return CardPublicationData.builder().publisher("PUBLISHER_1").processVersion("O")
+                .processInstanceId("PROCESS_1").severity(SeverityEnum.INFORMATION)
+                .title(I18nPublicationData.builder().key("title").build())
+                .summary(I18nPublicationData.builder().key("summary").build())
+                .startDate(Instant.now())
+                .recipient(RecipientPublicationData.builder().type(DEADEND).build())
+                .process("process5")
+                .state("state5")
+                .build();
+    }
+}

--- a/services/core/cards-publication/src/test/java/org/lfenergy/operatorfabric/cards/publication/kafka/command/BaseCommandHandlerShould.java
+++ b/services/core/cards-publication/src/test/java/org/lfenergy/operatorfabric/cards/publication/kafka/command/BaseCommandHandlerShould.java
@@ -1,3 +1,11 @@
+/* Copyright (c) 2020, Alliander (http://www.alliander.com)
+ * See AUTHORS.txt
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
+ */
 package org.lfenergy.operatorfabric.cards.publication.kafka.command;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -60,8 +68,7 @@ class BaseCommandHandlerShould {
 
     @Test
     void testBuildCardPublicationData_withoutDataProperty() throws JsonProcessingException {
-        String cardDataAsString = null;
-        when(card.getData()).thenReturn(cardDataAsString);
+        when(card.getData()).thenReturn(null);
         CardPublicationData result = cut.buildCardPublicationData(cardCommand);
         Map<String,Object> data = (Map<String,Object>) result.getData();
         Assertions.assertThat(data.size()).isEqualTo(0);

--- a/services/core/cards-publication/src/test/java/org/lfenergy/operatorfabric/cards/publication/kafka/command/BaseCommandHandlerShould.java
+++ b/services/core/cards-publication/src/test/java/org/lfenergy/operatorfabric/cards/publication/kafka/command/BaseCommandHandlerShould.java
@@ -26,7 +26,7 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 @ActiveProfiles(profiles = {"native", "test"})
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class BaseCommandHandlerTest {
+class BaseCommandHandlerShould {
 
     private final String ANY_STRING = "any_string";
     private final String PROCESS = "a_process";

--- a/services/core/cards-publication/src/test/java/org/lfenergy/operatorfabric/cards/publication/kafka/command/CreateCardCommandHandlerShould.java
+++ b/services/core/cards-publication/src/test/java/org/lfenergy/operatorfabric/cards/publication/kafka/command/CreateCardCommandHandlerShould.java
@@ -1,3 +1,11 @@
+/* Copyright (c) 2020, Alliander (http://www.alliander.com)
+ * See AUTHORS.txt
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
+ */
 package org.lfenergy.operatorfabric.cards.publication.kafka.command;
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/services/core/cards-publication/src/test/java/org/lfenergy/operatorfabric/cards/publication/kafka/command/DeleteCardCommandHandlerShould.java
+++ b/services/core/cards-publication/src/test/java/org/lfenergy/operatorfabric/cards/publication/kafka/command/DeleteCardCommandHandlerShould.java
@@ -1,3 +1,11 @@
+/* Copyright (c) 2020, Alliander (http://www.alliander.com)
+ * See AUTHORS.txt
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
+ */
 package org.lfenergy.operatorfabric.cards.publication.kafka.command;
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/services/core/cards-publication/src/test/java/org/lfenergy/operatorfabric/cards/publication/kafka/command/UpdateCardCommandHandlerShould.java
+++ b/services/core/cards-publication/src/test/java/org/lfenergy/operatorfabric/cards/publication/kafka/command/UpdateCardCommandHandlerShould.java
@@ -1,8 +1,15 @@
+/* Copyright (c) 2020, Alliander (http://www.alliander.com)
+ * See AUTHORS.txt
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
+ */
 package org.lfenergy.operatorfabric.cards.publication.kafka.command;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -43,10 +50,6 @@ class UpdateCardCommandHandlerShould {
         objectMapper = mock(CardObjectMapper.class);
         cut = new UpdateCardCommandHandler(cardProcessingService);
         ReflectionTestUtils.setField(cut, "objectMapper", objectMapper);
-    }
-
-    @BeforeEach
-    public void beforeEach() {
     }
 
     @Test

--- a/services/core/cards-publication/src/test/java/org/lfenergy/operatorfabric/cards/publication/kafka/consumer/CardCommandConsumerListenerShould.java
+++ b/services/core/cards-publication/src/test/java/org/lfenergy/operatorfabric/cards/publication/kafka/consumer/CardCommandConsumerListenerShould.java
@@ -1,3 +1,11 @@
+/* Copyright (c) 2020, Alliander (http://www.alliander.com)
+ * See AUTHORS.txt
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
+ */
 package org.lfenergy.operatorfabric.cards.publication.kafka.consumer;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;

--- a/services/core/cards-publication/src/test/java/org/lfenergy/operatorfabric/cards/publication/kafka/consumer/KafkaAvroWithoutRegistryDeserializerShould.java
+++ b/services/core/cards-publication/src/test/java/org/lfenergy/operatorfabric/cards/publication/kafka/consumer/KafkaAvroWithoutRegistryDeserializerShould.java
@@ -1,4 +1,11 @@
-package org.lfenergy.operatorfabric.cards.publication.kafka.consumer;
+/* Copyright (c) 2020, Alliander (http://www.alliander.com)
+ * See AUTHORS.txt
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
+ */package org.lfenergy.operatorfabric.cards.publication.kafka.consumer;
 
 import org.apache.avro.io.BinaryDecoder;
 import org.apache.avro.io.DatumReader;

--- a/services/core/cards-publication/src/test/java/org/lfenergy/operatorfabric/cards/publication/kafka/producer/KafkaAvroWithoutRegistrySerializerShould.java
+++ b/services/core/cards-publication/src/test/java/org/lfenergy/operatorfabric/cards/publication/kafka/producer/KafkaAvroWithoutRegistrySerializerShould.java
@@ -1,3 +1,11 @@
+/* Copyright (c) 2020, Alliander (http://www.alliander.com)
+ * See AUTHORS.txt
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
+ */
 package org.lfenergy.operatorfabric.cards.publication.kafka.producer;
 
 import org.apache.kafka.common.errors.SerializationException;

--- a/services/core/cards-publication/src/test/java/org/lfenergy/operatorfabric/cards/publication/kafka/producer/KafkaAvroWithoutRegistrySerializerShould.java
+++ b/services/core/cards-publication/src/test/java/org/lfenergy/operatorfabric/cards/publication/kafka/producer/KafkaAvroWithoutRegistrySerializerShould.java
@@ -1,0 +1,67 @@
+package org.lfenergy.operatorfabric.cards.publication.kafka.producer;
+
+import org.apache.kafka.common.errors.SerializationException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.lfenergy.operatorfabric.avro.*;
+import org.lfenergy.operatorfabric.cards.publication.kafka.consumer.KafkaAvroWithoutRegistryDeserializer;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+
+@ExtendWith(MockitoExtension.class)
+@ActiveProfiles(profiles = {"native", "test"})
+class KafkaAvroWithoutRegistrySerializerShould {
+
+    @InjectMocks
+    KafkaAvroWithoutRegistrySerializer cut;
+
+    @Test
+    void serializeRoundTripSuccess() {
+        KafkaAvroWithoutRegistryDeserializer deserializer = new KafkaAvroWithoutRegistryDeserializer();
+        String topic = "MyTopic";
+
+        Card card = createCard();
+        CardCommand cardCommand = createCardCommand(card);
+
+        CardCommand cardCommandRoundTrip = deserializer.deserialize(topic, cut.serialize(topic, cardCommand));
+        assertThat(cardCommandRoundTrip, is(cardCommand));
+    }
+
+    @Test
+    void testFailure() {
+        assertThat (cut.serialize("ATopic", null), is(nullValue()));
+    }
+
+    @Test
+    void testException() {
+        CardCommand cardCommand = mock (CardCommand.class);
+        assertThrows(SerializationException.class, () -> cut.serialize("Topic", cardCommand));
+    }
+
+    private Card createCard() {
+        return Card.newBuilder()
+                .setPublisher("Publisher")
+                .setProcessVersion("ProcessVersion")
+                .setStartDate(12345L)
+                .setSeverity(SeverityType.ALARM)
+                .setTitle(new I18n("Title", null))
+                .setSummary(new I18n("Summary", null))
+                .build();
+    }
+
+    private CardCommand createCardCommand(Card card) {
+        return CardCommand.newBuilder()
+                .setCommand(CommandType.CREATE_CARD)
+                .setProcess("Process")
+                .setProcessInstanceId("InstanceId")
+                .setCard(card)
+                .build();
+    }
+}

--- a/services/core/cards-publication/src/test/java/org/lfenergy/operatorfabric/cards/publication/kafka/producer/KafkaAvroWithoutRegistrySerializerShould.java
+++ b/services/core/cards-publication/src/test/java/org/lfenergy/operatorfabric/cards/publication/kafka/producer/KafkaAvroWithoutRegistrySerializerShould.java
@@ -18,8 +18,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.context.ActiveProfiles;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 
@@ -43,8 +42,9 @@ class KafkaAvroWithoutRegistrySerializerShould {
     }
 
     @Test
-    void testFailure() {
-        assertThat (cut.serialize("ATopic", null), is(nullValue()));
+    void testNullRecord() {
+        byte[] result = cut.serialize("ATopic", null);
+        assertThat (result.length, is(0));
     }
 
     @Test

--- a/services/core/cards-publication/src/test/java/org/lfenergy/operatorfabric/cards/publication/kafka/producer/ResponseCardProducerShould.java
+++ b/services/core/cards-publication/src/test/java/org/lfenergy/operatorfabric/cards/publication/kafka/producer/ResponseCardProducerShould.java
@@ -1,3 +1,11 @@
+/* Copyright (c) 2020, Alliander (http://www.alliander.com)
+ * See AUTHORS.txt
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
+ */
 package org.lfenergy.operatorfabric.cards.publication.kafka.producer;
 
 import org.apache.kafka.clients.producer.ProducerRecord;

--- a/services/core/cards-publication/src/test/java/org/lfenergy/operatorfabric/cards/publication/kafka/producer/ResponseCardProducerShould.java
+++ b/services/core/cards-publication/src/test/java/org/lfenergy/operatorfabric/cards/publication/kafka/producer/ResponseCardProducerShould.java
@@ -1,0 +1,99 @@
+package org.lfenergy.operatorfabric.cards.publication.kafka.producer;
+
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.TopicPartition;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.lfenergy.operatorfabric.avro.CardCommand;
+import org.lfenergy.operatorfabric.cards.publication.kafka.card.CardCommandFactory;
+import org.lfenergy.operatorfabric.cards.publication.model.CardPublicationData;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.util.concurrent.ListenableFuture;
+import org.springframework.util.concurrent.ListenableFutureCallback;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@ActiveProfiles(profiles = {"native", "test"})
+class ResponseCardProducerShould {
+
+    @Mock
+    private KafkaTemplate<String, CardCommand> kafkaTemplate;
+
+    @Mock
+    private CardCommandFactory cardCommandFactory;
+
+    @InjectMocks
+    private ResponseCardProducer cut;
+
+    private  SendResult<String, CardCommand> sendResult;
+    private ListenableFuture<SendResult<String, CardCommand>> responseFuture;
+    private CardPublicationData cardPublicationData;
+    private CardCommand cardCommand;
+
+    private final int partition = 11;
+    private final int offset = 2;
+    private final String topic = "MYTOPIC";
+    private final String key = "MyKey";
+
+    @BeforeEach
+    private void setUp() {
+        ReflectionTestUtils.setField(cut,"topic", topic);
+
+        cardPublicationData = mock(CardPublicationData.class);
+        cardCommand = mock(CardCommand.class);
+        when(cardCommand.getProcess()).thenReturn(key);
+        when (cardCommandFactory.create(any())).thenReturn(cardCommand);
+
+        responseFuture = mock(ListenableFuture.class);
+        sendResult = mock(SendResult.class);
+
+        when(kafkaTemplate.send(topic, key, cardCommand)).thenReturn(responseFuture);
+    }
+    @Test
+    void sendSuccess() {
+        ProducerRecord producerRecord = mock (ProducerRecord.class);
+        when (producerRecord.value()).thenReturn(cardCommand);
+        when(sendResult.getProducerRecord()).thenReturn(producerRecord);
+
+        RecordMetadata recordMetadata = new RecordMetadata(new TopicPartition(topic, partition), offset, 0L, 0L, 0L, 0, 0);
+        when(sendResult.getRecordMetadata()).thenReturn(recordMetadata);
+        doAnswer( invocation -> {
+            ListenableFutureCallback listenableFutureCallback = invocation.getArgument(0);
+            listenableFutureCallback.onSuccess(sendResult);
+            assertEquals(sendResult.getRecordMetadata().offset(), offset);
+            assertEquals(sendResult.getRecordMetadata().partition(), partition);
+            return null;
+        }).when(responseFuture).addCallback(any(ListenableFutureCallback.class));
+
+        cut.send(cardPublicationData);
+
+        verify(kafkaTemplate, times(1)).send(topic, key, cardCommand);
+    }
+
+    @Test
+    void testFailure() {
+        Throwable ex = mock (Throwable.class);
+
+        doAnswer( invocation -> {
+            ListenableFutureCallback listenableFutureCallback = invocation.getArgument(0);
+            listenableFutureCallback.onFailure(ex);
+            return null;
+        }).when(responseFuture).addCallback(any(ListenableFutureCallback.class));
+
+        cut.send(cardPublicationData);
+
+        verify(kafkaTemplate, times(1)).send(topic, key, cardCommand);
+        verify(ex).getMessage();
+
+    }
+}

--- a/services/core/cards-publication/src/test/java/org/lfenergy/operatorfabric/cards/publication/services/clients/impl/ExternalAppClientImplShould.java
+++ b/services/core/cards-publication/src/test/java/org/lfenergy/operatorfabric/cards/publication/services/clients/impl/ExternalAppClientImplShould.java
@@ -50,7 +50,7 @@ class ExternalAppClientImplShould {
     private final String externalRecipientHttp = "http_recipient";
     private final Map<String, String> externalRecipientsMapping = new HashMap<String, String>() {
         {
-            put (externalRecipientKafka, "kafka://");
+            put (externalRecipientKafka, "kafka:");
             put (externalRecipientHttp, "http://");
         }
     };

--- a/services/core/cards-publication/src/test/java/org/lfenergy/operatorfabric/cards/publication/services/clients/impl/ExternalAppClientImplShould.java
+++ b/services/core/cards-publication/src/test/java/org/lfenergy/operatorfabric/cards/publication/services/clients/impl/ExternalAppClientImplShould.java
@@ -1,0 +1,88 @@
+/* Copyright (c) 2020, Alliander (http://www.alliander.com)
+ * See AUTHORS.txt
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
+ */
+package org.lfenergy.operatorfabric.cards.publication.services.clients.impl;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.lfenergy.operatorfabric.cards.model.SeverityEnum;
+import org.lfenergy.operatorfabric.cards.publication.kafka.producer.ResponseCardProducer;
+import org.lfenergy.operatorfabric.cards.publication.model.CardPublicationData;
+import org.lfenergy.operatorfabric.cards.publication.model.I18nPublicationData;
+import org.lfenergy.operatorfabric.cards.publication.model.RecipientPublicationData;
+import org.lfenergy.operatorfabric.cards.publication.model.TimeSpanPublicationData;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.client.RestTemplate;
+
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.lfenergy.operatorfabric.cards.model.RecipientEnum.DEADEND;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@ActiveProfiles(profiles = {"native", "test"})
+class ExternalAppClientImplShould {
+
+    @Mock
+    private ResponseCardProducer responseCardProducer;
+
+    @Mock
+    private RestTemplate restTemplate;
+
+    @InjectMocks
+    private ExternalAppClientImpl cut;
+
+    private final String externalRecipientKafka = "kafka_recipient";
+    private final String externalRecipientHttp = "http_recipient";
+    private final Map<String, String> externalRecipientsMapping = new HashMap<String, String>() {
+        {
+            put (externalRecipientKafka, "kafka://");
+            put (externalRecipientHttp, "http://");
+        }
+    };
+
+    @Test
+    void sendCardToExternalApplicationKafka() {
+        CardPublicationData card = createCardPublicationData(externalRecipientKafka);
+        ReflectionTestUtils.setField(cut, "externalRecipients", externalRecipientsMapping);
+        cut.sendCardToExternalApplication(card);
+        verify (responseCardProducer).send(card);
+    }
+
+    @Test
+    void sendCardToExternalApplicationHttp() {
+        CardPublicationData card = createCardPublicationData(externalRecipientHttp);
+        ReflectionTestUtils.setField(cut, "externalRecipients", externalRecipientsMapping);
+        cut.sendCardToExternalApplication(card);
+        verify (restTemplate).postForObject(anyString(), any(), any());
+    }
+
+    private CardPublicationData createCardPublicationData( String externalRecipients ) {
+        return  CardPublicationData.builder().publisher("PUBLISHER_1").processVersion("O")
+                .processInstanceId("PROCESS_1").severity(SeverityEnum.ALARM)
+                .title(I18nPublicationData.builder().key("title").build())
+                .summary(I18nPublicationData.builder().key("summary").build())
+                .startDate(Instant.now())
+                .recipient(RecipientPublicationData.builder().type(DEADEND).build())
+                .timeSpan(TimeSpanPublicationData.builder()
+                        .start(Instant.ofEpochMilli(123l)).build())
+                .process("process1")
+                .state("state1")
+                .externalRecipients(Arrays.asList(externalRecipients))
+                .build();
+    }
+}

--- a/src/docs/asciidoc/deployment/configuration/configuration.adoc
+++ b/src/docs/asciidoc/deployment/configuration/configuration.adoc
@@ -105,11 +105,14 @@ The cards-publication service has these specific properties :
 
 |checkPerimeterForResponseCard|true|no|If false, OperatorFabric will not check that a user has write rights on a process/state to respond to a card
 |spring.kafka.consumer.group-id |null|no| If set, support for receiving cards via Kafka is enabled
-|spring.deserializer.key.delegate.class |io.confluent.kafka.serializers.
-|KafkaAvroDeserializer|yes| Deserializer used to convert the received bytes into objects
-|opfab.kafka.topics.topicname |opfab|no|Name of the topic to read the messages from
-|schema.registry.url|http://localhost:8081|yes|URL of the schema registry. Can be set to the empty string "" is no registry is used
+|spring.deserializer.value.delegate.class|io.confluent.kafka.serializers.
+KafkaAvroDeserializer|yes| Deserializer used to convert the received bytes into objects
+|spring.serializer.value.delegate.class |io.confluent.kafka.serializers.
+KafkaAvroSerializer|yes|Serializer used to convert cards to bytes
 |spring.kafka.producer.bootstrap-servers|http://localhost:9092|no|comma seperated list of URL(s) of the broker(s) / bootstrap server(s)
+|opfab.kafka.topics.card.topicname |opfab|no|Name of the topic to read the messages from
+|opfab.kafka.topics.response-card.topicname |opfab|no|Name of the topic to place the response cards to
+|opfab.kafka.schema.registry.url|http://localhost:8081|yes|URL of the schema registry. Can be set to the empty string "" is no registry is used
 |===
 
 
@@ -162,6 +165,17 @@ See link:{spring_kafka_doc}[Spring for Apache Kafka] for more information on the
 
 With the default settings, the Kafka consumer expects a broker running on http//127.0.0.1:9092 and a schema registry on http://127.0.0.1:8081.
 
-Response cards are not (yet) returned via Kafka, but by the URL specified in the cards-publication yml file.
+Operator Fabric is also able to publish response cards to a Kafka topic. The default topic name  `opfab-response`. You can specify which response cards
+are to be returned via Kafka by setting the `externalRecipients-url` in the `cards-publication` yaml file. Instead of setting `http://` URL you should set it to `kafka:`
 
-Note that enabling Kafka does not disable the REST interface.
+[source, yaml]
+----
+externalRecipients-url: "{\
+           processAction: \"http://localhost:8090/test\", \
+           mykafka: \"kafka:topicname\"
+           }"
+----
+
+Note that `topicname` is a placeholder for now. All response cards are returned via the same Kafka topic.
+
+Also note enabling Kafka does not disable the REST interface.

--- a/src/docs/asciidoc/dev_env/kafka.adoc
+++ b/src/docs/asciidoc/dev_env/kafka.adoc
@@ -24,7 +24,7 @@ To enable Kafka support you need to set the `kafka.consumer.group_id property` i
       group-id: opfab-command
 ----
 
-The default topic from which the messages are consumed is called 'opfab'. This setting can be modified by setting 'opfab.kafka.topics.topicname'.
+The default topic from which the messages are consumed is called 'opfab'. This setting can be modified by setting 'opfab.kafka.card.topics.topicname'.
 
 Make sure you also set the registry to either an empty string (`""`) or to the server providing the schema registry service.
 With the default settings, the Kafka consumer expects a broker running on http//127.0.0.1:9092 and a schema registry on http://127.0.0.1:8081.
@@ -42,8 +42,8 @@ the implementation of the deserializers and mapping of Kafka topics to OperatorF
 for the various Kafka configuration options.
 
 === Kafka OperatorFabric AVRO schema
-The AVRO schema, the byte format in which messages are transffered using Kafka topics, can be found at `client/src/main/avro`.
-Message are wrapped in a the CardCommand object before being sent to a Kafka topic.
+The AVRO schema, the byte format in which messages are transferred using Kafka topics, can be found at `client/src/main/avro`.
+Message are wrapped in a CardCommand object before being sent to a Kafka topic.
 This object is an almost one-to-one mapping of the OperatorFabric card, see also <<card_structure>>. The exceptions are  `Process` and
 `Process Instance Identifier`, which are moved to the top-level CardCommand.
 
@@ -52,7 +52,7 @@ This object is an almost one-to-one mapping of the OperatorFabric card, see also
 === Setting a new deserializer
 By default, OperatorFabric uses the  `io.confluent.kafka.serializers.KafkaAvroDeserializer` from link:{confluent}[Confluent]. However, you can write your own
 deserializer. To use your own deserializer, make sure
-`spring.kafka.deserializer.value` points to your deserializer.
+`spring.deserializer.value.delegate.class` points to your deserializer.
 
 
 == Kafka card producer
@@ -107,5 +107,16 @@ the dump below.
 ----
 
 == Response Cards
-OperatorFabric <<response_cards>> are currently returned only via REST. At the time of writing it is not possible to return
-response cards via Kafka.
+OperatorFabric <<response_cards>> can be sent by REST of put on a Kafka topic. The Kafka response card configuration follows the
+convention to configure a REST endpoint. Instead of setting the 'http://host/api' URL, you set it to 'kafka:response-topic' in the `externalRecipients-url:`
+section from the cards-publication.yml file:
+
+[source, yaml]
+----
+externalRecipients-url: "{\
+           processAction: \"http://localhost:8090/test\", \
+           mykafka: \"kafka:topicname\"
+           }"
+----
+
+Note that `topicname` is a placeholder for now. All response cards are returned via the same Kafka topic.


### PR DESCRIPTION
OC-1231: Enbles response-cards via a Kafka topic

This branch enables OpFab to return a response-card using a Kafka topic.
The configuration is similar to response-cards returned by REST. Instead of **http://** you should set the "URL" to **kafka:** in the externalRecipients-url config.

Example:
` externalRecipients-url: "{ \
 externalRecipient2: \"http://localhost:8090/test\", \
myKafkaRecipient: \"kafka:\" \ 
}" `
