### PR TITLE
[OC-1247] Changes to Kafka AVRO scheme for clearity

### DIFF
--- a/client/cards/src/main/avro/card.avsc
+++ b/client/cards/src/main/avro/card.avsc
@@ -14,6 +14,14 @@
       "default": null
     },
     {
+      "name": "process",
+      "type": "string"
+    },
+    {
+      "name": "processInstanceId",
+      "type": "string"
+    },
+    {
       "name": "publisher",
       "type": "string"
     },

--- a/client/cards/src/main/avro/cardCommand.avsc
+++ b/client/cards/src/main/avro/cardCommand.avsc
@@ -13,14 +13,6 @@
         }
     },
     {
-      "name": "process",
-      "type": "string"
-    },
-    {
-      "name": "processInstanceId",
-      "type": "string"
-    },
-    {
       "name": "card",
       "type": ["null","Card"],
       "default": null

--- a/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/kafka/card/CardCommandFactory.java
+++ b/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/kafka/card/CardCommandFactory.java
@@ -35,8 +35,6 @@ public class CardCommandFactory {
             kafkaCard = objectMapper.readCardValue(objectMapper.writeValueAsString(cardPublicationData), Card.class);
             cardCommand.setCommand(CommandType.RESPONSE_CARD);
             cardCommand.setCard(kafkaCard);
-            cardCommand.setProcess(cardPublicationData.getProcess());
-            cardCommand.setProcessInstanceId(cardPublicationData.getProcessInstanceId());
 
             String cardDataString = objectMapper.writeValueAsString(cardData);
             kafkaCard.setData(cardDataString);

--- a/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/kafka/command/BaseCommandHandler.java
+++ b/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/kafka/command/BaseCommandHandler.java
@@ -38,8 +38,6 @@ public class BaseCommandHandler {
         Map<String, Object> cardData = Collections.emptyMap();
         try {
             card = objectMapper.readValue(objectMapper.writeValueAsString(kafkaCard), CardPublicationData.class);
-            card.setProcess(cardCommand.getProcess());
-            card.setProcessInstanceId(cardCommand.getProcessInstanceId());
 
             String cardDataString = kafkaCard.getData();
             if (cardDataString != null) {

--- a/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/kafka/command/CreateCardCommandHandler.java
+++ b/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/kafka/command/CreateCardCommandHandler.java
@@ -11,6 +11,7 @@ package org.lfenergy.operatorfabric.cards.publication.kafka.command;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.lfenergy.operatorfabric.avro.Card;
 import org.lfenergy.operatorfabric.avro.CardCommand;
 import org.lfenergy.operatorfabric.avro.CommandType;
 import org.lfenergy.operatorfabric.cards.publication.model.CardPublicationData;
@@ -32,8 +33,9 @@ public class CreateCardCommandHandler extends BaseCommandHandler implements Comm
 
     @Override
     public void executeCommand(CardCommand cardCommand)  {
+        Card kafkaCard = cardCommand.getCard();
         log.debug("Received Kafka CREATE CARD with processInstanceId {}, taskId {} and variables: {}",
-                cardCommand.getProcessInstanceId(), cardCommand.getProcess(), cardCommand.getCard().getData());
+                kafkaCard.getProcessInstanceId(), kafkaCard.getProcess(), kafkaCard.getData());
 
         CardPublicationData card = buildCardPublicationData(cardCommand);
         if (card != null) {

--- a/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/kafka/command/DeleteCardCommandHandler.java
+++ b/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/kafka/command/DeleteCardCommandHandler.java
@@ -11,6 +11,7 @@ package org.lfenergy.operatorfabric.cards.publication.kafka.command;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.lfenergy.operatorfabric.avro.Card;
 import org.lfenergy.operatorfabric.avro.CardCommand;
 import org.lfenergy.operatorfabric.avro.CommandType;
 import org.lfenergy.operatorfabric.cards.publication.model.CardPublicationData;
@@ -31,8 +32,9 @@ public class DeleteCardCommandHandler extends BaseCommandHandler implements Comm
 
     @Override
     public void executeCommand(CardCommand cardCommand) {
+        Card kafkaCard = cardCommand.getCard();
         log.debug("Received Kafka DELETE CARD with processInstanceId {}, taskId {} and variables: {}",
-                cardCommand.getProcessInstanceId(), cardCommand.getProcess(), cardCommand.getCard().getData());
+                kafkaCard.getProcessInstanceId(), kafkaCard.getProcess(), kafkaCard.getData());
 
         CardPublicationData card = buildCardPublicationData(cardCommand);
         if (card != null) {

--- a/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/kafka/command/UpdateCardCommandHandler.java
+++ b/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/kafka/command/UpdateCardCommandHandler.java
@@ -11,6 +11,7 @@ package org.lfenergy.operatorfabric.cards.publication.kafka.command;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.lfenergy.operatorfabric.avro.Card;
 import org.lfenergy.operatorfabric.avro.CardCommand;
 import org.lfenergy.operatorfabric.avro.CommandType;
 import org.lfenergy.operatorfabric.cards.publication.model.CardPublicationData;
@@ -32,8 +33,9 @@ public class UpdateCardCommandHandler extends BaseCommandHandler implements Comm
 
     @Override
     public void executeCommand(CardCommand cardCommand) {
+        Card kafkaCard = cardCommand.getCard();
         log.debug("Received Kafka UPDATE CARD with processInstanceId {}, taskId {} and variables: {}",
-                cardCommand.getProcessInstanceId(), cardCommand.getProcess(), cardCommand.getCard().getData());
+                kafkaCard.getProcessInstanceId(), kafkaCard.getProcess(), kafkaCard.getData());
 
         CardPublicationData card = buildCardPublicationData(cardCommand);
         if (card != null) {

--- a/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/kafka/producer/ResponseCardProducer.java
+++ b/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/kafka/producer/ResponseCardProducer.java
@@ -38,7 +38,7 @@ public class ResponseCardProducer {
         CardCommand cardCommand = cardCommandFactory.create(cardPublicationData);
 
         ListenableFuture<SendResult<String, CardCommand>> future =
-                kafkaTemplate.send(topic, cardCommand.getProcess(), cardCommand);
+                kafkaTemplate.send(topic, cardCommand.getCard().getProcess(), cardCommand);
         future.addCallback(new ListenableFutureCallback<SendResult<String, CardCommand>>() {
             @Override
             public void onFailure(Throwable throwable) {

--- a/services/core/cards-publication/src/test/java/org/lfenergy/operatorfabric/cards/publication/kafka/card/CardCommandFactoryShould.java
+++ b/services/core/cards-publication/src/test/java/org/lfenergy/operatorfabric/cards/publication/kafka/card/CardCommandFactoryShould.java
@@ -47,7 +47,7 @@ class CardCommandFactoryShould {
         CardCommand cardCommand = cut.create(cardPublicationData);
 
         assertThat (cardCommand.getCommand(), is (CommandType.RESPONSE_CARD));
-        assertThat (cardCommand.getProcess(), is (cardPublicationData.getProcess()));
+        assertThat (cardCommand.getCard().getProcess(), is (cardPublicationData.getProcess()));
         assertThat (cardCommand.getCard().getState(), is(cardPublicationData.getState()));
     }
 

--- a/services/core/cards-publication/src/test/java/org/lfenergy/operatorfabric/cards/publication/kafka/command/BaseCommandHandlerShould.java
+++ b/services/core/cards-publication/src/test/java/org/lfenergy/operatorfabric/cards/publication/kafka/command/BaseCommandHandlerShould.java
@@ -37,8 +37,6 @@ import static org.mockito.Mockito.when;
 class BaseCommandHandlerShould {
 
     private final String ANY_STRING = "any_string";
-    private final String PROCESS = "a_process";
-    private final String PROCESS_INSTANCE_ID = "a_process_instance_id";
     private final String DATA_KEY = "key";
     private final String DATA_VALUE = "value";
 
@@ -57,11 +55,10 @@ class BaseCommandHandlerShould {
         ReflectionTestUtils.setField(cut, "objectMapper", objectMapper);
         CardPublicationData cardPublicationData = CardPublicationData.builder()
                 .build();
+
         cardCommand = mock(CardCommand.class);
         card = mock(Card.class);
         when(cardCommand.getCard()).thenReturn(card);
-        when(cardCommand.getProcess()).thenReturn(PROCESS);
-        when(cardCommand.getProcessInstanceId()).thenReturn(PROCESS_INSTANCE_ID);
         when(objectMapper.writeValueAsString(card)).thenReturn(ANY_STRING);
         when(objectMapper.readValue(ANY_STRING, CardPublicationData.class)).thenReturn(cardPublicationData);
     }
@@ -72,8 +69,6 @@ class BaseCommandHandlerShould {
         CardPublicationData result = cut.buildCardPublicationData(cardCommand);
         Map<String,Object> data = (Map<String,Object>) result.getData();
         Assertions.assertThat(data.size()).isEqualTo(0);
-        Assertions.assertThat(result.getProcess()).isEqualTo(PROCESS);
-        Assertions.assertThat(result.getProcessInstanceId()).isEqualTo(PROCESS_INSTANCE_ID);
     }
 
     @Test
@@ -86,8 +81,6 @@ class BaseCommandHandlerShould {
         Map<String,Object> data = (Map<String,Object>) result.getData();
         Assertions.assertThat(data.size()).isEqualTo(1);
         Assertions.assertThat(data.get(DATA_KEY)).isEqualTo(DATA_VALUE);
-        Assertions.assertThat(result.getProcess()).isEqualTo(PROCESS);
-        Assertions.assertThat(result.getProcessInstanceId()).isEqualTo(PROCESS_INSTANCE_ID);
     }
 
 }

--- a/services/core/cards-publication/src/test/java/org/lfenergy/operatorfabric/cards/publication/kafka/producer/KafkaAvroWithoutRegistrySerializerShould.java
+++ b/services/core/cards-publication/src/test/java/org/lfenergy/operatorfabric/cards/publication/kafka/producer/KafkaAvroWithoutRegistrySerializerShould.java
@@ -55,6 +55,8 @@ class KafkaAvroWithoutRegistrySerializerShould {
 
     private Card createCard() {
         return Card.newBuilder()
+                .setProcess("Process")
+                .setProcessInstanceId("InstanceId")
                 .setPublisher("Publisher")
                 .setProcessVersion("ProcessVersion")
                 .setStartDate(12345L)
@@ -67,8 +69,6 @@ class KafkaAvroWithoutRegistrySerializerShould {
     private CardCommand createCardCommand(Card card) {
         return CardCommand.newBuilder()
                 .setCommand(CommandType.CREATE_CARD)
-                .setProcess("Process")
-                .setProcessInstanceId("InstanceId")
                 .setCard(card)
                 .build();
     }

--- a/services/core/cards-publication/src/test/java/org/lfenergy/operatorfabric/cards/publication/kafka/producer/ResponseCardProducerShould.java
+++ b/services/core/cards-publication/src/test/java/org/lfenergy/operatorfabric/cards/publication/kafka/producer/ResponseCardProducerShould.java
@@ -14,6 +14,7 @@ import org.apache.kafka.common.TopicPartition;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.lfenergy.operatorfabric.avro.Card;
 import org.lfenergy.operatorfabric.avro.CardCommand;
 import org.lfenergy.operatorfabric.cards.publication.kafka.card.CardCommandFactory;
 import org.lfenergy.operatorfabric.cards.publication.model.CardPublicationData;
@@ -47,6 +48,7 @@ class ResponseCardProducerShould {
     private ListenableFuture<SendResult<String, CardCommand>> responseFuture;
     private CardPublicationData cardPublicationData;
     private CardCommand cardCommand;
+    private Card card;
 
     private final int partition = 11;
     private final int offset = 2;
@@ -59,7 +61,9 @@ class ResponseCardProducerShould {
 
         cardPublicationData = mock(CardPublicationData.class);
         cardCommand = mock(CardCommand.class);
-        when(cardCommand.getProcess()).thenReturn(key);
+        card = mock(Card.class);
+        when(card.getProcess()).thenReturn(key);
+        when(cardCommand.getCard()).thenReturn(card);
         when (cardCommandFactory.create(any())).thenReturn(cardCommand);
 
         responseFuture = mock(ListenableFuture.class);

--- a/src/docs/asciidoc/dev_env/kafka.adoc
+++ b/src/docs/asciidoc/dev_env/kafka.adoc
@@ -43,10 +43,9 @@ for the various Kafka configuration options.
 
 === Kafka OperatorFabric AVRO schema
 The AVRO schema, the byte format in which messages are transferred using Kafka topics, can be found at `client/src/main/avro`.
-Message are wrapped in a CardCommand object before being sent to a Kafka topic.
-This object is an almost one-to-one mapping of the OperatorFabric card, see also <<card_structure>>. The exceptions are  `Process` and
-`Process Instance Identifier`, which are moved to the top-level CardCommand.
-
+Message are wrapped in a CardCommand object before being sent to a Kafka topic. The CardCommand consists of some additional information and the
+OperatorFabric card itself, see also <<card_structure>>. The additional information, for example CommandType, consists mostly of the information
+present in a REST operation but not in Kafka. For example the http method (POST, DELETE, UPDATE) used.
 
 == Configure Kafka
 === Setting a new deserializer


### PR DESCRIPTION
[OC-1247]. Moved process and processInstanceId from CardCommand to Card in the AVRO schema. Now Card is a 100% match to the REST API Card. All that is left in CardCommand are properties present in the REST method (like POST, DELETE, UPDATE) that are not available on Kafka

[OC-1247]: https://opfab.atlassian.net/browse/OC-1247