### PR TITLE
[OC-1248] Users service : do not trace the stack trace exception, only the message

### DIFF
--- a/services/core/users/src/main/java/org/lfenergy/operatorfabric/users/controllers/CustomExceptionHandler.java
+++ b/services/core/users/src/main/java/org/lfenergy/operatorfabric/users/controllers/CustomExceptionHandler.java
@@ -51,7 +51,7 @@ public class CustomExceptionHandler extends ResponseEntityExceptionHandler {
   @ExceptionHandler(ApiErrorException.class)
   public ResponseEntity<Object> handleApiError(ApiErrorException exception, final WebRequest
      request) {
-    log.info(GENERIC_MSG,exception);
+    log.info(GENERIC_MSG + " : " + exception.getError().getMessage());
     return new ResponseEntity<>(exception.getError(), exception.getError().getStatus());
   }
 


### PR DESCRIPTION
Release notes : 
In Tasks section : 

[OC-1248](https://opfab.atlassian.net/browse/OC-1248) : Users service : do not trace the stack trace exception, only the message