### PR TITLE
[OC-1139] Add in documentation : describe notion of processes groups

### DIFF
--- a/src/docs/asciidoc/reference_doc/process_definition.adoc
+++ b/src/docs/asciidoc/reference_doc/process_definition.adoc
@@ -187,7 +187,7 @@ ifndef::single-page-doc[<<{gradle-rootdir}/documentation/current/reference_doc/i
 The following templates display a l10n title and a line containing the value of the scope property `card.level1.level1Prop`.
 In english, the translation of this key is '_This is a root property_'.
 
-`/template/en/template1.handlers`
+`/template/en/template1.handlebars`
 
 [source,html]
 ----
@@ -195,7 +195,7 @@ In english, the translation of this key is '_This is a root property_'.
 <div class="bundle-test">'{{card.data.level1.level1Prop}}'</div>
 ----
 
-`/template/fr/template1.handlers`
+`/template/fr/template1.handlebars`
 
 [source,html]
 ----
@@ -205,7 +205,7 @@ In english, the translation of this key is '_This is a root property_'.
 
 The two following template examples display also a l10n title and a list of numeric values from 1 to 3.
 
-`/template/en/template2.handelbars`
+`/template/en/template2.handlebars`
 
 [source,html]
 ----
@@ -217,7 +217,7 @@ The two following template examples display also a l10n title and a list of nume
 </ul>
 ----
 
-`/template/fr/template2.handelbars`
+`/template/fr/template2.handlebars`
 
 [source,html]
 ----
@@ -332,3 +332,66 @@ For further help check the
 ifdef::single-page-doc[<<troubleshooting_bundle, Troubleshooting>>]
 ifndef::single-page-doc[<<{gradle-rootdir}/documentation/current/getting_started/index.adoc#troubleshooting_bundle, Troubleshooting>>]
 section which resumes how to resolve common problems.
+
+== Processes groups
+
+OperatorFabric offers the possibility of defining processes groups. These groups have an impact only on the UI, for example on the notification configuration screen, by offering a more organized view of all the processes.
+
+To define processes groups, you have to upload a file via a `POST` http request as described in the
+ifdef::single-page-doc[<<../api/businessconfig/#/businessconfig/uploadProcessgroups, Businessconfig Service API documentation>>]
+ifndef::single-page-doc[<<{gradle-rootdir}/documentation/current/api/businessconfig/#/businessconfig/uploadProcessgroups, Businessconfig Service API documentation>>]
+.
+
+*Example*
+
+[source,shell]
+----
+cd ${PROCESSES_GROUPS_FOLDER}
+curl -X POST "http://localhost:2100/businessconfig/processgroups"\
+	-H "accept: application/json"\
+	-H "Content-Type: multipart/form-data"\
+	-F "file=@processesGroups.json"\
+	-H "Authorization: Bearer ${token}"
+----
+
+Where:
+
+- `${PROCESSES_GROUPS_FOLDER}` is the folder containing the processes groups file to upload.
+- `processesGroups.json` is the name of the uploaded file.
+- `${token}` is a valid token for OperatorFabric use.
+
+Example of content for uploaded file :
+[source,json]
+----
+{
+  "groups": [
+    {
+      "id": "processgroup1",
+      "processes": [
+        "process1",
+        "process2"
+      ]
+    },
+    {
+      "id": "processgroup2",
+      "processes": [
+        "process3",
+        "process4"
+      ]
+    }
+  ],
+  "locale": {
+    "en": {
+      "processgroup1": "Process Group 1",
+      "processgroup2": "Process Group 2"
+    },
+    "fr": {
+      "processgroup1": "Groupe de process 1",
+      "processgroup2": "Groupe de process 2"
+    }
+  }
+}
+
+----
+
+These command line should return a `201 http status`.


### PR DESCRIPTION
Frederic, I propose for release notes : 

In Tasks section : 

Documentation :
    [OC-1139] Add in documentation : describe notion of processes groups



[OC-1139]: https://opfab.atlassian.net/browse/OC-1139