### PR TITLE
Delete card without id, but based on process and processInstanceId

### DIFF
--- a/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/kafka/command/DeleteCardCommandHandler.java
+++ b/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/kafka/command/DeleteCardCommandHandler.java
@@ -38,7 +38,7 @@ public class DeleteCardCommandHandler extends BaseCommandHandler implements Comm
 
         CardPublicationData card = buildCardPublicationData(cardCommand);
         if (card != null) {
-            cardProcessingService.deleteCard(card.getProcessInstanceId());
+            cardProcessingService.deleteCard(card);
         }
     }
 }

--- a/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/services/CardProcessingService.java
+++ b/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/services/CardProcessingService.java
@@ -11,6 +11,7 @@
 package org.lfenergy.operatorfabric.cards.publication.services;
 
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang.StringUtils;
 import org.lfenergy.operatorfabric.aop.process.AopTraceType;
 import org.lfenergy.operatorfabric.aop.process.mongo.models.UserActionTraceData;
 import org.lfenergy.operatorfabric.cards.model.CardOperationTypeEnum;
@@ -251,6 +252,13 @@ public class CardProcessingService {
     public Optional<CardPublicationData> deleteCard(String id) {
         CardPublicationData cardToDelete = cardRepositoryService.findCardById(id);
         return deleteCard0(cardToDelete);
+    }
+
+    public Optional<CardPublicationData> deleteCard(CardPublicationData card) {
+        if (StringUtils.isEmpty(card.getId())) {
+            card.prepare(card.getPublishDate());
+        }
+        return deleteCard0(card);
     }
 
     public Optional<CardPublicationData> deleteUserCard(String id, CurrentUserWithPerimeters user) {

--- a/services/core/cards-publication/src/test/java/org/lfenergy/operatorfabric/cards/publication/kafka/command/DeleteCardCommandHandlerShould.java
+++ b/services/core/cards-publication/src/test/java/org/lfenergy/operatorfabric/cards/publication/kafka/command/DeleteCardCommandHandlerShould.java
@@ -66,7 +66,7 @@ class DeleteCardCommandHandlerShould {
         when(objectMapper.readValue(anyString(), eq(CardPublicationData.class))).thenReturn(cardPublicationDataMock);
         cut.executeCommand(cardCommandMock);
 
-        verify(cardProcessingService, times(1)).deleteCard(any());
+        verify(cardProcessingService, times(1)).deleteCard(eq(cardPublicationDataMock));
     }
 
 }

--- a/services/core/cards-publication/src/test/java/org/lfenergy/operatorfabric/cards/publication/services/CardProcessServiceShould.java
+++ b/services/core/cards-publication/src/test/java/org/lfenergy/operatorfabric/cards/publication/services/CardProcessServiceShould.java
@@ -439,6 +439,55 @@ class CardProcessServiceShould {
                 .expectNextMatches(r -> r.intValue()==thereShouldBeOneCardLess).verifyComplete();
     }
 
+    @Test
+    void deleteOneCard_with_card_no_id() {
+
+        EasyRandom easyRandom = instantiateRandomCardGenerator();
+        int numberOfCards = 13;
+        List<CardPublicationData> cards = instantiateSeveralRandomCards(easyRandom, numberOfCards);
+        cards.forEach(c -> {
+            c.setParentCardId(null);
+            c.setInitialParentCardUid(null);
+        });
+
+        StepVerifier.create(cardProcessingService.processCards(Flux.just(cards.toArray(new CardPublicationData[numberOfCards]))))
+                .expectNextMatches(r -> r.getCount().equals(numberOfCards)).verifyComplete();
+
+        CardPublicationData firstCard = cards.get(0);
+        firstCard.setId(null);
+        cardProcessingService.deleteCard(firstCard);
+
+        /* one card should be deleted(the first one) */
+        int thereShouldBeOneCardLess = numberOfCards - 1;
+
+        StepVerifier.create(cardRepository.count())
+                .expectNextMatches(r -> r.intValue()==thereShouldBeOneCardLess).verifyComplete();
+    }
+
+    @Test
+    void deleteOneCard_with_card_with_id() {
+
+        EasyRandom easyRandom = instantiateRandomCardGenerator();
+        int numberOfCards = 13;
+        List<CardPublicationData> cards = instantiateSeveralRandomCards(easyRandom, numberOfCards);
+        cards.forEach(c -> {
+            c.setParentCardId(null);
+            c.setInitialParentCardUid(null);
+        });
+
+        StepVerifier.create(cardProcessingService.processCards(Flux.just(cards.toArray(new CardPublicationData[numberOfCards]))))
+                .expectNextMatches(r -> r.getCount().equals(numberOfCards)).verifyComplete();
+
+        CardPublicationData firstCard = cards.get(0);
+        cardProcessingService.deleteCard(firstCard);
+
+        /* one card should be deleted(the first one) */
+        int thereShouldBeOneCardLess = numberOfCards - 1;
+
+        StepVerifier.create(cardRepository.count())
+                .expectNextMatches(r -> r.intValue()==thereShouldBeOneCardLess).verifyComplete();
+    }
+
     // FIXME unify way test cards are created throughout tests
     private List<CardPublicationData> instantiateSeveralRandomCards(EasyRandom randomGenerator, int cardNumber) {
 


### PR DESCRIPTION
OC-delete-card-without-id
Added a new method which accepts a card which is then deleted. If the card does not have an id set, the id is calculated.
Please check if you are fine with using the card.prepare() method like this.
