### PR TITLE
[OC-1275] Delete all cards in the UI state before reloading them when…

### DIFF
--- a/ui/main/src/app/modules/feedconfiguration/feedconfiguration.component.ts
+++ b/ui/main/src/app/modules/feedconfiguration/feedconfiguration.component.ts
@@ -18,7 +18,8 @@ import { UserWithPerimeters } from '@ofModel/userWithPerimeters.model';
 import { ProcessesService } from '@ofServices/processes.service';
 import { FormArray, FormBuilder, FormControl, FormGroup } from '@angular/forms';
 import { SettingsService } from '@ofServices/settings.service';
-import {CardService} from "@ofServices/card.service";
+import {CardService} from '@ofServices/card.service';
+import {EmptyLightCards} from '@ofActions/light-card.actions';
 
 
 @Component({
@@ -182,6 +183,7 @@ export class FeedconfigurationComponent implements OnInit {
                         this.messageAfterSavingSettings = 'feedConfiguration.settingsSavedWithNoError';
                         this.displaySendResultOk = true;
                         this.cardService.resetStartOfAlreadyLoadedPeriod();
+                        this.store.dispatch(new EmptyLightCards());
                     }
                     this.modalRef.close();
                 },


### PR DESCRIPTION
Release notes : 

In Tasks section :

[OC-1275](https://opfab.atlassian.net/browse/OC-1275) : Delete all cards in the UI state  before reloading them when changing notification reception filter