### PR TITLE
[OC-1341] Monitoring screen adjustement

### DIFF
--- a/src/test/utils/karate/businessconfig/resources/bundle_userCardExamples/i18n/fr.json
+++ b/src/test/utils/karate/businessconfig/resources/bundle_userCardExamples/i18n/fr.json
@@ -6,7 +6,7 @@
 	},
 	"conference":{
 		"title":"Conférence téléphonique ☏",
-		"summary":"You êtes invités à une conférence téléphonique"
+		"summary":"Vous êtes invité à une conférence téléphonique"
 	},
 	"question":{
 		"title":"Question",

--- a/ui/main/src/app/model/line-of-monitoring-result.model.ts
+++ b/ui/main/src/app/model/line-of-monitoring-result.model.ts
@@ -1,4 +1,4 @@
-/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+/* Copyright (c) 2018-2021, RTE (http://www.rte-france.com)
  * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -20,4 +20,5 @@ export interface LineOfMonitoringResult {
     coordinationStatus: string;
     coordinationStatusColor: string;
     cardId: string;
+    severity: string;
 }

--- a/ui/main/src/app/modules/monitoring/components/monitoring-table/monitoring-table.component.html
+++ b/ui/main/src/app/modules/monitoring/components/monitoring-table/monitoring-table.component.html
@@ -1,4 +1,4 @@
-<!-- Copyright (c) 2018-2020, RTE (http://www.rte-france.com)              -->
+<!-- Copyright (c) 2018-2021, RTE (http://www.rte-france.com)              -->
 <!-- Copyright (c) 2020, RTEi (http://www.rte-international.com)           -->
 <!-- See AUTHORS.txt                                                       -->
 <!-- This Source Code Form is subject to the terms of the Mozilla Public   -->
@@ -14,7 +14,7 @@
         <tr>
             <th scope="col"></th>
             <th scope="col" translate>monitoring.time</th>
-            <th colspan="2" scope="col" translate>monitoring.businessPeriod</th>
+            <th scope="col" translate>monitoring.businessPeriod</th>
             <th scope="col" translate>monitoring.filters.process</th>
             <th scope="col" translate>monitoring.title</th>
             <th scope="col" translate>monitoring.summary</th>
@@ -24,16 +24,13 @@
     </thead>
     <tbody>
         <tr *ngFor="let line of result" (click)="selectCard(line.cardId)" style="cursor: pointer;">
-            <td [ngStyle]="{'background-color': line.coordinationStatusColor, 'color': line.coordinationStatusColor}" style="width: 15px;"> 
-                
-            </td>
+            <td class="opfab-monitoring-sev opfab-monitoring-sev-{{line.severity}}"></td>
             <td>{{displayTime(line.creationDateTime)}}</td>
-            <td>{{displayTime(line.beginningOfBusinessPeriod)}}</td>
-            <td>{{displayTime(line.endOfBusinessPeriod)}}</td>
+            <td>{{displayTime(line.beginningOfBusinessPeriod)}} - {{displayTime(line.endOfBusinessPeriod)}}</td>
             <td translate>{{line.processName}}</td>
             <td translate [translateParams]="line.title.parameters">{{line.title.key}}</td>
             <td translate [translateParams]="line.summary.parameters">{{line.summary.key}}</td>
-            <td translate>{{line.coordinationStatus}} </td>
+            <td translate [ngStyle]="{'color': line.coordinationStatusColor}">{{line.coordinationStatus}} </td>
         </tr>
     </tbody>
 </table>

--- a/ui/main/src/app/modules/monitoring/components/monitoring-table/monitoring-table.component.scss
+++ b/ui/main/src/app/modules/monitoring/components/monitoring-table/monitoring-table.component.scss
@@ -1,4 +1,4 @@
-/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+/* Copyright (c) 2018-2021, RTE (http://www.rte-france.com)
  * Copyright (c) 2020, RTEi (http://www.rte-international.com)
  * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
@@ -7,6 +7,8 @@
  * SPDX-License-Identifier: MPL-2.0
  * This file is part of the OperatorFabric project.
  */
+
+ @import "~assets/styles/_variables.scss";
 
 
 .export-div {
@@ -19,3 +21,13 @@
 .export-btn {
   float: right;
 }
+
+.opfab-monitoring-sev {
+  width: 15px;
+}
+
+
+.opfab-monitoring-sev-alarm {background-color: $sev-alarm;}
+.opfab-monitoring-sev-action {background-color: $sev-action;}
+.opfab-monitoring-sev-compliant {background-color: $sev-compliant;}
+.opfab-monitoring-sev-information {background-color: $sev-information;}

--- a/ui/main/src/app/modules/monitoring/components/monitoring-table/monitoring-table.component.ts
+++ b/ui/main/src/app/modules/monitoring/components/monitoring-table/monitoring-table.component.ts
@@ -1,4 +1,4 @@
-/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+/* Copyright (c) 2018-2021, RTE (http://www.rte-france.com)
 * Copyright (c) 2020, RTEi (http://www.rte-international.com)
 * See AUTHORS.txt
 * This Source Code Form is subject to the terms of the Mozilla Public
@@ -74,7 +74,8 @@ export class MonitoringTableComponent implements OnDestroy {
                     process: processName,
                     title: title,
                     summary: summary,
-                    status: status
+                    status: status,
+                    severity: line.severity
                 });
             }
         });

--- a/ui/main/src/app/modules/monitoring/monitoring.component.ts
+++ b/ui/main/src/app/modules/monitoring/monitoring.component.ts
@@ -1,4 +1,4 @@
-/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+/* Copyright (c) 2018-2021, RTE (http://www.rte-france.com)
  * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -91,7 +91,8 @@ export class MonitoringComponent implements OnInit, OnDestroy, AfterViewInit {
                                         processName: this.prefixForTranslation(card, currentProcess.name),
                                         coordinationStatusColor: color,
                                         coordinationStatus: this.prefixForTranslation(card, name),
-                                        cardId: card.id
+                                        cardId: card.id,
+                                        severity: card.severity.toLocaleLowerCase()
 
                                     } as LineOfMonitoringResult);
                             }


### PR DESCRIPTION
Add a "-"  between start and end date in business date
First column color is severity color (like archives and logging)
Color of the state text is color of the state in config.json

In release note : 

Feature:
[OC-1341] Monitoring screen adjustement

[OC-1341]: https://opfab.atlassian.net/browse/OC-1341