### PR TITLE
[OC-1322] Add link to hide filter in monitoring screen

### DIFF
--- a/src/test/utils/karate/businessconfig/resources/bundle_defaultProcess/i18n/fr.json
+++ b/src/test/utils/karate/businessconfig/resources/bundle_defaultProcess/i18n/fr.json
@@ -1,5 +1,5 @@
 {
-	"process": {"label": "Processus d'example"},
+	"process": {"label": "Processus d'exemple"},
 	"message":{
 		"title":"Message",
 		"summary":"Message reçu"

--- a/src/test/utils/karate/businessconfig/resources/bundle_defaultProcess_V0.1/i18n/fr.json
+++ b/src/test/utils/karate/businessconfig/resources/bundle_defaultProcess_V0.1/i18n/fr.json
@@ -1,5 +1,5 @@
 {
-	"process": {"label": "Processus d'example V0.1"},
+	"process": {"label": "Processus d'exemple V0.1"},
 	"name": "test API",
 	"defaultProcess":{
 		"title":"Message (V0.1)",

--- a/ui/main/src/app/modules/cards/components/detail/detail.component.scss
+++ b/ui/main/src/app/modules/cards/components/detail/detail.component.scss
@@ -217,6 +217,5 @@
   background: var( --opfab-bgcolor);
 }
 .opfab-entities-popover .arrow::after {
-  border-bottom-color: var( --opfab-bgcolor);
   border-bottom: 0px;
 }

--- a/ui/main/src/app/modules/monitoring/components/monitoring-filters/monitoring-filters.component.html
+++ b/ui/main/src/app/modules/monitoring/components/monitoring-filters/monitoring-filters.component.html
@@ -6,11 +6,12 @@
 <!-- SPDX-License-Identifier: MPL-2.0                                      -->
 <!-- This file is part of the OperatorFabric project.                      -->
 
-<form [formGroup]="monitoringForm" #currentForm>
+<form [hidden]="hideFilters" [formGroup]="monitoringForm" #currentForm>
+    <!-- Using hidden class rather than ngIf in order to keep selected values when filters are hidden -->
     <div class="opfab-monitoring">
         <div style="display: flex;">
             <div style="margin-top: 28px;margin-right: 40px;position:relative; min-width:400px;max-width:550px;">
-                <of-multi-filter filterPath="process" id="process" 
+                <of-multi-filter filterPath="process" id="process"
                     [parentForm]="monitoringForm" [values]="dropdownList"
                     [dropdownSettings]="dropdownSettings" [selectedItems]="[]" i18nRootLabelKey="monitoring.filters.">
                 </of-multi-filter>
@@ -19,11 +20,11 @@
             <div style="margin-left:40px;margin-right: 30px;width:300px;min-width: 250px;">
                 <div>
                     <of-datetime-filter filterPath="publishDateFrom" formControlName="publishDateFrom"
-                        labelKey="archive.filters."></of-datetime-filter>
+                                        labelKey="archive.filters."></of-datetime-filter>
                 </div>
                 <div>
                     <of-datetime-filter filterPath="publishDateTo" formControlName="publishDateTo"
-                        labelKey="archive.filters."></of-datetime-filter>
+                                        labelKey="archive.filters."></of-datetime-filter>
                 </div>
             </div>
 
@@ -31,7 +32,7 @@
             <div style="margin-left:40px;width:300px;min-width: 250px;">
                 <div>
                     <of-datetime-filter filterPath="activeFrom" formControlName="activeFrom"
-                        labelKey="archive.filters."></of-datetime-filter>
+                                        labelKey="archive.filters."></of-datetime-filter>
                 </div>
                 <div>
                     <of-datetime-filter filterPath="activeTo" formControlName="activeTo" labelKey="archive.filters.">
@@ -51,3 +52,55 @@
     </div>
 
 </form>
+
+
+<div class="opfab-filters-summary" *ngIf="hideFilters">
+    <div class="col-7 align-left" style="margin-left: 5%">
+        <div class="row align-top"><span translate>archive.filters.process</span>: &nbsp;
+            <div *ngIf="this.processSummary&&this.processSummary.length>0 else noSelection">
+            <span *ngFor="let process of listVisibleProcessesForSummary(); let isLast = last">
+                {{process.itemName}}<span *ngIf="!isLast">,&nbsp;</span>
+            </span>
+            <span *ngIf="listDropdownProcessesForSummary() && listDropdownProcessesForSummary().length > 0"
+                  id="opfab-process-summary-dropdown" class="opfab-processes-dropdown" placement="bottom-right" [ngbPopover]="processesDropdown"
+                  container="body" [autoClose]="'true'" popoverClass="opfab-processes-popover">
+              &nbsp;...&nbsp;
+            </span>
+            </div>
+        </div>
+    </div>
+    <div class="col-2 align-left">
+        <div class="row align-top"><span translate>archive.filters.publishDateFrom</span>: &nbsp;
+            <span *ngIf="this.publishDateFromSummary&&this.publishDateFromSummary.length>0 else noSelection">{{this.publishDateFromSummary}}</span>
+        </div>
+        <div class="row align-top"><span translate>archive.filters.publishDateTo</span>: &nbsp;
+            <span *ngIf="this.publishDateToSummary&&this.publishDateToSummary.length>0 else noSelection">{{this.publishDateToSummary}}</span>
+        </div>
+    </div>
+    <div class="col-2 align-left">
+        <div class="row align-top"><span translate>archive.filters.activeFrom</span>: &nbsp;
+            <span *ngIf="this.activeDateFromSummary&&this.activeDateFromSummary.length>0 else noSelection">{{this.activeDateFromSummary}}</span>
+        </div>
+        <div class="row align-top"><span translate>archive.filters.activeTo</span>: &nbsp;
+            <span *ngIf="this.activeDateToSummary&&this.activeDateToSummary.length>0 else noSelection">{{this.activeDateToSummary}}</span>
+        </div>
+    </div>
+    <ng-template #noSelection>
+        <span translate>monitoring.noSelection</span>
+    </ng-template>
+    <ng-template #processesDropdown>
+        <div *ngFor="let process of listDropdownProcessesForSummary();">
+            &nbsp; {{process.itemName}} &nbsp;
+        </div>
+    </ng-template>
+</div>
+
+
+<div class="opfab-showhide-filters">
+    <div id="opfab-monitoring-link-hide-filters" *ngIf="!hideFilters" (click)="showOrHideFilters()">
+        ˄ &nbsp;&nbsp; <span translate> monitoring.hideFilters </span>
+    </div>
+    <div id="opfab-monitoring-link-show-filters" *ngIf="hideFilters" (click)="showOrHideFilters()">
+        ˅ &nbsp;&nbsp; <span translate> monitoring.showFilters </span>
+    </div>
+</div>

--- a/ui/main/src/app/modules/monitoring/components/monitoring-filters/monitoring-filters.component.scss
+++ b/ui/main/src/app/modules/monitoring/components/monitoring-filters/monitoring-filters.component.scss
@@ -27,3 +27,53 @@
     border-color: var(--opfab-form-border-color);
 
 }
+
+.opfab-showhide-filters {
+    background-color: var(--opfab-bgcolor);
+    width: 100%;
+    text-align: right;
+    font-size: 13px;
+    padding-top : 2px;
+    padding-right:20px;
+}
+
+.opfab-showhide-filters:hover {
+    color: var(--opfab-navbar-color-active);
+    font-weight: bold;
+}
+
+.opfab-filters-summary {
+    font-size : 15px;
+    width: 100%;
+    background-color: var(--opfab-timeline-bgcolor);
+    display: flex;
+    padding-top: 5px;
+    padding-bottom: 5px;
+}
+
+.opfab-processes-dropdown {
+    text-align: center;
+    padding-left: 5px;
+}
+
+.opfab-processes-dropdown::after {
+    content: "V";
+    transform: matrix(1, 0, 0, 0.5, 0, 3);
+    position: relative;
+    display: inline-block;
+    width: 30px;
+    height: 100%;
+    text-align: center;
+    font-size: 20px;
+    margin-top: -5px;
+    color: var(--opfab-form-border-color);
+    pointer-events: none;
+}
+
+.opfab-processes-popover {
+    background: var( --opfab-bgcolor);
+}
+.opfab-processes-popover .arrow::after {
+    border-bottom-color: var( --opfab-bgcolor);
+    border-bottom: 0px;
+}

--- a/ui/main/src/app/modules/monitoring/components/monitoring-filters/monitoring-filters.component.scss
+++ b/ui/main/src/app/modules/monitoring/components/monitoring-filters/monitoring-filters.component.scss
@@ -74,6 +74,5 @@
     background: var( --opfab-bgcolor);
 }
 .opfab-processes-popover .arrow::after {
-    border-bottom-color: var( --opfab-bgcolor);
     border-bottom: 0px;
 }

--- a/ui/main/src/app/modules/monitoring/components/monitoring-filters/monitoring-filters.component.ts
+++ b/ui/main/src/app/modules/monitoring/components/monitoring-filters/monitoring-filters.component.ts
@@ -119,6 +119,11 @@ export class MonitoringFiltersComponent implements OnInit, OnDestroy {
         this.monitoringForm.controls.activeTo.patchValue({'date': {'year': end.year(), 'month': end.month() + 1, 'day': end.date()}, 'time': {'hour': end.hour(), 'minute': end.minute()}});
         this.monitoringForm.controls.activeFrom.updateValueAndValidity({onlySelf: false, emitEvent: true});
         this.monitoringForm.controls.activeTo.updateValueAndValidity({onlySelf: false, emitEvent: true});
+
+        // Show init dates on summary (in case the monitoring screen is opened with filters hidden)
+        this.activeDateFromSummary = this.formValueToString(this.monitoringForm.get('activeFrom').value);
+        this.activeDateToSummary = this.formValueToString(this.monitoringForm.get('activeTo').value);
+
     }
 
     sendQuery() {
@@ -219,7 +224,6 @@ export class MonitoringFiltersComponent implements OnInit, OnDestroy {
     }
 
     showOrHideFilters() {
-        console.log("AGU ",this.selectedProcesses.value);
         // Update summary of filters
         // There is no need to use observables are the summary should only be updated when it is needed, rather than react to every selection change
         //This takes advantage of the translation managed by the filter component to produce the list of available processes rather than do the translation again.
@@ -240,7 +244,8 @@ export class MonitoringFiltersComponent implements OnInit, OnDestroy {
     }
 
     formValueToDate(value : DateTimeFilterValue) : Date {
-        return new Date(value.date.year,value.date.month, value.date.day,value.time.hour,value.time.minute)
+        //Note the -1 for the month because the Date constructor takes the month as a number between 0 and 11 (January to December) as parameter
+        return new Date(value.date.year,value.date.month -1, value.date.day,value.time.hour,value.time.minute);
     }
 
     listVisibleProcessesForSummary() {

--- a/ui/main/src/app/modules/share/datetime-filter/datetime-filter.component.ts
+++ b/ui/main/src/app/modules/share/datetime-filter/datetime-filter.component.ts
@@ -7,13 +7,12 @@
  * This file is part of the OperatorFabric project.
  */
 
-import * as moment from 'moment';
-import {AfterViewInit, Component, EventEmitter, forwardRef, Input, OnDestroy, OnInit, Output} from '@angular/core';
+import {Component, EventEmitter, forwardRef, Input, OnDestroy, OnInit, Output} from '@angular/core';
 import {ControlValueAccessor, FormControl, FormGroup, NG_VALUE_ACCESSOR} from '@angular/forms';
 import {NgbDateStruct} from '@ng-bootstrap/ng-bootstrap';
 import {takeUntil} from 'rxjs/operators';
 import {Subject} from 'rxjs';
-import {getDateTimeNgbFromMoment, offSetCurrentTime} from '@ofModel/datetime-ngb.model';
+import {offSetCurrentTime} from '@ofModel/datetime-ngb.model';
 
 @Component({
     selector: 'of-datetime-filter',
@@ -147,5 +146,19 @@ export class DatetimeFilterComponent implements ControlValueAccessor, OnInit, On
         return this.labelKey + this.filterPath;
     }
 
+}
+
+export class DateTimeFilterValue {
+
+    date : {
+        year : number;
+        month : number;
+        day : number;
+    };
+
+    time : {
+        hour : number;
+        minute : number;
+    }
 
 }

--- a/ui/main/src/assets/i18n/en.json
+++ b/ui/main/src/assets/i18n/en.json
@@ -162,6 +162,9 @@
     "resultsNumber":"Results number"
   },
   "monitoring": {
+    "hideFilters" : "Hide Filters",
+    "showFilters" : "Show Filters",
+    "noSelection" : "NA",
     "filters": {
       "process": "PROCESS",
       "selectProcessText": "Select a Process"

--- a/ui/main/src/assets/i18n/fr.json
+++ b/ui/main/src/assets/i18n/fr.json
@@ -162,6 +162,9 @@
     "resultsNumber":"Nombre de résultats"
   },
   "monitoring": {
+    "hideFilters" : "Masquer les filtres",
+    "showFilters" : "Afficher les filtres",
+    "noSelection" : "NA",
     "filters": {
       "process": "PROCESSUS",
       "selectProcessText": "Sélectionner un Processus"


### PR DESCRIPTION
## Implementation choices

* No need to make default value configurable like hide/show timeline, by default filters are shown.
* Show/hide value is stored in local storage.
* The "summary" shown when the filters are hidden displays the values from the last sent query (which matches the results that are being displayed)
Meaning that if I send a query filtering on process "Test1", then change to "Test2" (without submitting the query), when I hide the filters the "summary" will display Test1. It might sometimes be confusing for the user but this way at least the filter summary is consistent with the results.
* I didn't do the white/bold style on the summary values (as described in Invision) because it wasn't the case for the existing text displayed when the timeline is hidden, I think we should either do it for both or not do it at all.

## Tests
* Tested with night and day mode
* Tested with long lists of processes, with no selected values
* Tested translation

## Notes
Created OC-1368 for issue with i18n assets