### PR TITLE
[OC-1386] Card header style ajustement

### DIFF
--- a/ui/main/src/app/modules/cards/components/detail/detail.component.html
+++ b/ui/main/src/app/modules/cards/components/detail/detail.component.html
@@ -61,10 +61,9 @@
       <div  *ngIf='responseDataExists && showDetailCardHeader' class="opfab-card-response-header" >
         <div class="flex-container">
           <div style="width:30%;" >
-            <span style="border-right:3px solid white" >
-              <span translate>response.status</span> :
-              <span class="opfab-question-card-state-name" >{{cardStateName}} &nbsp;</span>
-            </span>
+            <span style="padding-left:15px" translate>response.status</span> :
+            <span class="opfab-question-card-state-name" >{{cardStateName}} &nbsp;</span>
+            <span *ngIf="!!this.card.lttd"> |</span>
             <of-countdown [card]="card"></of-countdown>
           </div>
 

--- a/ui/main/src/app/modules/cards/components/detail/detail.component.scss
+++ b/ui/main/src/app/modules/cards/components/detail/detail.component.scss
@@ -145,8 +145,8 @@
 
 .opfab-icon-help {
   display: inline-block;
-  height: 15px;
-  width: 15px;
+  height: 13px;
+  width: 13px;
   margin-bottom:-2px;
   margin-right: 10px;
   border-width: 0px;

--- a/ui/main/src/app/modules/share/countdown/countdown.component.scss
+++ b/ui/main/src/app/modules/share/countdown/countdown.component.scss
@@ -21,6 +21,6 @@
 }
 
 .lttd-icon{
-  font-size:20px;
+  font-size: small;
   padding-left: 6px;
 }


### PR DESCRIPTION
I put "font-size:small" for lttd-icon for having the same value with lttd-text.
I also put "height" and "width": 13px for opfab-icon-help for having the same value than the text next to it, displaying the answers.
I think, this way, everything is aligned vertically, and I find it more harmonious, don't hesitate to tell me if you have remarks.