### PR TITLE
[OC-1418] Solve bug when querying archives

### DIFF
--- a/ui/main/src/app/modules/archives/archives.component.ts
+++ b/ui/main/src/app/modules/archives/archives.component.ts
@@ -180,7 +180,6 @@ export class ArchivesComponent implements OnDestroy, OnInit {
         const params = this.filtersToMap(value);
         params.set('size', [this.size.toString()]);
         params.set('page', [page_number]);
-        this.hasResult = true;
         this.cardService.fetchArchivedCards(params)
             .pipe(takeUntil(this.unsubscribe$))
             .subscribe((page: Page<LightCard>) => {
@@ -191,7 +190,6 @@ export class ArchivesComponent implements OnDestroy, OnInit {
                 else this.hasResult = false;
                 page.content.forEach(card => this.loadTranslationForCardIfNeeded(card));
                 this.results = page.content;
-
             });
 
     }


### PR DESCRIPTION
BUG - Archives
Making another search after reseting filters, the old result appear quickly before the results of the new query is displayed
