### PR TITLE
[OC-1437] Make AOT compilation the default for ng build

### DIFF
--- a/ui/main/angular.json
+++ b/ui/main/angular.json
@@ -22,6 +22,7 @@
             "main": "src/main.ts",
             "polyfills": "src/polyfills.ts",
             "tsConfig": "src/tsconfig.app.json",
+            "aot": true,
             "assets": [
               "src/favicon.ico",
               "src/assets",
@@ -57,7 +58,6 @@
               "sourceMap": false,
               "extractCss": true,
               "namedChunks": false,
-              "aot": true,
               "extractLicenses": true,
               "vendorChunk": false,
               "buildOptimizer": true


### PR DESCRIPTION
Note : PR [OC-1191_fix] should be merged first otherwise this won't build.

I don't know if it's worth mentioning in the release notes?