### PR TITLE
[OC-1455] Fix undefined currentPath error in console

### DIFF
--- a/ui/main/src/app/modules/navbar/navbar.component.html
+++ b/ui/main/src/app/modules/navbar/navbar.component.html
@@ -28,7 +28,7 @@
     <ul class="navbar-nav mr-auto ">
       <!-- Links to OperatorFabric pages as defined in app-rooting.module.ts (e.g. Card Feed, Archive) -->
       <li class="nav-item" *ngFor="let link of navigationRoutes, let i = index"
-        [class.active]="currentPath && link.path === currentPath[1]">
+        [class.active]="link.path === currentPath[1]">
         <a id="opfab-navbar-menu-{{link.path}}" class="nav-link" [routerLink]="link.path" routerLinkActive #rla="routerLinkActive"
           (click)="activeLinkIndex = i" translate>{{'menu.'+link.path}}</a>
       </li>

--- a/ui/main/src/app/modules/navbar/navbar.component.ts
+++ b/ui/main/src/app/modules/navbar/navbar.component.ts
@@ -63,6 +63,7 @@ export class NavbarComponent implements OnInit {
   constructor(private store: Store<AppState>, private globalStyleService: GlobalStyleService, private configService: ConfigService
     , private userService: UserService, private modalService: NgbModal, private appService: AppService) {
 
+      this.currentPath = ['']; // Initializing currentPath to avoid 'undefined' errors when it is used to determine 'active' look in template
   }
 
     ngOnInit() {


### PR DESCRIPTION
I looked it up and Angular offers ways to deal with the issue of a variable that is not initialized yet when the template is being rendered, but it's mostly if there is something "clever" to do while the data is being prepared (show a placeholder, a little "loading" icon, etc.)...
But it's not the case here, this time is very short, and if the currentPath has not been initialized yet we just won't add the "active" style to any item in the navbar. To do that I felt the easiest way was to add an initialization of the currentPath in the constructor.

I don't think it's worth mentioning in the release notes.