### PR TITLE
[OC-1497] Fixing issue with card edition and IT incident example

### DIFF
--- a/src/docs/asciidoc/reference_doc/template_description.adoc
+++ b/src/docs/asciidoc/reference_doc/template_description.adoc
@@ -445,6 +445,16 @@ Return an array that is a merge of the two arrays.
 {{/each}}
 ....
 
+[[conditionalAttribute]]
+=== conditionalAttribute
+
+Adds the specified attribute to an HTML element if the given condition is truthy.
+This is useful for attributes such as `checked` where it is the presence or absence of the attribute that matters (i.e.
+an checkbox with `checked=false` will still be checked).
+....
+<input type="checkbox" id="optionA" {{conditionalAttribute card.data.optionA 'checked'}}></input>
+....
+
 [[opfab_template_style]]
 == OperatorFabric css styles
 

--- a/src/test/utils/karate/businessconfig/resources/bundle_userCardExamples/template/en/incidentInProgress.handlebars
+++ b/src/test/utils/karate/businessconfig/resources/bundle_userCardExamples/template/en/incidentInProgress.handlebars
@@ -23,12 +23,11 @@
 <div >
 
 
-    <strong> <center> Please fill in the impacts from your perspective  </center> </strong>
+     <div style="text-align: center;"> <strong>Please fill in the impacts from your perspective </strong> </div>
 
     <br/>
     <br />
-
-    <table width="100%">
+    <table style="width: 100%">
         <tr>
             <td> <label class="opfab-checkbox"> SERVICE A <input type="checkbox" id="SA">   <span class="opfab-checkbox-checkmark"> </span>   </label>   </td>
             <td> <label class="opfab-checkbox"> SERVICE B <input type="checkbox" id="SB">   <span class="opfab-checkbox-checkmark"> </span>   </label>   </td>
@@ -38,13 +37,11 @@
             <td> <label class="opfab-checkbox"> SERVICE F <input type="checkbox" id="SF">   <span class="opfab-checkbox-checkmark"> </span>   </label>   </td>
         </tr>
     </table>
-
-
 </div>
 <br/>
 <br/>
 <div class="opfab-input">
-    <label> OTHER IMPACTS </label>
+    <label for="OTHERS"> OTHER IMPACTS </label>
     <input id="OTHERS" name="OTHERS">
 </div>
 
@@ -80,14 +77,14 @@
 
         if (templateGateway.childCards[0]) {
             let childsDiv = document.getElementById("childs-div");
-            let responses = '<strong> RESPONSES RECEIVED : </strong> <center> <br/>'
-            responses += ' <table width="100%""> <tr> <th> Entity </th>';
+            let responses = '<strong> RESPONSES RECEIVED : </strong> <br/>';
+            responses += ' <table style="width: 100%"> <tr> <th> Entity </th>';
             responses += ' <th> Service A </th> <th> Service B </th> <th> Service C </th> <th> Service D </th> <th>Service E </th> <th> Service F </th>';
             responses += ' </tr>';
 
-            templateGateway.childCards.forEach((c, i) => {
+            templateGateway.childCards.forEach((c) => {
                  const entityName = templateGateway.getEntityName(c.publisher);
-                responses += `<tr> <td> ${entityName} </td>`
+                responses += `<tr> <td> ${entityName} </td>`;
                 if (c.data.impacts.SA)  responses += `<td style="color:red;">  YES </td>`;
                 else  responses += `<td>  NO </td>`;
                 if (c.data.impacts.SB)  responses += `<td style="color:red;">  YES </td>`;
@@ -108,13 +105,11 @@
 
             childsDiv.innerHTML = responses;
         }
-    }
-
-    templateGateway.applyChildCards();
+    };
 
     templateGateway.validyForm = function () {
 
-        const S1 = document.getElementById('SA').checked;
+        const SA = document.getElementById('SA').checked;
         const SB = document.getElementById('SB').checked;
         const SC = document.getElementById('SC').checked;
         const SD = document.getElementById('SD').checked;
@@ -133,7 +128,7 @@
                 SF: SF,
                 OTHERS: OTHERS
             }
-        }
+        };
 
         return {
             valid: true,
@@ -141,6 +136,3 @@
         };
     }
 </script>
-
-
-</p>

--- a/src/test/utils/karate/businessconfig/resources/bundle_userCardExamples/template/en/usercard_incidentInProgress.handlebars
+++ b/src/test/utils/karate/businessconfig/resources/bundle_userCardExamples/template/en/usercard_incidentInProgress.handlebars
@@ -10,7 +10,7 @@
 <br/>
 <br/>
 <div class="opfab-textarea">
-    <label> INCIDENT DESCRIPTION </label>
+    <label for="message"> INCIDENT DESCRIPTION </label>
     <textarea id="message" name="message" placeholder="Write something.."
         style="width:100%"> {{card.data.message}} </textarea>
 </div>
@@ -19,32 +19,26 @@
 
 IMPACTED SERVICES : <br/><br/>
 <div>
-    <table width="100%">
+    <table style="width: 100%">
         <tr>
-            <td> <label class="opfab-checkbox"> SERVICE A <input type="checkbox" id="SA">   <span class="opfab-checkbox-checkmark"> </span>   </label>   </td>
-            <td> <label class="opfab-checkbox"> SERVICE B <input type="checkbox" id="SB">   <span class="opfab-checkbox-checkmark"> </span>   </label>   </td>
-            <td> <label class="opfab-checkbox"> SERVICE C <input type="checkbox" id="SC">   <span class="opfab-checkbox-checkmark"> </span>   </label>   </td>
-            <td> <label class="opfab-checkbox"> SERVICE D <input type="checkbox" id="SD">   <span class="opfab-checkbox-checkmark"> </span>   </label>   </td>
-            <td> <label class="opfab-checkbox"> SERVICE E <input type="checkbox" id="SE">   <span class="opfab-checkbox-checkmark"> </span>   </label>   </td>
-            <td> <label class="opfab-checkbox"> SERVICE F <input type="checkbox" id="SF">   <span class="opfab-checkbox-checkmark"> </span>   </label>   </td>
+            <td> <label class="opfab-checkbox"> SERVICE A <input type="checkbox" id="SA" {{conditionalAttribute card.data.impacts.SA 'checked'}}>   <span class="opfab-checkbox-checkmark"> </span>   </label>   </td>
+            <td> <label class="opfab-checkbox"> SERVICE B <input type="checkbox" id="SB" {{conditionalAttribute card.data.impacts.SB 'checked'}}>   <span class="opfab-checkbox-checkmark"> </span>   </label>   </td>
+            <td> <label class="opfab-checkbox"> SERVICE C <input type="checkbox" id="SC" {{conditionalAttribute card.data.impacts.SC 'checked'}}>   <span class="opfab-checkbox-checkmark"> </span>   </label>   </td>
+            <td> <label class="opfab-checkbox"> SERVICE D <input type="checkbox" id="SD" {{conditionalAttribute card.data.impacts.SD 'checked'}}>   <span class="opfab-checkbox-checkmark"> </span>   </label>   </td>
+            <td> <label class="opfab-checkbox"> SERVICE E <input type="checkbox" id="SE" {{conditionalAttribute card.data.impacts.SE 'checked'}}>   <span class="opfab-checkbox-checkmark"> </span>   </label>   </td>
+            <td> <label class="opfab-checkbox"> SERVICE F <input type="checkbox" id="SF" {{conditionalAttribute card.data.impacts.SF 'checked'}}>   <span class="opfab-checkbox-checkmark"> </span>   </label>   </td>
         </tr>
     </table>
 </div>
 <br/>
 <div class="opfab-input">
-    <label> OTHER IMPACTS </label>
-    <input id="OTHERS" name="OTHERS" 
+    <label for="OTHERS"> OTHER IMPACTS </label>
+    <input id="OTHERS" name="OTHERS"
         style="width:100%" value="{{card.data.impacts.OTHERS}}">
 </div>
 <br/>
 <script>
 
-    document.getElementById("SA").checked = "{{card.data.impacts.SA}}";
-    document.getElementById("SB").checked = "{{card.data.impacts.SB}}";
-    document.getElementById("SC").checked = "{{card.data.impacts.SC}}";
-    document.getElementById("SD").checked = "{{card.data.impacts.SD}}";
-    document.getElementById("SE").checked = "{{card.data.impacts.SE}}";
-    document.getElementById("SF").checked = "{{card.data.impacts.SF}}";
 
 
     templateGateway.getSpecificCardInformation = function () {

--- a/src/test/utils/karate/businessconfig/resources/bundle_userCardExamples/template/fr/incidentInProgress.handlebars
+++ b/src/test/utils/karate/businessconfig/resources/bundle_userCardExamples/template/fr/incidentInProgress.handlebars
@@ -24,11 +24,11 @@
 <div >
 
 
-    <strong> <center> Merci de saisir les impacts que vous identifiez de votre coté </center>  </strong>
+   <div style="text-align: center;"> <strong>  Merci de saisir les impacts que vous identifiez de votre coté </strong> </div>
 
     <br/>
     <br />
-    <table width="100%">
+    <table style="width: 100%">
         <tr>
             <td> <label class="opfab-checkbox"> SERVICE A <input type="checkbox" id="SA">   <span class="opfab-checkbox-checkmark"> </span>   </label>   </td>
             <td> <label class="opfab-checkbox"> SERVICE B <input type="checkbox" id="SB">   <span class="opfab-checkbox-checkmark"> </span>   </label>   </td>
@@ -42,7 +42,7 @@
 <br/>
 <br/>
 <div class="opfab-input">
-    <label> AUTRES IMPACTS </label>
+    <label for="OTHERS"> AUTRES IMPACTS </label>
     <input id="OTHERS" name="OTHERS">
 </div>
 
@@ -78,14 +78,14 @@
 
         if (templateGateway.childCards[0]) {
             let childsDiv = document.getElementById("childs-div");
-            let responses = ' <strong> REPONSES RECUES : </strong> <center> <br/>'
-            responses += ' <table width="100%""> <tr> <th> Entity </th>';
+            let responses = ' <strong> REPONSES RECUES : </strong> <br/>';
+            responses += ' <table style="width: 100%"> <tr> <th> Entity </th>';
             responses += ' <th> Service A </th> <th> Service B </th> <th> Service C </th> <th> Service D </th> <th>Service E </th> <th> Service F </th>';
             responses += ' </tr>';
 
-            templateGateway.childCards.forEach((c, i) => {
+            templateGateway.childCards.forEach((c) => {
                 const entityName = templateGateway.getEntityName(c.publisher);
-                responses += `<tr> <td> ${entityName} </td>`
+                responses += `<tr> <td> ${entityName} </td>`;
                 if (c.data.impacts.SA)  responses += `<td style="color:red;">  OUI </td>`;
                 else  responses += `<td>  NON </td>`;
                 if (c.data.impacts.SB)  responses += `<td style="color:red;">  OUI </td>`;
@@ -106,11 +106,11 @@
 
             childsDiv.innerHTML = responses;
         }
-    }
+    };
 
     templateGateway.validyForm = function () {
 
-        const S1 = document.getElementById('SA').checked;
+        const SA = document.getElementById('SA').checked;
         const SB = document.getElementById('SB').checked;
         const SC = document.getElementById('SC').checked;
         const SD = document.getElementById('SD').checked;
@@ -129,7 +129,7 @@
                 SF: SF,
                 OTHERS: OTHERS
             }
-        }
+        };
 
         return {
             valid: true,
@@ -139,4 +139,3 @@
 </script>
 
 
-</p>

--- a/src/test/utils/karate/businessconfig/resources/bundle_userCardExamples/template/fr/usercard_incidentInProgress.handlebars
+++ b/src/test/utils/karate/businessconfig/resources/bundle_userCardExamples/template/fr/usercard_incidentInProgress.handlebars
@@ -6,10 +6,11 @@
 <!-- SPDX-License-Identifier: MPL-2.0                                      -->
 <!-- This file is part of the OperatorFabric project.                      -->
 
+
 <br/>
 <br/>
 <div class="opfab-textarea">
-    <label> DESCRIPTION DE L'INCIDENT </label>
+    <label for="message"> DESCRIPTION DE L'INCIDENT </label>
     <textarea id="message" name="message" placeholder="Write something.."
         style="width:100%"> {{card.data.message}} </textarea>
 </div>
@@ -18,32 +19,26 @@
 
 SERVICES IMPACTES : <br/><br/>
 <div>
-    <table width="100%">
+    <table style="width: 100%">
         <tr>
-            <td> <label class="opfab-checkbox"> SERVICE A <input type="checkbox" id="SA">   <span class="opfab-checkbox-checkmark"> </span>   </label>   </td>
-            <td> <label class="opfab-checkbox"> SERVICE B <input type="checkbox" id="SB">   <span class="opfab-checkbox-checkmark"> </span>   </label>   </td>
-            <td> <label class="opfab-checkbox"> SERVICE C <input type="checkbox" id="SC">   <span class="opfab-checkbox-checkmark"> </span>   </label>   </td>
-            <td> <label class="opfab-checkbox"> SERVICE D <input type="checkbox" id="SD">   <span class="opfab-checkbox-checkmark"> </span>   </label>   </td>
-            <td> <label class="opfab-checkbox"> SERVICE E <input type="checkbox" id="SE">   <span class="opfab-checkbox-checkmark"> </span>   </label>   </td>
-            <td> <label class="opfab-checkbox"> SERVICE F <input type="checkbox" id="SF">   <span class="opfab-checkbox-checkmark"> </span>   </label>   </td>
+            <td> <label class="opfab-checkbox"> SERVICE A <input type="checkbox" id="SA" {{conditionalAttribute card.data.impacts.SA 'checked'}}>   <span class="opfab-checkbox-checkmark"> </span>   </label>   </td>
+            <td> <label class="opfab-checkbox"> SERVICE B <input type="checkbox" id="SB" {{conditionalAttribute card.data.impacts.SB 'checked'}}>   <span class="opfab-checkbox-checkmark"> </span>   </label>   </td>
+            <td> <label class="opfab-checkbox"> SERVICE C <input type="checkbox" id="SC" {{conditionalAttribute card.data.impacts.SC 'checked'}}>   <span class="opfab-checkbox-checkmark"> </span>   </label>   </td>
+            <td> <label class="opfab-checkbox"> SERVICE D <input type="checkbox" id="SD" {{conditionalAttribute card.data.impacts.SD 'checked'}}>   <span class="opfab-checkbox-checkmark"> </span>   </label>   </td>
+            <td> <label class="opfab-checkbox"> SERVICE E <input type="checkbox" id="SE" {{conditionalAttribute card.data.impacts.SE 'checked'}}>   <span class="opfab-checkbox-checkmark"> </span>   </label>   </td>
+            <td> <label class="opfab-checkbox"> SERVICE F <input type="checkbox" id="SF" {{conditionalAttribute card.data.impacts.SF 'checked'}}>   <span class="opfab-checkbox-checkmark"> </span>   </label>   </td>
         </tr>
     </table>
 </div>
 <br/>
 <div class="opfab-input">
-    <label> AUTRES IMPACTS </label>
+    <label for="OTHERS"> AUTRES IMPACTS </label>
     <input id="OTHERS" name="OTHERS" 
         style="width:100%" value="{{card.data.impacts.OTHERS}}">
 </div>
 <br/>
 <script>
 
-    document.getElementById("SA").checked = "{{card.data.impacts.SA}}";
-    document.getElementById("SB").checked = "{{card.data.impacts.SB}}";
-    document.getElementById("SC").checked = "{{card.data.impacts.SC}}";
-    document.getElementById("SD").checked = "{{card.data.impacts.SD}}";
-    document.getElementById("SE").checked = "{{card.data.impacts.SE}}";
-    document.getElementById("SF").checked = "{{card.data.impacts.SF}}";
 
 
     templateGateway.getSpecificCardInformation = function () {

--- a/ui/main/src/app/modules/cards/services/handlebars.service.spec.ts
+++ b/ui/main/src/app/modules/cards/services/handlebars.service.spec.ts
@@ -1,4 +1,4 @@
-/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+/* Copyright (c) 2018-2021, RTE (http://www.rte-france.com)
  * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -8,29 +8,28 @@
  */
 
 
-
 import {getTestBed, TestBed} from '@angular/core/testing';
 
 import {ProcessesService} from '@ofServices/processes.service';
 import {HttpClientTestingModule, HttpTestingController, TestRequest} from '@angular/common/http/testing';
 import {environment} from '@env/environment';
-import {TranslateLoader, TranslateModule, TranslateService} from "@ngx-translate/core";
-import {RouterTestingModule} from "@angular/router/testing";
-import {Store, StoreModule} from "@ngrx/store";
-import {appReducer, AppState} from "@ofStore/index";
-import {getOneRandomCard,AuthenticationImportHelperForSpecs, BusinessconfigI18nLoaderFactory} from "@tests/helpers";
-import {LightCard} from "@ofModel/light-card.model";
-import {ServicesModule} from "@ofServices/services.module";
-import {HandlebarsService} from "./handlebars.service";
-import {Guid} from "guid-typescript";
-import {I18n} from "@ofModel/i18n.model";
-import * as moment from "moment";
-import {UserContext} from "@ofModel/user-context.model";
-import {DetailContext} from "@ofModel/detail-context.model";
+import {TranslateLoader, TranslateModule, TranslateService} from '@ngx-translate/core';
+import {RouterTestingModule} from '@angular/router/testing';
+import {Store, StoreModule} from '@ngrx/store';
+import {appReducer, AppState} from '@ofStore/index';
+import {AuthenticationImportHelperForSpecs, BusinessconfigI18nLoaderFactory, getOneRandomCard} from '@tests/helpers';
+import {LightCard} from '@ofModel/light-card.model';
+import {ServicesModule} from '@ofServices/services.module';
+import {HandlebarsService} from './handlebars.service';
+import {Guid} from 'guid-typescript';
+import {I18n} from '@ofModel/i18n.model';
+import * as moment from 'moment';
+import {UserContext} from '@ofModel/user-context.model';
+import {DetailContext} from '@ofModel/detail-context.model';
 
 function computeTemplateUri(templateName) {
     return `${environment.urls.processes}/testProcess/templates/${templateName}`;
-    //TODO OC-1009 Why is the pprocess hardcoded? It needs to match the one set by default in getOneRandomCard.
+    // TODO OC-1009 Why is the pprocess hardcoded? It needs to match the one set by default in getOneRandomCard.
 }
 
 describe('Handlebars Services', () => {
@@ -87,6 +86,8 @@ describe('Handlebars Services', () => {
                 unsortedNumbers: [2, 1, 4, 0, 5, 3],
                 numberStrings: ['0', '1', '2', '3', '4', '5'],
                 arrays: [[], [0, 1, 2], ['0', '1', '2', '3']],
+                undefinedValue: undefined,
+                nullValue: null,
                 booleans: [false, true],
                 splitString: 'a.split.string',
                 pythons: {
@@ -140,51 +141,51 @@ describe('Handlebars Services', () => {
             });
         }
 
-        it('complile polyIf helper ==', (done) => {
+        it('compile polyIf helper ==', (done) => {
             expectIfCond(card, 'card.data.numbers.[0]', '==', 'card.data.numbers.[0]', 'true', done);
             expectIfCond(card, 'card.data.numbers.[0]', '==', 'card.data.numbers.[1]', 'false', done);
             expectIfCond(card, 'card.data.numbers.[0]', '==', 'card.data.numberStrings.[0]', 'true', done);
         });
-        it('complile polyIf helper ===', (done) => {
+        it('compile polyIf helper ===', (done) => {
             expectIfCond(card, 'card.data.numbers.[0]', '===', 'card.data.numbers.[0]', 'true', done);
             expectIfCond(card, 'card.data.numbers.[0]', '===', 'card.data.numberStrings.[0]', 'false', done);
         });
-        it('complile polyIf helper <', (done) => {
+        it('compile polyIf helper <', (done) => {
             // expectIfCond(card, 'card.data.numbers.[0]', '<', 'card.data.numbers.[1]', 'true');
             expectIfCond(card, 'card.data.numbers.[0]', '<', 'card.data.numberStrings.[1]', 'true', done);
             expectIfCond(card, 'card.data.numbers.[1]', '<', 'card.data.numbers.[0]', 'false', done);
             expectIfCond(card, 'card.data.numbers.[1]', '<', 'card.data.numbers.[1]', 'false', done);
         });
-        it('complile polyIf helper >', (done) => {
+        it('compile polyIf helper >', (done) => {
             expectIfCond(card, 'card.data.numbers.[1]', '>', 'card.data.numbers.[0]', 'true', done);
             expectIfCond(card, 'card.data.numbers.[1]', '>', 'card.data.numberStrings.[0]', 'true', done);
             expectIfCond(card, 'card.data.numbers.[0]', '>', 'card.data.numbers.[1]', 'false', done);
             expectIfCond(card, 'card.data.numbers.[1]', '>', 'card.data.numbers.[1]', 'false', done);
         });
-        it('complile polyIf helper <=', (done) => {
+        it('compile polyIf helper <=', (done) => {
             expectIfCond(card, 'card.data.numbers.[0]', '<=', 'card.data.numbers.[1]', 'true', done);
             expectIfCond(card, 'card.data.numbers.[0]', '<=', 'card.data.numberStrings.[1]', 'true', done);
             expectIfCond(card, 'card.data.numbers.[1]', '<=', 'card.data.numbers.[0]', 'false', done);
             expectIfCond(card, 'card.data.numbers.[1]', '<=', 'card.data.numbers.[1]', 'true', done);
             expectIfCond(card, 'card.data.numbers.[1]', '<=', 'card.data.numberStrings.[1]', 'true', done);
         });
-        it('complile polyIf helper >=', (done) => {
+        it('compile polyIf helper >=', (done) => {
             expectIfCond(card, 'card.data.numbers.[1]', '>=', 'card.data.numbers.[0]', 'true', done);
             expectIfCond(card, 'card.data.numbers.[1]', '>=', 'card.data.numberStrings.[0]', 'true', done);
             expectIfCond(card, 'card.data.numbers.[0]', '>=', 'card.data.numbers.[1]', 'false', done);
             expectIfCond(card, 'card.data.numbers.[1]', '>=', 'card.data.numbers.[1]', 'true', done);
             expectIfCond(card, 'card.data.numbers.[1]', '>=', 'card.data.numberStrings.[1]', 'true', done);
         });
-        it('complile polyIf helper !=', (done) => {
+        it('compile polyIf helper !=', (done) => {
             expectIfCond(card, 'card.data.numbers.[0]', '!=', 'card.data.numbers.[0]', 'false', done);
             expectIfCond(card, 'card.data.numbers.[0]', '!=', 'card.data.numbers.[1]', 'true', done);
             expectIfCond(card, 'card.data.numbers.[0]', '!=', 'card.data.numberStrings.[0]', 'false', done);
         });
-        it('complile polyIf helper !==', (done) => {
+        it('compile polyIf helper !==', (done) => {
             expectIfCond(card, 'card.data.numbers.[0]', '!==', 'card.data.numbers.[0]', 'false', done);
             expectIfCond(card, 'card.data.numbers.[0]', '!==', 'card.data.numberStrings.[0]', 'true', done);
         });
-        it('complile polyIf helper &&', (done) => {
+        it('compile polyIf helper &&', (done) => {
             expectIfCond(card, 'card.data.booleans.[0]', '&&', 'card.data.booleans.[0]', 'false', done);
             expectIfCond(card, 'card.data.booleans.[0]', '&&', 'card.data.numbers.[0]', 'false', done);
             expectIfCond(card, 'card.data.booleans.[0]', '&&', 'card.data.numberStrings.[0]', 'false', done);
@@ -193,7 +194,7 @@ describe('Handlebars Services', () => {
             expectIfCond(card, 'card.data.booleans.[1]', '&&', 'card.data.numbers.[2]', 'true', done);
             expectIfCond(card, 'card.data.booleans.[1]', '&&', 'card.data.numberStrings.[3]', 'true', done);
         });
-        it('complile polyIf helper ||', (done) => {
+        it('compile polyIf helper ||', (done) => {
             expectIfCond(card, 'card.data.booleans.[0]', '||', 'card.data.booleans.[0]', 'false', done);
             expectIfCond(card, 'card.data.booleans.[0]', '||', 'card.data.numbers.[0]', 'false', done);
             expectIfCond(card, 'card.data.booleans.[0]', '||', 'card.data.numberStrings.[0]', 'true', done);
@@ -216,7 +217,42 @@ describe('Handlebars Services', () => {
                 expect(call.request.method).toBe('GET');
                 call.flush('{{arrayAtIndexLength card.data.arrays 1}}');
             });
-        })
+        });
+
+        function expectConditionalAttribute(card, condition, attribute, expectedResult: string, done) {
+            const templateName = Guid.create().toString();
+            const testedExpression = `{{conditionalAttribute ${condition} ${attribute}}}`;
+            handlebarsService.executeTemplate(templateName, new DetailContext(card, userContext, null))
+                .subscribe((result) => {
+                    console.debug(`testing [${testedExpression}], result [${result}], expected [${expectedResult}]`);
+                    expect(result).toEqual(expectedResult,
+                        `Expected result to be ${expectedResult} when testing [${condition}]`);
+                    done();
+                });
+            let calls = httpMock.match(req => req.url == computeTemplateUri(templateName));
+            expect(calls.length).toEqual(1);
+            calls.forEach(call => {
+                expect(call.request.method).toBe('GET');
+                call.flush(testedExpression);
+            });
+        }
+
+        it('compile conditionalAttribute', (done) => {
+            // The attribute will show up if the property exists and is truthy
+            expectConditionalAttribute(card, 'card.data.booleans.[0]', '\'someAttribute\'', '', done);
+            expectConditionalAttribute(card, 'card.data.booleans.[1]', '\'someAttribute\'', 'someAttribute', done);
+            expectConditionalAttribute(card, 'card.data.name', '\'someAttribute\'', 'someAttribute', done);
+            expectConditionalAttribute(card, 'card.data.some.property.that.doesnt.exist', '\'someAttribute\'', '', done);
+            expectConditionalAttribute(card, 'card.data.undefinedValue', '\'someAttribute\'', '', done);
+            expectConditionalAttribute(card, 'card.data.nullValue', '\'someAttribute\'', '', done);
+
+            // The condition can also be an expression using other helpers
+            expectConditionalAttribute(card, '(bool card.data.name "===" \'something\')', '\'someAttribute\'', 'someAttribute', done);
+
+            // The attribute itself can also come from the card data
+            expectConditionalAttribute(card, 'card.data.booleans.[1]', 'card.data.name', 'something', done);
+        });
+
         it('compile arrayAtIndexLength Alt', (done) => {
             const templateName = Guid.create().toString();
             handlebarsService.executeTemplate(templateName, new DetailContext(card, userContext, null))
@@ -517,7 +553,7 @@ describe('Handlebars Services', () => {
                     expect(lines[3]).toMatch(/         <\/script>/);
                     done();
                 });
-            let calls = httpMock.match(req => req.url == computeTemplateUri(templateName));
+            const calls = httpMock.match(req => req.url === computeTemplateUri(templateName));
             expect(calls.length).toEqual(1);
             calls.forEach(call => {
                 expect(call.request.method).toBe('GET');

--- a/ui/main/src/app/modules/cards/services/handlebars.service.ts
+++ b/ui/main/src/app/modules/cards/services/handlebars.service.ts
@@ -1,4 +1,4 @@
-/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+/* Copyright (c) 2018-2021, RTE (http://www.rte-france.com)
  * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -8,96 +8,72 @@
  */
 
 
-
-import {Injectable} from "@angular/core";
-import * as Handlebars from "handlebars/dist/handlebars.js"
-import {TranslateService} from "@ngx-translate/core";
+import {Injectable} from '@angular/core';
+import * as Handlebars from 'handlebars/dist/handlebars.js';
+import {TranslateService} from '@ngx-translate/core';
 import * as moment from 'moment';
-import {Map} from "@ofModel/map";
-import {Observable, of} from "rxjs";
-import {map, tap} from "rxjs/operators";
-import {ProcessesService} from "@ofServices/processes.service";
-import {Guid} from "guid-typescript";
-import {DetailContext} from "@ofModel/detail-context.model";
-import {Store} from "@ngrx/store";
-import {AppState} from "@ofStore/index";
-import {buildSettingsOrConfigSelector} from "@ofSelectors/settings.x.config.selectors";
+import {Map} from '@ofModel/map';
+import {Observable, of} from 'rxjs';
+import {map, tap} from 'rxjs/operators';
+import {ProcessesService} from '@ofServices/processes.service';
+import {Guid} from 'guid-typescript';
+import {DetailContext} from '@ofModel/detail-context.model';
+import {Store} from '@ngrx/store';
+import {AppState} from '@ofStore/index';
+import {buildSettingsOrConfigSelector} from '@ofSelectors/settings.x.config.selectors';
 
 @Injectable()
 export class HandlebarsService {
 
-    private templateCache:Map<Function> = new Map();
-    private _locale: string;
-
     constructor(
                 private translate: TranslateService,
                 private businessconfig: ProcessesService,
-                private store: Store<AppState>){
-        this.registerPreserveSpace();
+                private store: Store<AppState>) {
+        HandlebarsService.registerPreserveSpace();
         this.registerNumberFormat();
         this.registerDateFormat();
-        this.registerCardAction();
+        HandlebarsService.registerCardAction();
         this.registerSvg();
         this.registerI18n();
         this.registerSort();
-        this.registerSlice();
-        this.registerArrayAtIndex();
-        this.registerMath();
-        this.registerSplit();
-        this.registerArrayAtIndexLength();
-        this.registerBool();
+        HandlebarsService.registerSlice();
+        HandlebarsService.registerArrayAtIndex();
+        HandlebarsService.registerMath();
+        HandlebarsService.registerSplit();
+        HandlebarsService.registerArrayAtIndexLength();
+        HandlebarsService.registerBool();
         this.registerNow();
-        this.registerJson();
-        this.registerKeyValue();
-        this.registerToBreakage();
-        this.registerArrayContains();
-        this.registerArrayContainsOneOf();
-        this.registerTimes();
-        this.registerKeepSpacesAndEndOfLine();
-        this.registerMergeArrays();
-        this.store.select(buildSettingsOrConfigSelector('locale')).subscribe(locale => this.changeLocale(locale))
+        HandlebarsService.registerJson();
+        HandlebarsService.registerKeyValue();
+        HandlebarsService.registerToBreakage();
+        HandlebarsService.registerArrayContains();
+        HandlebarsService.registerArrayContainsOneOf();
+        HandlebarsService.registerTimes();
+        HandlebarsService.registerKeepSpacesAndEndOfLine();
+        HandlebarsService.registerMergeArrays();
+        HandlebarsService.registerConditionalAttribute();
+        this.store.select(buildSettingsOrConfigSelector('locale')).subscribe(locale => this.changeLocale(locale));
     }
 
-    public changeLocale(locale:string){ 
-        if(locale) {
-            this._locale = locale;
-        }else{
-            this._locale = 'en';
-        }
-    }
+    private templateCache: Map<Function> = new Map();
+    private _locale: string;
 
-    public executeTemplate(templateName: string, context: DetailContext):Observable<string> {
-        return this.queryTemplate(context.card.process,context.card.processVersion,templateName).pipe(
-            map(t => t(context)));
-    }
-
-    public  queryTemplate(process:string, version:string, name: string):Observable<Function> {
-        const locale = this._locale;
-        const key = `${process}.${version}.${name}.${locale}`;
-        let template = this.templateCache[key];
-        if(template){
-           return of(template);
-        }
-        return this.businessconfig.fetchHbsTemplate(process,version,name,locale).pipe(
-            map(s=>Handlebars.compile(s)),
-            tap(t=>this.templateCache[key]=t)
-        );
-    }
-
-    private registerJson() {
+    private static registerJson() {
         Handlebars.registerHelper('json', function (obj) {
-            return new Handlebars.SafeString(JSON.stringify(obj))
+            return new Handlebars.SafeString(JSON.stringify(obj));
         });
     }
 
-    private registerBool() {
+    private static registerBool() {
         Handlebars.registerHelper('bool', function (v1, operator, v2, options) {
             switch (operator) {
                 case '==':
+                    // tslint:disable-next-line:triple-equals
                     return (v1 == v2);
                 case '===':
                     return (v1 === v2);
                 case '!=':
+                    // tslint:disable-next-line:triple-equals
                     return (v1 != v2);
                 case '!==':
                     return (v1 !== v2);
@@ -119,51 +95,51 @@ export class HandlebarsService {
         });
     }
 
-    private registerArrayAtIndexLength() {
+    private static registerArrayAtIndexLength() {
         Handlebars.registerHelper('arrayAtIndexLength', function (value, index, options) {
             return value[index].length;
         });
     }
 
-    private registerSplit() {
+    private static registerSplit() {
         Handlebars.registerHelper('split', function (...args: any[]) {
-            if(args.length === 3)
+            if (args.length === 3)
                 return args[0].split(args[1]);
-            if(args.length === 4)
+            if (args.length === 4)
                 return args[0].split(args[1])[args[2]];
         });
     }
 
-    private registerMath(){
-        Handlebars.registerHelper("math", function(lvalue, operator, rvalue, options) {
+    private static registerMath() {
+        Handlebars.registerHelper('math', function(lvalue, operator, rvalue, options) {
             let result;
-            switch(operator) {
-                case "+": result = lvalue + rvalue; break;
-                case "-": result = lvalue - rvalue; break;
-                case "*": result = lvalue * rvalue; break;
-                case "/": result = lvalue / rvalue; break;
-                case "%": result = lvalue % rvalue; break;
+            switch (operator) {
+                case '+': result = lvalue + rvalue; break;
+                case '-': result = lvalue - rvalue; break;
+                case '*': result = lvalue * rvalue; break;
+                case '/': result = lvalue / rvalue; break;
+                case '%': result = lvalue % rvalue; break;
             }
             return result;
         });
     }
 
-    private registerArrayAtIndex() {
+    private static registerArrayAtIndex() {
         Handlebars.registerHelper('arrayAtIndex', function (value, index, options) {
             return value[index];
         });
     }
 
-    private registerSlice() {
+    private static registerSlice() {
         Handlebars.registerHelper('slice', function () {
-            let args = [];
+            const args = [];
             for (let index = 0; index < arguments.length - 1; index++) {
                 args.push(arguments[index]);
             }
-            const value = args[0]
+            const value = args[0];
             const from = args[1];
             let to = null;
-            if(args.length>=3) {
+            if (args.length >= 3) {
                 to = args[2];
                 return value.slice(from, to);
             }
@@ -171,26 +147,149 @@ export class HandlebarsService {
         });
     }
 
+    private static registerCardAction() {
+        Handlebars.registerHelper('action', function () {
+            const args = [];
+            for (let i = 0; i < arguments.length - 1; i++) {
+                args.push(arguments[i]);
+            }
+            let actionId = '';
+            for (let i = 0; i < args.length; i++) {
+                actionId += args[i];
+            }
+            return `<button action-id="${actionId}"><i></i></button>`;
+        });
+    }
+
+    private static registerPreserveSpace() {
+        Handlebars.registerHelper('preserveSpace', function (value, options) {
+            return value.replace(/ /g, '\u00A0');
+        });
+    }
+
+    private static registerArrayContains() {
+        Handlebars.registerHelper('arrayContains', function(arr, value, options) {
+            return arr.includes(value);
+        });
+    }
+
+    private static registerArrayContainsOneOf() {
+        Handlebars.registerHelper('arrayContainsOneOf', function(arr1, arr2, options) {
+            return arr1.some( ai => arr2.includes(ai) );
+        });
+    }
+
+    private static registerTimes() {
+        Handlebars.registerHelper('times', function(n, block) {
+            let accum = '';
+            for (let i = 0; i < n; ++i)
+                accum += block.fn(i);
+            return accum;
+        });
+    }
+
+    private static registerToBreakage() {
+        Handlebars.registerHelper('toBreakage', function (word, breakage, options) {
+            switch (breakage) {
+                case 'lowercase':
+                    return word.toLowerCase();
+                case 'uppercase':
+                    return word.toUpperCase();
+                default:
+                    console.error(`Invalid parameter ${breakage} for the toBreakage helper`);
+                    return 'ERROR';
+            }
+        });
+    }
+
+    private static registerKeyValue() {
+        Handlebars.registerHelper('keyValue', function (obj, options) {
+            if (Object.keys(obj).length === 0) {
+              return options.fn({value: false});
+            }
+            let buffer, key;
+            buffer = '';
+            for (key in obj) {
+                if (!Object.hasOwnProperty.call(obj, key)) {
+                    continue;
+                }
+                buffer += options.fn({
+                    key: key,
+                    value: obj[key]
+                }) || '';
+            }
+            return buffer;
+        });
+    }
+
+    private static registerKeepSpacesAndEndOfLine() {
+        Handlebars.registerHelper('keepSpacesAndEndOfLine', function (value, options) {
+            let  result =  Handlebars.escapeExpression(value);
+            result = result.replace(/\n/g, '<br/>');
+            result = result.replace(/\s\s/g, '&nbsp;&nbsp;');
+            return new Handlebars.SafeString(result);
+        });
+
+    }
+
+    private static registerMergeArrays() {
+      Handlebars.registerHelper('mergeArrays', function (arr1, arr2, options) {
+        return arr1.concat(arr2);
+      });
+    }
+
+    private static registerConditionalAttribute() {
+        Handlebars.registerHelper('conditionalAttribute', function (condition, attribute) {
+            return (condition) ? attribute : '';
+        });
+    }
+
+    public changeLocale(locale: string) {
+        if (locale) {
+            this._locale = locale;
+        } else {
+            this._locale = 'en';
+        }
+    }
+
+    public executeTemplate(templateName: string, context: DetailContext): Observable<string> {
+        return this.queryTemplate(context.card.process, context.card.processVersion, templateName).pipe(
+            map(t => t(context)));
+    }
+
+    public  queryTemplate(process: string, version: string, name: string): Observable<Function> {
+        const locale = this._locale;
+        const key = `${process}.${version}.${name}.${locale}`;
+        const template = this.templateCache[key];
+        if (template) {
+           return of(template);
+        }
+        return this.businessconfig.fetchHbsTemplate(process, version, name, locale).pipe(
+            map(s => Handlebars.compile(s)),
+            tap(t => this.templateCache[key] = t)
+        );
+    }
+
     private registerSort() {
         Handlebars.registerHelper('sort', function () {
-            let args = [];
+            const args = [];
             for (let index = 0; index < arguments.length - 1; index++) {
                 args.push(arguments[index]);
             }
             const context: any | any[] = args[0];
             const sortKey = args[1];
             let arrayToSort: any[];
-            let isObject:boolean;
-            if (typeof context == 'object') {
+            let isObject: boolean;
+            if (typeof context === 'object') {
                 if (context.length !== undefined && context.length !== null) {
                     arrayToSort = context;
-                    isObject = (typeof arrayToSort[0] == 'object')
+                    isObject = (typeof arrayToSort[0] === 'object');
                 } else {
                     isObject = true;
                     arrayToSort = [];
-                    for (let property in context) {
+                    for (const property in context) {
                         if (context.hasOwnProperty(property)) {
-                            if (typeof context[property] == 'object') {
+                            if (typeof context[property] === 'object') {
                                 arrayToSort.push({templatedObjectkey: property, ...context[property]});
                             } else {
                                 arrayToSort.push({
@@ -215,21 +314,21 @@ export class HandlebarsService {
 
     private registerI18n() {
         Handlebars.registerHelper('i18n', (...fctArgs) => {
-            let args = [],
+            const args = [],
                 options = fctArgs[fctArgs.length - 1];
             for (let i = 0; i < fctArgs.length - 1; i++) {
                 args.push(fctArgs[i]);
             }
 
             let i18nKey: string, i18nParams: string[];
-            if (typeof args[0] == 'object') {
+            if (typeof args[0] === 'object') {
                 i18nKey = args[0].key;
                 i18nParams = args[0].parameters;
             } else {
-                i18nKey = "";
+                i18nKey = '';
                 for (let i = 0; i < args.length; i++) {
                     if (i18nKey)
-                        i18nKey += "."
+                        i18nKey += '.';
                     i18nKey += args[i];
                 }
                 i18nParams = options.hash;
@@ -242,32 +341,18 @@ export class HandlebarsService {
     private registerSvg() {
         const svgUid = Guid.create().toString();
         Handlebars.registerHelper('svg', function () {
-            let args = [];
+            const args = [];
             for (let i = 0; i < arguments.length - 1; i++) {
                 args.push(arguments[i]);
             }
-            let imageUrl = "";
+            let imageUrl = '';
             for (let i = 0; i < args.length; i++) {
                 imageUrl += args[i];
             }
             return `<embed type="image/svg+xml" src="${imageUrl}" id="${svgUid}" />
                     <script>document.getElementById('${svgUid}').addEventListener('load', function(){
                             svgPanZoom(document.getElementById('${svgUid}'));});
-                    </script>`
-        });
-    }
-
-    private registerCardAction() {
-        Handlebars.registerHelper('action', function () {
-            let args = [];
-            for (let i = 0; i < arguments.length - 1; i++) {
-                args.push(arguments[i]);
-            }
-            let actionId = "";
-            for (let i = 0; i < args.length; i++) {
-                actionId += args[i];
-            }
-            return `<button action-id="${actionId}"><i></i></button>`
+                    </script>`;
         });
     }
 
@@ -289,98 +374,21 @@ export class HandlebarsService {
     private registerNow() {
         Handlebars.registerHelper('now', function (options) {
             return moment().valueOf();
-        })
-    }
-
-    private registerPreserveSpace() {
-        Handlebars.registerHelper("preserveSpace", function (value, options) {
-            return value.replace(/ /g, '\u00A0')
         });
-    }
-
-    private registerArrayContains() {
-        Handlebars.registerHelper('arrayContains', function(arr, value, options) {
-            return arr.includes(value);
-        });
-    }
-
-    private registerArrayContainsOneOf() {
-        Handlebars.registerHelper('arrayContainsOneOf', function(arr1, arr2, options) {
-            return arr1.some( ai => arr2.includes(ai) );
-        });
-    }
-
-    private registerTimes() {
-        Handlebars.registerHelper('times', function(n, block) {
-            var accum = '';
-            for(var i = 0; i < n; ++i)
-                accum += block.fn(i);
-            return accum;
-        });
-    }
-
-    private registerToBreakage() {
-        Handlebars.registerHelper('toBreakage', function (word, breakage, options) {
-            switch (breakage) {
-                case 'lowercase':
-                    return word.toLowerCase();
-                case 'uppercase':
-                    return word.toUpperCase();
-                default:
-                    console.error(`Invalid parameter ${breakage} for the toBreakage helper`);
-                    return 'ERROR';
-            }
-        });
-    }
-
-    private registerKeyValue() {
-        Handlebars.registerHelper('keyValue', function (obj, options) {
-            if (Object.keys(obj).length === 0) {
-              return options.fn({value: false});
-            }
-            var buffer, key;
-            buffer = "";
-            for (key in obj) {
-                if (!Object.hasOwnProperty.call(obj, key)) {
-                    continue;
-                }
-                buffer += options.fn({
-                    key: key,
-                    value: obj[key]
-                }) || '';
-            }
-            return buffer;
-        });
-    }
-
-    private registerKeepSpacesAndEndOfLine() {
-        Handlebars.registerHelper('keepSpacesAndEndOfLine', function (value, options) {
-            let  result =  Handlebars.escapeExpression(value);
-            result = result.replace(/\n/g, '<br/>');
-            result = result.replace(/\s\s/g, '&nbsp;&nbsp;');
-            return new Handlebars.SafeString(result);
-        });
-
-    }
-
-    private registerMergeArrays() {
-      Handlebars.registerHelper('mergeArrays', function (arr1, arr2, options) {
-        return arr1.concat(arr2);
-      });
     }
 }
 
-function sortOnKey(key){
-    return function(a,b){
-        if(typeof  a[key] == 'string' && typeof b[key] == 'string'){
-            if(a[key]<b[key])
+function sortOnKey(key) {
+    return function(a, b) {
+        if (typeof  a[key] === 'string' && typeof b[key] === 'string') {
+            if (a[key] < b[key])
                 return -1;
-            else if(a[key]>b[key])
-                return 1
+            else if (a[key] > b[key])
+                return 1;
             return 0;
-        }else if(typeof  a[key] == 'number' && typeof b[key] == 'number'){
-            return a[key]-b[key];
+        } else if (typeof  a[key] === 'number' && typeof b[key] === 'number') {
+            return a[key] - b[key];
         }
         return 0;
-    }
+    };
 }

--- a/ui/main/src/app/services/app.service.ts
+++ b/ui/main/src/app/services/app.service.ts
@@ -1,4 +1,4 @@
-/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+/* Copyright (c) 2018-2021, RTE (http://www.rte-france.com)
  * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -47,5 +47,9 @@ export class AppService {
     closeDetails(currentPath: string) {
         this.store.dispatch(new ClearLightCardSelection());
         this._router.navigate(['/' + currentPath, 'cards']);
+    }
+
+    reopenDetails(currentPath: string, cardId: string) {
+        this._router.navigate(['/' + currentPath, 'cards', cardId]);
     }
 }


### PR DESCRIPTION
There were several issues:

- The fact that the existing card detail remained present in the background when the edition modal was open, which led to conflicts for the template functions referencing elements by id. => solved by closing the detail before opening the edition modal and re-opening it afterwards.
- When editing the card, all impacts where checked regardless of the actual card content because an element with "checked=false" will still render as checked, the checked attribute needs to be absent for the checkbox to be unchecked. => created a custom handlebar helper for that.

The rest of the changes are just fixes for tslint warnings.

In the release notes, under bug:
[OC-1497] Fixing issue with card edition and IT incident example

[OC-1497]: https://opfab.atlassian.net/browse/OC-1497