### PR TITLE
[OC-1257] Set groups of entities compatible with reponse card 

### DIFF
--- a/config/dev/users-dev.yml
+++ b/config/dev/users-dev.yml
@@ -49,18 +49,25 @@ operatorfabric.users.default:
       name: ReadOnly
       description: ReadOnly Group
   entities:
-    - id: ENTITY1
-      name: Control Room 1
-      description: Control Room 1
-    - id: ENTITY2
-      name: Control Room 2
-      description: Control Room 2
-    - id: ENTITY3
-      name: Control Room 3
-      description: Control Room 3
-    - id: ENTITY4
-      name: IT Supervision Center 
-      description: IT Supervision Center 
+   - id: ENTITY1
+     name: Control Room 1
+     description: Control Room 1
+     parents : ["ALLCONTROLROOMS"]
+   - id: ENTITY2
+     name: Control Room 2
+     description: Control Room 2
+     parents : ["ALLCONTROLROOMS"]
+   - id: ENTITY3
+     name: Control Room 3
+     description: Control Room 3
+     parents : ["ALLCONTROLROOMS"]
+   - id: ALLCONTROLROOMS
+     name: All Control Rooms 
+     description: All Control Rooms
+     entityAllowedToSendCard: false
+   - id: ENTITY4
+     name: IT Supervision Center 
+     description: IT Supervision Center 
   user-settings:
     - login: operator3
       description: Da Operator Rulez

--- a/config/docker/users-docker.yml
+++ b/config/docker/users-docker.yml
@@ -50,15 +50,23 @@ operatorfabric.users.default:
       name: ReadOnly
       description: ReadOnly Group
   entities:
-    - id: ENTITY1
-      name: Control Room 1
-      description: Control Room 1
-    - id: ENTITY2
-      name: Control Room 2
-      description: Control Room 2
-    - id: ENTITY3
-      name: Control Room 3
-      description: Control Room 3
-    - id: ENTITY4
-      name: IT Supervision Center 
-      description: IT Supervision Center
+   - id: ENTITY1
+     name: Control Room 1
+     description: Control Room 1
+     parents : ["ALLCONTROLROOMS"]
+   - id: ENTITY2
+     name: Control Room 2
+     description: Control Room 2
+     parents : ["ALLCONTROLROOMS"]
+   - id: ENTITY3
+     name: Control Room 3
+     description: Control Room 3
+     parents : ["ALLCONTROLROOMS"]
+   - id: ALLCONTROLROOMS
+     name: All Control Rooms 
+     description: All Control Rooms
+     entityAllowedToSendCard: false
+   - id: ENTITY4
+     name: IT Supervision Center 
+     description: IT Supervision Center 
+

--- a/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/services/processors/impl/UserCardProcessorImpl.java
+++ b/services/core/cards-publication/src/main/java/org/lfenergy/operatorfabric/cards/publication/services/processors/impl/UserCardProcessorImpl.java
@@ -26,11 +26,9 @@ public class UserCardProcessorImpl implements UserCardProcessor {
 
         Optional<List<String>> entitiesUser= Optional.ofNullable(user.getUserData().getEntities());
 
-        //take first entity of the user as the card publisher id
-        if(entitiesUser.isPresent() && !entitiesUser.get().isEmpty()) {
-            card.setPublisher(entitiesUser.get().get(0));
-            return entitiesUser.get().get(0);
-
+        //Check thah publisher is included in user entities
+        if(entitiesUser.isPresent() && !entitiesUser.get().isEmpty() && entitiesUser.get().contains(card.getPublisher()) ) {
+            return card.getPublisher();
         }
         //no possible calculation of publisher id from card and user arguments,
         // throw a runtime exception to be handled by Mono.onErrorResume()

--- a/services/core/users/src/main/java/org/lfenergy/operatorfabric/users/model/EntityData.java
+++ b/services/core/users/src/main/java/org/lfenergy/operatorfabric/users/model/EntityData.java
@@ -1,4 +1,4 @@
-/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+/* Copyright (c) 2018-2021, RTE (http://www.rte-france.com)
  * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -10,7 +10,6 @@
 
 package org.lfenergy.operatorfabric.users.model;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -38,7 +37,10 @@ public class EntityData implements Entity {
     private String id;
     private String name;
     private String description;
-    @JsonIgnore
+
+    @Builder.Default
+    private Boolean entityAllowedToSendCard = true;
+
     private Set<String> parents;
 
     public EntityData(Entity entity) {
@@ -46,6 +48,7 @@ public class EntityData implements Entity {
         this.id = entity.getId();
         this.name = entity.getName();
         this.description = entity.getDescription();
+        this.entityAllowedToSendCard = entity.getEntityAllowedToSendCard();
         this.parents = entity.getParents().stream().collect(Collectors.toSet());
     }
 

--- a/services/core/users/src/main/modeling/swagger.yaml
+++ b/services/core/users/src/main/modeling/swagger.yaml
@@ -99,6 +99,8 @@ definitions:
         type: string
       description:
         type: string
+      entityAllowedToSendCard:
+        type: boolean
       parents:
         type: array
         items:

--- a/services/core/users/src/test/java/org/lfenergy/operatorfabric/users/configuration/ObjectMapperShould.java
+++ b/services/core/users/src/test/java/org/lfenergy/operatorfabric/users/configuration/ObjectMapperShould.java
@@ -1,4 +1,4 @@
-/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+/* Copyright (c) 2018-2021, RTE (http://www.rte-france.com)
  * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -93,7 +93,8 @@ public class ObjectMapperShould {
         String stringEntity = "{" +
                 "\"id\": \"TESTENTITY\"," +
                 "\"name\": \"Test Entity\"," +
-                "\"description\": \"An entity used for tests\"" +
+                "\"description\": \"An entity used for tests\"," +
+                "\"entityAllowedToSendCard\": false" +
                 "}";
         Entity entity = mapper.readValue(stringEntity, Entity.class);
         assertThat(entity).isNotNull();
@@ -101,5 +102,6 @@ public class ObjectMapperShould {
         assertThat(entity.getId()).isEqualTo("TESTENTITY");
         assertThat(entity.getName()).isEqualTo("Test Entity");
         assertThat(entity.getDescription()).isEqualTo("An entity used for tests");
+        assertThat(entity.getEntityAllowedToSendCard()).isFalse();
     }
 }

--- a/src/docs/asciidoc/reference_doc/users_management.adoc
+++ b/src/docs/asciidoc/reference_doc/users_management.adoc
@@ -55,7 +55,7 @@ ifndef::single-page-doc[<<{gradle-rootdir}/documentation/current/deployment/inde
 The notion of entity is loose and can be used to model organizations structures(examples : control center, company , department... ).
 Entities are used to send cards to several users without a name specifically. The information about membership to an
 entity is stored in the user's data (`entities` field of the `user` object). In Entity objects, the `parents` property (array) expresses the fact that this entity is a part of one or several other entities. This feature allows cards to be sent to a group of entities without having to repeat the detailed list of entities for each card.
-
+The boolean property `entityAllowedToSendCard` (default value `true`) can be used to mark an Entity as not eligible as card publisher. This can be useful for a group of entities where only child entities should be used as card publishers while the parent is just a logical group usable as card recipient.
 
 Examples using entities can be found 
 ifdef::single-page-doc[<<_send_to_several_users, here>>]

--- a/src/test/api/karate/cards/deleteUserCard.feature
+++ b/src/test/api/karate/cards/deleteUserCard.feature
@@ -201,7 +201,7 @@ Feature: deleteUserCards tests
     * def cardForDeleteForbidden3 =
 """
 {
-	"publisher" : "ENTITY1",
+	"publisher" : "ENTITY2",
 	"processVersion" : "1",
 	"process"  :"processDeleteUserCard",
 	"processInstanceId" : "processDeleteUserCardForbidden3",

--- a/src/test/api/karate/cards/userCards.feature
+++ b/src/test/api/karate/cards/userCards.feature
@@ -168,7 +168,32 @@ Feature: UserCards tests
 }
 """
 
-    # Push user card without authentication
+# Push user card with wrong publisher
+    Given url opfabPublishCardUrl + 'cards/userCard'
+    And request card
+    When method post
+    Then status 401
+
+
+    * def card =
+"""
+{
+	"publisher" : "ENTITY1",
+	"processVersion" : "1",
+	"process"  :"process_1",
+	"processInstanceId" : "process_id_w",
+	"state": "state2",
+	"groupRecipients": ["Dispatcher"],
+	"externalRecipients" : ["api_test_externalRecipient1"],
+	"severity" : "INFORMATION",
+	"startDate" : 1553186770681,
+	"summary" : {"key" : "defaultProcess.summary"},
+	"title" : {"key" : "defaultProcess.title"},
+	"data" : {"message":"a message"}
+}
+"""
+
+# Push user card without authentication
     Given url opfabPublishCardUrl + 'cards/userCard'
     And request card
     When method post
@@ -195,7 +220,7 @@ Feature: UserCards tests
     * def card =
 """
 {
-	"publisher" : "cardTest2",
+	"publisher" : "ENTITY1",
 	"processVersion" : "1",
 	"process"  :"process_2",
 	"processInstanceId" : "process_o",
@@ -342,7 +367,7 @@ Feature: UserCards tests
     * def childCard1 =
 """
 {
-	"publisher" : "cardTest4",
+	"publisher" : "ENTITY1",
 	"processVersion" : "1",
 	"process"  :"process_1",
 	"processInstanceId" : "process_id_4",
@@ -380,7 +405,7 @@ Feature: UserCards tests
     * def childCard2 =
 """
 {
-	"publisher" : "cardTest5",
+	"publisher" : "ENTITY1",
 	"processVersion" : "1",
 	"process"  :"process_1",
 	"processInstanceId" : "process_id_5",

--- a/src/test/api/karate/users/entities/createEntities.feature
+++ b/src/test/api/karate/users/entities/createEntities.feature
@@ -20,7 +20,8 @@ Feature: CreateEntities
 {
   "id" : "entityKarate1",
   "name" : "entityKarate1 name",
-  "description" : "I Love Karate"
+  "description" : "I Love Karate",
+  "entityAllowedToSendCard" : false
 }
 """
     * def wrongEntity =
@@ -42,6 +43,7 @@ Feature: CreateEntities
     And match response.description == entity.description
     And match response.name == entity.name
     And match response.id == entity.id
+    And match response.entityAllowedToSendCard == true
 
   Scenario: Update my entity
 
@@ -54,6 +56,7 @@ Feature: CreateEntities
     And match response.description == entityUpdated.description
     And match response.name == entityUpdated.name
     And match response.id == entity.id
+    And match response.entityAllowedToSendCard == false
 
   Scenario: create without admin role
         #HForbiden without admin role, expected response 403

--- a/ui/main/angular.json
+++ b/ui/main/angular.json
@@ -120,7 +120,9 @@
               "src/assets/styles/style.css",
               "src/assets/styles/styles.scss"
             ],
-            "scripts": [],
+            "scripts": [
+              "src/assets/js/templateGateway.js"
+            ],
             "assets": [
               "src/favicon.ico",
               "src/assets"

--- a/ui/main/src/app/model/entity.model.ts
+++ b/ui/main/src/app/model/entity.model.ts
@@ -1,4 +1,4 @@
-/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+/* Copyright (c) 2018-2021, RTE (http://www.rte-france.com)
  * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -14,7 +14,9 @@ export class Entity {
     public constructor(
     readonly id:string,
     readonly name:string,
-    readonly description:string
+    readonly description:string,
+    readonly entityAllowedToSendCard:boolean,
+    readonly parents: string[]
 ){}
 
 }

--- a/ui/main/src/app/modules/admin/components/editmodal/entities/edit-entity-modal.component.html
+++ b/ui/main/src/app/modules/admin/components/editmodal/entities/edit-entity-modal.component.html
@@ -42,6 +42,14 @@
             <label for="description" translate>admin.input.description</label>
             <input formControlName="description" name="description" id="description" type="text">
           </div>
+
+          <div class="row">
+            <label for="entityAllowedToSendCard" class="opfab-checkbox "> <span class="" translate> admin.input.entityAllowedToSendCard </span>
+              <input formControlName="entityAllowedToSendCard" name="entityAllowedToSendCard" id="entityAllowedToSendCard" type="checkbox">
+              <span class="opfab-checkbox-checkmark"></span>
+            </label>
+          </div>
+
         </div>
       </div>
     </form>

--- a/ui/main/src/app/modules/admin/components/editmodal/entities/edit-entity-modal.component.ts
+++ b/ui/main/src/app/modules/admin/components/editmodal/entities/edit-entity-modal.component.ts
@@ -26,7 +26,8 @@ export class EditEntityModalComponent implements OnInit {
     id: new FormControl(''
       , [Validators.required, Validators.minLength(2), Validators.pattern(/^[A-z\d\-_]+$/)]),
     name: new FormControl('', [Validators.required]),
-    description: new FormControl('')
+    description: new FormControl(''),
+    entityAllowedToSendCard: new FormControl(false),
   });
 
   @Input() row: any;
@@ -65,7 +66,7 @@ export class EditEntityModalComponent implements OnInit {
     this.id.setValue((this.id.value as string).trim());
     this.name.setValue((this.name.value as string).trim());
     this.description.setValue((this.description.value as string).trim());
-
+    this.entityAllowedToSendCard.setValue(this.entityAllowedToSendCard.value as boolean);
   }
 
   get id() {
@@ -78,6 +79,10 @@ export class EditEntityModalComponent implements OnInit {
 
   get description() {
     return this.entityForm.get('description') as FormControl;
+  }
+
+  get entityAllowedToSendCard() {
+    return this.entityForm.get('entityAllowedToSendCard') as FormControl;
   }
 
   dismissModal(reason: string): void {

--- a/ui/main/src/app/modules/admin/components/table/entities-table.component.ts
+++ b/ui/main/src/app/modules/admin/components/table/entities-table.component.ts
@@ -20,7 +20,7 @@ import {AdminItemType} from '../../services/sharing.service';
 export class EntitiesTableComponent extends AdminTableDirective implements OnInit {
 
   tableType = AdminItemType.ENTITY;
-  fields = [new Field('id', 3), new Field('name', 3), new Field('description', 5), new Field('parents', 5, 'entityCellRenderer')];
+  fields = [new Field('id', 3), new Field('name', 3), new Field('description', 5), new Field('entityAllowedToSendCard', 3), new Field('parents', 5, 'entityCellRenderer')];
   idField = 'id';
   editModalComponent = EditEntityModalComponent;
 

--- a/ui/main/src/app/modules/cards/components/detail/detail.component.ts
+++ b/ui/main/src/app/modules/cards/components/detail/detail.component.ts
@@ -454,8 +454,14 @@ export class DetailComponent implements OnChanges, OnInit, OnDestroy, AfterViewC
     private setEntitiesToRespond() {
         this._listEntitiesToRespond = new Array<EntityMessage>();
         this._userEntitiesAllowedToRespond = [];
+
         if (this.card.entitiesAllowedToRespond) {
-            this.card.entitiesAllowedToRespond.forEach(entity => {
+
+            const entitiesToRespond = this.entitiesService.getEntities().filter(entity  => this.card.entitiesAllowedToRespond.includes(entity.id));
+            const allowed = this.entitiesService.getEntitiesAllowedToRespond(entitiesToRespond).map(entity => entity.id);
+            console.log(new Date().toISOString(), ' Detail card - entities allowed to respond = ', allowed);
+
+            allowed.forEach(entity => {
                 const entityName = this.getEntityName(entity);
                 if (entityName) {
                     this._listEntitiesToRespond.push(
@@ -465,7 +471,9 @@ export class DetailComponent implements OnChanges, OnInit, OnDestroy, AfterViewC
                         });
                 }
             });
-            this._userEntitiesAllowedToRespond = this.card.entitiesAllowedToRespond.filter(x => this.user.entities.includes(x));
+
+            this._userEntitiesAllowedToRespond = allowed.filter(x => this.user.entities.includes(x));
+            console.log(new Date().toISOString(), ' Detail card - users entities allowed to respond = ', this._userEntitiesAllowedToRespond);
         }
     }
 

--- a/ui/main/src/app/modules/usercard/usercard.component.ts
+++ b/ui/main/src/app/modules/usercard/usercard.component.ts
@@ -37,6 +37,7 @@ import {MessageLevel} from '@ofModel/message.model';
 import {AlertMessage} from '@ofStore/actions/alert.actions';
 import {RightsEnum} from '@ofModel/perimeter.model';
 import {Utilities} from '../../common/utilities';
+import {Entity} from '@ofModel/entity.model';
 
 declare const templateGateway: any;
 
@@ -64,6 +65,7 @@ export class UserCardComponent implements OnDestroy, OnInit {
         };
     });
 
+    entities: Entity[];
     stateOptions: any[];
     recipientsOptions = [];
     selectedRecipients = [];
@@ -184,7 +186,8 @@ export class UserCardComponent implements OnDestroy, OnInit {
 
 
     loadAllEntities(): void {
-        this.entitiesService.getEntities().forEach(entity =>
+        this.entities = this.entitiesService.getEntities();
+        this.entities.forEach(entity =>
             this.recipientsOptions.push({ id: entity.id, itemName: entity.name }));
 
         this.recipientsOptions.sort(( a, b ) => a.itemName.localeCompare(b.itemName));
@@ -402,11 +405,15 @@ export class UserCardComponent implements OnDestroy, OnInit {
             return;
         } else selectedRecipients.forEach(entity => recipients.push(entity.id));
 
+        const publisher =  this.currentUserWithPerimeters.userData.entities.find(userEntity => {
+            const entity = this.entities.find(e => e.id === userEntity);
+            return entity.entityAllowedToSendCard;
+        });
 
         const entitiesAllowedToRespond = [];
         if (selectedProcess.states[state].response) {
                 recipients.forEach(entity => {
-                    if (!this.currentUserWithPerimeters.userData.entities.includes(entity)) entitiesAllowedToRespond.push(entity);
+                    if (entity != publisher) entitiesAllowedToRespond.push(entity);
                 });
         }
 
@@ -436,7 +443,6 @@ export class UserCardComponent implements OnDestroy, OnInit {
             else timeSpans = [new TimeSpan(startDate , endDate )];
         }
 
-
         let processInstanceId ;
         if (this.editCardMode) processInstanceId = this.cardToEdit.card.processInstanceId;
         else processInstanceId  = Guid.create().toString();
@@ -444,7 +450,7 @@ export class UserCardComponent implements OnDestroy, OnInit {
         this.card = {
             id: 'dummyId',
             publishDate: null,
-            publisher: this.currentUserWithPerimeters.userData.entities[0],
+            publisher: publisher,
             processVersion: processVersion,
             process: selectedProcess.id,
             processInstanceId: processInstanceId,

--- a/ui/main/src/app/services/entities.service.spec.ts
+++ b/ui/main/src/app/services/entities.service.spec.ts
@@ -1,4 +1,4 @@
-/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+/* Copyright (c) 2018-2021, RTE (http://www.rte-france.com)
  * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -35,11 +35,12 @@ describe('EntitiesService', () => {
   it('should be created', () => {
     expect(entitiesService).toBeTruthy();
   });
+
   describe('#getAllEntities', () => {
     it('should return an Observable<Entity[]>', () => {
       const listEntities: Entity[] = [];
-      const entity1 = new Entity('ENTITY1', 'Control Room 1', 'Control Room 1');
-      const entity2 = new Entity('ENTITY2', 'Control Room 2', 'Control Room 2');
+      const entity1 = new Entity('ENTITY1', 'Control Room 1', 'Control Room 1', true, []);
+      const entity2 = new Entity('ENTITY2', 'Control Room 2', 'Control Room 2', true, []);
       listEntities.push(entity1);
       listEntities.push(entity2);
       entitiesService.getAllEntities().subscribe(result => {
@@ -52,4 +53,98 @@ describe('EntitiesService', () => {
       req.flush(listEntities);
     });
   });
+  
+
+  describe('#getEntitiesAllowedToRespond', () => {
+    it('shoud return 3 entities', () => {
+      const listEntities: Entity[] = [];
+      const entity1 = new Entity('ENTITY1', 'Control Room 1', 'Control Room 1', true, []);
+      const entity2 = new Entity('ENTITY2', 'Control Room 2', 'Control Room 2', true, []);
+      const entity3 = new Entity('ENTITY3', 'Control Room 3', 'Control Room 3', false, []);
+      const entity3_1 = new Entity('ENTITY3.1', 'Control Room 3.1', 'Control Room 3.1', false, ['ENTITY3']);
+      const entity3_1_1 = new Entity('ENTITY3.1.1', 'Control Room 3.1.1', 'Control Room 3.1.1', false, ['ENTITY3.1']);
+      const entity3_1_2 = new Entity('ENTITY3.1.2', 'Control Room 3.1.2', 'Control Room 3.1.2', true, ['ENTITY3.1']);
+      const entity3_2 = new Entity('ENTITY3.2', 'Control Room 3.2', 'Control Room 3.2', true, ['ENTITY3']);
+
+      listEntities.push(entity1);
+      listEntities.push(entity2);
+      listEntities.push(entity3);
+      listEntities.push(entity3_1);
+      listEntities.push(entity3_1_1);
+      listEntities.push(entity3_1_2);
+      listEntities.push(entity3_2);
+
+      entitiesService.loadAllEntitiesData().subscribe(result => {
+        expect(result.length).toBe(7);
+        const selectedEntities: Entity[] = [];
+        selectedEntities.push(entity2);
+        selectedEntities.push(entity3);
+        const allowedEntities = entitiesService.getEntitiesAllowedToRespond(selectedEntities);
+        expect(allowedEntities.length).toBe(3);
+        expect(allowedEntities[0].id).toBe('ENTITY2');
+        expect(allowedEntities[1].id).toBe('ENTITY3.1.2');
+        expect(allowedEntities[2].id).toBe('ENTITY3.2');
+      });
+      const req = httpMock.expectOne(`${environment.urls.entities}`);
+      expect(req.request.method).toBe('GET');
+      req.flush(listEntities);
+
+    });
+
+    it('shoud return 1 entity', () => {
+      const listEntities: Entity[] = [];
+
+      const entityGroup = new Entity('ENTITYGROUP', 'Control Rooms', 'Control Rooms', true, []);
+      const entity1 = new Entity('ENTITY1', 'Control Room 1', 'Control Room 1', true, ['ENTITYGROUP']);
+      const entity2 = new Entity('ENTITY2', 'Control Room 2', 'Control Room 2', true, ['ENTITYGROUP']);
+
+      listEntities.push(entity1);
+      listEntities.push(entity2);
+      listEntities.push(entityGroup);
+
+      entitiesService.loadAllEntitiesData().subscribe(result => {
+        expect(result.length).toBe(3);
+        const selectedEntities: Entity[] = [];
+        selectedEntities.push(entityGroup);
+
+        const allowedEntities = entitiesService.getEntitiesAllowedToRespond(selectedEntities);
+        expect(allowedEntities.length).toBe(1);
+        expect(allowedEntities[0].id).toBe('ENTITYGROUP');
+      });
+      const req = httpMock.expectOne(`${environment.urls.entities}`);
+      expect(req.request.method).toBe('GET');
+      req.flush(listEntities);
+
+    });
+
+    it('shoud return 2 entity', () => {
+      const listEntities: Entity[] = [];
+  
+      const entityGroup = new Entity('ENTITYGROUP', 'Control Rooms', 'Control Rooms', false, []);
+      const entity1 = new Entity('ENTITY1', 'Control Room 1', 'Control Room 1', true, ['ENTITYGROUP']);
+      const entity2 = new Entity('ENTITY2', 'Control Room 2', 'Control Room 2', true, ['ENTITYGROUP']);
+  
+      listEntities.push(entity1);
+      listEntities.push(entity2);
+      listEntities.push(entityGroup);
+
+      entitiesService.loadAllEntitiesData().subscribe(result => {
+        expect(result.length).toBe(3);
+        const selectedEntities: Entity[] = [];
+        selectedEntities.push(entity1);
+        selectedEntities.push(entity2);
+        selectedEntities.push(entityGroup);
+  
+        const allowedEntities = entitiesService.getEntitiesAllowedToRespond(selectedEntities);
+        expect(allowedEntities.length).toBe(2);
+        expect(allowedEntities[0].id).toBe('ENTITY1');
+        expect(allowedEntities[1].id).toBe('ENTITY2');
+      });
+      const req = httpMock.expectOne(`${environment.urls.entities}`);
+      expect(req.request.method).toBe('GET');
+      req.flush(listEntities);
+  
+    });
+  });
+
 })

--- a/ui/main/src/app/services/entities.service.ts
+++ b/ui/main/src/app/services/entities.service.ts
@@ -117,4 +117,19 @@ export class EntitiesService extends CachedCrudService implements OnDestroy {
     templateGateway.setEntityNames(entityNames);
   }
 
+  public getEntitiesAllowedToRespond(selected: Entity[]) : Entity[] {
+    let allowed = new Set<Entity>();
+    selected.forEach(entity => {
+        if (entity.entityAllowedToSendCard) {
+            allowed.add(entity);
+        } else {
+          const childs = this._entities.filter(child => child.parents.includes(entity.id));
+          const childsAllowed = this.getEntitiesAllowedToRespond(childs);
+          childsAllowed.forEach(c => allowed.add(c));
+        }
+    })
+
+    return Array.from(allowed);
+  }
+
 }

--- a/ui/main/src/assets/i18n/en.json
+++ b/ui/main/src/assets/i18n/en.json
@@ -277,6 +277,7 @@
         "name": "Name",
         "parents": "Parent Entities",
         "description": "Description",
+        "entityAllowedToSendCard": "Card sending allowed",
         "confirmDelete": "Do you really want to delete entity",
         "add": "Add new entity"
       },
@@ -326,7 +327,8 @@
         "label":"Name"
       },
       "description": "Description",
-      "lines": "lines per page"
+      "lines": "lines per page",
+      "entityAllowedToSendCard": "Card sending allowed"
     },
     "tabs": {
       "users": "Users Management",

--- a/ui/main/src/assets/i18n/fr.json
+++ b/ui/main/src/assets/i18n/fr.json
@@ -277,6 +277,7 @@
         "name": "Nom",
         "parents": "Entités parentes",
         "description": "Description",
+        "entityAllowedToSendCard": "Envoi de carte autorisé",
         "confirmDelete": "Voulez-vous vraiment supprimer l'entité",
         "add":"Ajouter une nouvelle entité"
       },
@@ -326,7 +327,8 @@
         "label":"Nom"
       },
       "description": "Description",
-      "lines": "lignes par page"
+      "lines": "lignes par page",
+      "entityAllowedToSendCard": "Envoi de carte autorisé"
     },
     "tabs": {
       "users": "Gestion des utilisateurs",


### PR DESCRIPTION
Release notes:

In Features:
[OC-1257] Set groups of entities compatible with response card. Added "entityAllowedToSendCard "boolean field to Entity.
NOTE: If an Entity has entityAllowedToSendCard=false and has child entities, than child entities will be checked recursively 

[OC-1257]: https://opfab.atlassian.net/browse/OC-1257