### PR TITLE
[OC-1526] Fixes configuration in cards-consult and card-pub docker images

### DIFF
--- a/services/core/cards-consultation/src/main/docker/Dockerfile
+++ b/services/core/cards-consultation/src/main/docker/Dockerfile
@@ -20,5 +20,5 @@ COPY add-certificates.sh /add-certificates.sh
 COPY java-config-docker-entrypoint.sh /docker-entrypoint.sh
 COPY common-docker.yml /config/common-docker.yml
 COPY ${JAR_FILE} app.jar
-COPY cards-consultation-docker.yml /config/
+COPY cards-consultation-docker.yml /config/application-docker.yml
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/services/core/cards-publication/src/main/docker/Dockerfile
+++ b/services/core/cards-publication/src/main/docker/Dockerfile
@@ -20,5 +20,5 @@ COPY add-certificates.sh /add-certificates.sh
 COPY java-config-docker-entrypoint.sh /docker-entrypoint.sh
 COPY common-docker.yml /config/common-docker.yml
 COPY ${JAR_FILE} app.jar
-COPY cards-publication-docker.yml /config/
+COPY cards-publication-docker.yml /config/application-docker.yml
 ENTRYPOINT ["/docker-entrypoint.sh"]


### PR DESCRIPTION
Tested it with the Getting Started by changing the value for checkPerimeterForResponseCard and making sure it was taken into account.
To test, make sure to rebuild your snapshot images locally.

In the release notes under Bugs:

[OC-1526] Fixes configuration in cards-consultation and cards-publication docker images
+
2.1.0.RELEASE images for these two services did not take custom configuration passed through docker-compose into account properly

[OC-1526]: https://opfab.atlassian.net/browse/OC-1526