### PR TITLE
[OC-1473] Upgrade MongoDB and Keycloak docker images.

### DIFF
--- a/config/dev/docker-compose.yml
+++ b/config/dev/docker-compose.yml
@@ -14,8 +14,8 @@ services:
       MONGO_INITDB_ROOT_USERNAME: root
       MONGO_INITDB_ROOT_PASSWORD: password
   keycloak:
-    image: jboss/keycloak:6.0.1
-    command: -Dkeycloak.migration.action=import -Dkeycloak.migration.provider=dir -Dkeycloak.migration.dir=/keycloak/export
+    image: jboss/keycloak:12.0.2
+    command: -Dkeycloak.migration.action=import -Dkeycloak.migration.provider=dir -Dkeycloak.migration.dir=/keycloak/export -Dkeycloak.profile.feature.upload_scripts=enabled
     environment:
       - KEYCLOAK_USER=admin
       - KEYCLOAK_PASSWORD=admin

--- a/config/docker/docker-compose.yml
+++ b/config/docker/docker-compose.yml
@@ -14,8 +14,8 @@ services:
 #      - "5672:5672"
 #      - "15672:15672"
   keycloak:
-    image: jboss/keycloak:6.0.1
-    command: -Dkeycloak.migration.action=import -Dkeycloak.migration.provider=dir -Dkeycloak.migration.dir=/keycloak/export
+    image: jboss/keycloak:12.0.2
+    command: -Dkeycloak.migration.action=import -Dkeycloak.migration.provider=dir -Dkeycloak.migration.dir=/keycloak/export -Dkeycloak.profile.feature.upload_scripts=enabled
     environment:
     - KEYCLOAK_USER=admin
     - KEYCLOAK_PASSWORD=admin


### PR DESCRIPTION
This branch upgrades the MongoDB docker image from 4.1.1-xenial to 4.4.4-bionic and upgrades the Keycloak docker image from 6.0.1 to 12.0.2 and adds a configuration parameter to support the 'upload_scripts' feature in Keycloak 12.