### PR TITLE
[OC-1555] Permit to access opfab directly from localhost:2002 without /ui/

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -86,7 +86,7 @@ cd ./config/docker
 ./docker-compose.sh
 ----
 
-. After a little while, log into the application UI at *localhost:2002/ui/* using admin/test as credentials.
+. After a little while, log into the application UI at *localhost:2002/* using admin/test as credentials.
 +
 WARNING: Don't forget the *final slash* in the URL or you will get an error.
 

--- a/config/dev/nginx.conf.template
+++ b/config/dev/nginx.conf.template
@@ -19,6 +19,11 @@ server {
   add_header 'Access-Control-Allow-Credentials' 'true' always;
   add_header 'Access-Control-Allow-Methods' '*' always;
   add_header 'Access-Control-Allow-Headers' '*' always;
+
+  location / {
+    alias /usr/share/nginx/html/;
+    index index.html index.htm;
+  }
   location /ui/ {
     alias /usr/share/nginx/html/;
     index index.html index.htm;

--- a/config/docker/nginx-cors-permissive.conf
+++ b/config/docker/nginx-cors-permissive.conf
@@ -19,6 +19,11 @@ server {
   add_header 'Access-Control-Allow-Credentials' 'true' always;
   add_header 'Access-Control-Allow-Methods' '*' always;
   add_header 'Access-Control-Allow-Headers' '*' always;
+  
+  location / {
+    alias /usr/share/nginx/html/;
+    index index.html index.htm;
+  }
   location /ui/ {
     alias /usr/share/nginx/html/;
     index index.html index.htm;

--- a/config/docker/nginx.conf
+++ b/config/docker/nginx.conf
@@ -13,7 +13,11 @@ server {
   ### CUSTOMIZATION - END
   set $BasicValue "Basic $ClientPairOFAuthentication";
   set $KeycloakOpenIdConnect $KeycloakBaseUrl/auth/realms/$OperatorFabricRealm/protocol/openid-connect;
-  #   access_log /var/log/nginx/host.access.log main;
+
+  location / {
+    alias /usr/share/nginx/html/;
+    index index.html index.htm;
+  }
   location /ui/ {
     alias /usr/share/nginx/html/;
     index index.html index.htm;

--- a/src/docs/asciidoc/deployment/configuration/security_configuration.adoc
+++ b/src/docs/asciidoc/deployment/configuration/security_configuration.adoc
@@ -135,7 +135,7 @@ These two modes share the same way of declaring the delegate URL.
           "provider": "Opfab Keycloak",
           "delegate-url": "http://localhost:89/auth/realms/dev/protocol/openid-connect/auth?response_type=code&client_id=opfab-client"
       },
-      "logout-url":"http://localhost:89/auth/realms/dev/protocol/openid-connect/logout?redirect_uri=http://localhost:2002/ui/",
+      "logout-url":"http://localhost:89/auth/realms/dev/protocol/openid-connect/logout?redirect_uri=http://localhost:2002/",
     "provider-realm": "dev",
     "provider-url": "http://localhost:89"
     }
@@ -170,7 +170,7 @@ To enable IMPLICIT Flow authentication the following properties need to be set:
           "provider": "Opfab Keycloak",
           "delegate-url": "http://localhost:89/auth/realms/dev"
       },
-      "logout-url":"http://localhost:89/auth/realms/dev/protocol/openid-connect/logout?redirect_uri=http://localhost:2002/ui/",
+      "logout-url":"http://localhost:89/auth/realms/dev/protocol/openid-connect/logout?redirect_uri=http://localhost:2002/",
     "provider-realm": "dev",
     "provider-url": "http://localhost:89"
       }

--- a/src/docs/asciidoc/dev_env/launch_dev.adoc
+++ b/src/docs/asciidoc/dev_env/launch_dev.adoc
@@ -133,7 +133,7 @@ bin/run_all.sh status
 
 == Log into the UI
 
-*_URL:_* localhost:2002/ui/ +
+*_URL:_* localhost:2002/ +
 *_login:_* operator1 +
 *_password:_* test
 

--- a/src/docs/asciidoc/dev_env/troubleshooting.adoc
+++ b/src/docs/asciidoc/dev_env/troubleshooting.adoc
@@ -146,7 +146,7 @@ IMPORTANT: Don't use *sudo* to build OperatorFabric otherwise unexpected problem
 When using the following command line:
 [source]
 ----
-curl http://localhost:2002/ui/
+curl http://localhost:2002/
 ----
 
 .Error message

--- a/src/docs/asciidoc/dev_env/ui.adoc
+++ b/src/docs/asciidoc/dev_env/ui.adoc
@@ -66,7 +66,7 @@ Started with pid: 7501
 
 Wait a moment before trying to connect to the`SPA`, leaving time for the OperatorFabricServices to boot up completely.
 
-The `SPA`, on a local machine, is available at the following Url: `http://localhost:2002/ui/`.
+The `SPA`, on a local machine, is available at the following Url: `http://localhost:2002/`.
 
 To log in you need to use a valid user among the following: `operator1`, `operator3` or `admin`.
 The common password is `test` for them all.
@@ -83,7 +83,7 @@ For more realistic card sending use, once Karate env correctly configured, the K
 ** `${OF_HOME}/src/test/utils/karate/loadBundles.sh`
 ** `${OF_HOME}/src/test/utils/karate/postTestCards.sh`
 
-Once logged in, after one of those scripts have been running, you should be able to see some cards displayed in `http://localhost:2002/ui/feed`.
+Once logged in, after one of those scripts have been running, you should be able to see some cards displayed in `http://localhost:2002/`.
 
 
 == Build


### PR DESCRIPTION

Release note 

Task :
[OC-1555] Permit to access opfab directly from localhost:2002 without /ui/

[OC-1555]: https://opfab.atlassian.net/browse/OC-1555