### PR TITLE
[OC-1540] Bug fix in JAVA_OPTIONS in docker-entrypoint script

### DIFF
--- a/src/main/docker/java-config-docker-entrypoint.sh
+++ b/src/main/docker/java-config-docker-entrypoint.sh
@@ -13,5 +13,5 @@ cp $JAVA_HOME/jre/lib/security/cacerts /tmp
 chmod u+w /tmp/cacerts
 ./add-certificates.sh /certificates_to_add /tmp/cacerts
 
-java -agentlib:jdwp=transport=dt_socket,address=5005,server=y,suspend=n -Djavax.net.ssl.trustStore=/tmp/cacerts -Djava.security.egd=file:/dev/./urandom  -jar /app.jar $JAVA_OPTIONS
+java -agentlib:jdwp=transport=dt_socket,address=5005,server=y,suspend=n -Djavax.net.ssl.trustStore=/tmp/cacerts -Djava.security.egd=file:/dev/./urandom $JAVA_OPTIONS -jar /app.jar
 


### PR DESCRIPTION
Moved JAVA_OPTIONS environment parameter in docker-entrypoint shell script. In the old position it was placed behind the -jar parameter. This caused java to skip the JAVA_OPTIONS and ignore the optional extra settings.

Signed-off-by: Gerben Danen <gerben.danen@alliander.com>