### PR TITLE
[OC-1563] Bug Chrome  - Timeline domain list on two lines sometimes

### DIFF
--- a/ui/main/src/app/modules/share/timeline-buttons/timeline-buttons.component.scss
+++ b/ui/main/src/app/modules/share/timeline-buttons/timeline-buttons.component.scss
@@ -42,6 +42,11 @@
 
         padding-left: 0px;
         padding-right: 25px;
+        // The following 3 lines avoid having the text go an a new line 
+        // Arise only on chrome (OC-1563)
+        text-overflow: clip;
+        white-space: nowrap;
+        overflow: hidden;
 
         .link-selected {
           color: var(--opfab-navbar-color-active);


### PR DESCRIPTION
Release note :

BUG 

[OC-1563] Bug Chrome  - Timeline domain list on two lines sometimes

[OC-1563]: https://opfab.atlassian.net/browse/OC-1563