### PR TITLE
[OC-1554] Adapting CICD for hotfixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -79,6 +79,10 @@ jobs:
       script:
         - ./gradlew --build-cache generateSwaggerUI asciidoctor
         - ./CICD/travis/upload_doc.sh
+    - stage: doc-latest
+      script:
+        - ./gradlew --build-cache generateSwaggerUI asciidoctor
+        - ./CICD/travis/upload_doc.sh --updateLatest true
     - stage: doc-dry-run
       script:
         - ./gradlew --build-cache generateSwaggerUI asciidoctor
@@ -106,13 +110,15 @@ stages:
   - name: test-sonar
     if: NOT (type = pull_request AND head_repo != opfab/operatorfabric-core)
   - name: doc
-    if: ((((type = cron OR commit_message =~ ci_documentation) AND branch = develop) OR branch = master) AND NOT type = pull_request)
+    if: ((((type = cron OR commit_message =~ ci_documentation) AND branch = develop) OR (commit_message =~ ci_documentation AND NOT commit_message =~ ci_latest AND branch =~ .+hotfixes$)) AND NOT type = pull_request)
+  - name: doc-latest
+    if: (branch = master OR (branch =~ .+hotfixes$ AND commit_message =~ ci_latest)) AND NOT type = pull_request
   - name: doc-dry-run
-    if: (branch =~ .+release$) OR (NOT (branch IN (master,develop)) AND commit_message =~ ci_documentation)
+    if: (NOT branch =~ .+hotfixes$) AND (NOT (branch IN (master,develop)) AND commit_message =~ ci_documentation)
   - name: docker-push-version
-    if: (((type = cron OR commit_message =~ ci_docker) AND branch = develop) OR branch = master) AND NOT type = pull_request
+    if: (((type = cron OR commit_message =~ ci_docker) AND (branch = develop OR branch =~ .+hotfixes$)) OR branch = master) AND NOT type = pull_request
   - name: docker-push-latest
-    if: branch = master AND commit_message =~ ci_latest AND NOT type = pull_request
+    if: branch = master OR (branch =~ .+hotfixes$ AND commit_message =~ ci_latest) AND NOT type = pull_request
   - name: docker-tag-version
     if: (branch =~ .+release$) OR (NOT (branch IN (master,develop)) AND commit_message =~ ci_docker)
 before_cache:

--- a/CICD/travis/check_version.sh
+++ b/CICD/travis/check_version.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+# Copyright (c) 2018-2021, RTE (http://www.rte-france.com)
 # See AUTHORS.txt
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -15,7 +15,7 @@ display_usage() {
 	echo -e "\tcheck_version.sh [OPTIONS] \n"
 	echo -e "options:\n"
 	echo -e "\t-b, --branch  : string. Branch on which Travis is running the build"
-	echo -e "\t-b, --version  : string. Version set for current repository state"
+	echo -e "\t-v, --version  : string. Version set for current repository state"
 }
 
 # Read parameters
@@ -58,11 +58,16 @@ fi
 
 echo "check_version: branch $branch, version $version"
 
+minor_version_pattern='([0-9]+\.[0-9]+)'
+if [[ $branch =~ $minor_version_pattern\.hotfixes$ ]] ; then
+    minor_version=${BASH_REMATCH[1]}
+    [[ $version =~ $minor_version\.[0-9]+\.RELEASE$ ]] && exit 0 || echo "check_version failed: for hotfixes branch $branch version should be $minor_version.X.RELEASE."; exit 1;
+fi
+
 [[ $branch == 'develop' ]] && { [[ $version == 'SNAPSHOT' ]] && exit 0 || echo "check_version failed: for branch develop version should be SNAPSHOT."; exit 1;}
 [[ $branch == 'master' ]] && { [[ $version =~ [0-9]+\.[0-9]+\.[0-9]+\.RELEASE$ ]] && exit 0 || echo "check_version failed: for branch master version should be X.X.X.RELEASE."; exit 1;}
 [[ $branch =~ [0-9]+\.[0-9]+\.[0-9]+\.release$ ]] && { [[ $version == ${branch^^} ]] && exit 0 || echo "check_version failed: for release branch $branch version should be ${branch^^}."; exit 1;}
-[[ $branch =~ OC-.+$ ]] && { [[ $version == 'SNAPSHOT' ]] && exit 0 || echo "check_version failed: for feature branches version should be SNAPSHOT."; exit 1;}
-[[ $branch =~ HF_OC-.+$ ]] && { [[ $version =~ [0-9]+\.[0-9]+\.[0-9]+\.RELEASE$ ]] && exit 0 || echo "check_version failed: for hotfix branches version should be X.X.X.RELEASE."; exit 1;}
+[[ $branch =~ OC-.+$ ]] && { [[ $version == 'SNAPSHOT' || $version =~ [0-9]+\.[0-9]+\.[0-9]+\.RELEASE$ ]] && exit 0 || echo "check_version failed: for feature branches version should be SNAPSHOT or X.X.X.RELEASE."; exit 1;}
 
 echo "check_version failed: unhandled branch type"
 exit 1;

--- a/CICD/travis/upload_doc.sh
+++ b/CICD/travis/upload_doc.sh
@@ -11,6 +11,39 @@
 
 . ${BASH_SOURCE%/*}/../../bin/load_variables.sh
 
+updateLatest=false
+
+display_usage() {
+	echo "This script gets the documentation from the website in its current state, "
+	echo -e "Usage:\n"
+	echo -e "\tcheck_version.sh [OPTIONS] \n"
+	echo -e "options:\n"
+	echo -e "\t-b, --commitMessage  : boolean. If set to true, the script also updates the latest documentation (found under current in the website). Defaults to $updateLatest\n"
+}
+
+# Read parameters
+while [[ $# -gt 0 ]]
+do
+key="$1"
+# echo $key
+case $key in
+    -u|--updateLatest)
+    updateLatest="$2"
+    shift # past argument
+    shift # past value
+    ;;
+    -h|--help)
+    shift # past argument
+display_usage
+    exit 0
+    ;;
+    *)    # unknown option
+    POSITIONAL+=("$1") # save it in an array for later
+    shift # past argument
+    ;;
+esac
+done
+
 CURRENT_PATH=$(pwd)
 GH_REPO=github.com/opfab/opfab.github.io.git
 HTTP_REPO="https://opfabtech:${GH_DOC_TOKEN}@${GH_REPO}"
@@ -28,8 +61,10 @@ fi
 if [[ $OF_VERSION =~ .+RELEASE$ ]]; then
   # Clear existing documentation in archive for current version
   rm -r $HOME/documentation/documentation/archives/$OF_VERSION/*
-  # Update current documentation
-  rm -r $HOME/documentation/documentation/current/*
+
+  # If updateLatest is true, update current documentation
+  if [[ $updateLatest = true ]]; then
+    rm -r $HOME/documentation/documentation/current/*
     # Copy API documentation for each component
     for prj in "${OF_CLIENT_REL_COMPONENTS[@]}"; do
       echo "copying $prj documentation"
@@ -39,6 +74,8 @@ if [[ $OF_VERSION =~ .+RELEASE$ ]]; then
     # Copy asciidoctor documentation (including images)
     mkdir -p $HOME/documentation/documentation/current/
     cp -r $OF_HOME/build/asciidoc/html5/* $HOME/documentation/documentation/current/
+  fi
+
 fi
 
 # For archives

--- a/src/docs/asciidoc/CICD/pipeline_conf.adoc
+++ b/src/docs/asciidoc/CICD/pipeline_conf.adoc
@@ -30,7 +30,10 @@ We use Travis CI to manage our pipeline. As of today, it is composed of 7 stages
 test-sonar:: Builds the commit, runs tests and sonar analysis
 test:: Similar to `test-sonar` but without sonar analysis
 doc:: Generates the documentation (from asciidoc sources and API documentation) and pushes it to the opfab.github.io
-repository to update the website.
+repository to update the documentation for this release on the website.
+doc-latest:: Generates the documentation (from asciidoc sources and API documentation) and pushes it to the
+opfab.github.io repository to update the documentation for this release, as well as the "current" documentation on the
+website.
 doc-dry-run:: Generates the documentation without pushing it
 docker-push-version:: Builds Docker images, tags them with the current version (either `SNAPSHOT` or `X.X.X.RELEASE`) and
 pushes them to DockerHub
@@ -54,18 +57,19 @@ doc hook:: stands for adding the keyword `ci_documentation` to the commit messag
 docker hook:: stands for adding the keyword `ci_docker` to the commit message
 latest hook:: stands for adding the keyword `ci_latest` to the commit message
 
-.Summary of stage triggers
-[caption="", cols="3,^1,^1,^1,^1,^1,^1,^1,^1,^1,^1,^1", stripes=even]
+.Summary of stage triggers depending on branch
+[caption="", cols="3,^1,^1,^1,^1,^1,^1,^1,^1,^1,^1,^1,^1,^1,^1", stripes=even]
 |==========================
-h|      4+h|develop h|release 2+h|master 3+h|feature or hotfix h| pull request
-h|Stage              h|CRON h|push h|doc hook h|docker hook h|push h|push h|latest hook h|push h|doc hook h|docker hook h|push
-e|test-sonar          |X|X| | |X|X| |X| | |internal
-e|test                | | | | | | | | | | |external
-e|doc                 |X| |X| | |X| | | | |
-e|doc-dry-run         | | | | |X| | | |X| |
-e|docker-push-version |X| | |X| |X| | | | |
-e|docker-push-latest  | | | | | | |X| | | |
-e|docker-tag-version  | | | | |X| | | | |X|
+h|      4+h|develop h|release h|master 4+h|hotfixes 3+h|feature h| pull request
+h|Stage              h|CRON h|push h|doc hook h|docker hook h|push h|push h|push h|doc hook h|docker hook h|latest hook h|push h|doc hook h|docker hook h|push
+e|test-sonar          |X|X| | |X|X|X| | | |X| | |internal
+e|test                | | | | | | | | | | | | | |external
+e|doc                 |X| |X| | | | |X| | | | | |
+e|doc-latest          | | | | | |X| | | |X| | | |
+e|doc-dry-run         | | | | |X| | | | | | |X| |
+e|docker-push-version |X| | |X| |X| | |X| | | | |
+e|docker-push-latest  | | | | | |X| | | |X| | | |
+e|docker-tag-version  | | | | |X| | | | | | | |X|
 |==========================
 
 * The `test-sonar` phase is ran for every build except those triggered by external PRs (i.e. originating from a fork

--- a/src/docs/asciidoc/CICD/release_process.adoc
+++ b/src/docs/asciidoc/CICD/release_process.adoc
@@ -25,7 +25,7 @@ Version numbers for X.Y.Z.RELEASE should be understood like this:
 the same major version.
 * Z: Patch, a patch version only contains bug fixes of current minor version
 
-== Releasing a Version
+== Releasing a Major or Minor Version
 
 IMPORTANT: To release a version we use some Travis dedicated jobs. These jobs are triggered by specific commit keywords
 and rely on the VERSION file at the root of this repository to know which version is being produced.
@@ -52,9 +52,9 @@ explanations if need be.
 . On the link:{opfab_core_repo}[operatorfabric-core repository], create a branch off the `develop` branch named
 `X.X.X.release` (note the lowercase `release` to distinguish it from `X.X.X.RELEASE` tags).
 +
-```
+----
 git checkout -b X.X.X.release
-```
+----
 
 . Cut the contents from the release_notes.adoc file from the
 link:https://github.com/opfab/release-notes/[release-notes repository] and paste it to the release_notes.adoc file
@@ -67,9 +67,9 @@ title by `Version X.X.X.RELEASE`
 
 . Use the ./CICD/prepare_release_version.sh script to automatically perform all the necessary changes:
 +
-```
+----
 ./CICD/prepare_release_version.sh -v X.X.X.RELEASE
-```
+----
 +
 You should get the following output:
 +
@@ -95,16 +95,16 @@ This script performs the following changes:
 +
 . Commit the changes with the template message:
 +
-```
+----
 git add .
 git commit -m "[RELEASE] X.X.X.RELEASE"
-```
+----
 +
 . Push the commit
 +
-```
+----
 git push --set-upstream origin X.X.X.release
-```
+----
 
 . Check that the build is correctly triggered
 +
@@ -117,6 +117,11 @@ image::release_branch_build.png[Running build for release branch screenshot]
 Wait for the build to complete (around 20 minutes) and check that all stages have been successful.
 This ensures that the code builds, tests are OK and there is no error preventing documentation or Docker images
 generation.
+
+NOTE: Specific keywords such as "ci_docker" etc. are no longer required in the case of a release on master as
+by design any release on master becomes the "latest" version, so docker images generation (both for the version
+tag and the latest tag) and documentation update (both for the release and the "current" folder) should always
+be triggered.
 
 === Merging the release branch into `master`
 
@@ -184,29 +189,29 @@ that it's working correctly.
 
 In the "Releases" screen, release `X.X.X.RELEASE`.
 
-== Advertising the new release on the LFE mailing list
+=== Advertising the new release on the LFE mailing list
 
 . Send an email to the opfab-announce@lists.lfenergy.org mailing list with a link to the release notes on the website.
 
 NOTE: Here is the link to the link:https://lists.lfenergy.org/g/main[administration website for the LFE mailing lists]
 in case there is an issue.
 
-== Preparing the next version
+=== Preparing the next version
 
 IMPORTANT: You should wait for all the tasks associated with creating the X.X.X.RELEASE
 version to finish and make sure that they've had the expected output before starting the
 preparation of the next version. This is because any committed/pushed changes preparing the
 new version will make rolling back or correcting any mistake on the release more complicated.
 
-=== In Jira
+==== In Jira
 
 In the "Releases" screen create a new release called `Next Release`.
 
-=== On the release-notes repository
+==== On the release-notes repository
 
 Remove the items listed in the release_notes.adoc file so it's ready for the next version.
 
-=== On the operatorfabric-core repository
+==== On the operatorfabric-core repository
 
 Now that the release branch has served its purpose, it should be deleted so as not to clutter the repository and to
 avoid confusion with the actual release commit tagged on `master`.
@@ -217,3 +222,65 @@ git branch -d X.X.X.release <1>
 <1> Delete the branch locally
 
 NOTE: The branch will automatically be deleted from GitHub after it is merged (new repository policy).
+
+== Releasing a Patch (Hotfixes) Version
+
+Let's say fixes are needed on version X.X.0.RELEASE, and will be released as X.X.X.RELEASE. If it's the first patch 
+version to be released for this minor version (i.e. version X.X.1.RELEASE), you will need to create the `X.X.hotfixes` 
+branch.
+To do so:
+
+[source,bash]
+----
+git checkout X.X.0.RELEASE <1>
+git checkout -b X.X.hotfixes <2>
+----
+<1> Checkout X.X.0.RELEASE tag
+<2> Create (and checkout) branch `X.X.hotfixes` from this commit
+
+If branch `X.X.hotfixes` already exists, you can just check it out.
+
+[source,bash]
+----
+git checkout X.X.hotfixes
+----
+
+You also need to create the corresponding release on JIRA so it can be defined as "Fix version" once the fixes are 
+completed.
+
+Then, follow the process described
+ifdef::single-page-doc[<<working_on_hotfix, here>>]
+ifndef::single-page-doc[<<{gradle-rootdir}/documentation/current/community/index.adoc#working_on_hotfix, here>>] to
+create feature branches, work on fixes and merge them back into `X.X.hotfixes`.
+
+Once all the big fixes that need to go into the version X.X.X.RELEASE have been merged into branch `X.X.hotfix`, you
+can release the patch version. To do so:
+
+. Write a release notes detailing the bug fixes in the release_notes.adoc file found under 
+*src/docs/asciidoc/docs* in the link:{opfab_core_repo}[operatorfabric-core repository].
+
+. Make sure all the issues that have been fixed have "X.X.X.RELEASE" as their "Fix Version" on JIRA.
+
+. Use the ./CICD/prepare_release_version.sh script to automatically perform all the necessary changes:
++
+----
+./CICD/prepare_release_version.sh -v X.X.X.RELEASE
+----
++
+. Commit the changes, tag them and push both to GitHub:
++
+----
+git add .
+git commit -m "[RELEASE] X.X.X.RELEASE ci_docker ci_documentation" <1>
+git tag X.X.X.RELEASE <2>
+git push <3>
+git push origin X.X.X.RELEASE <4>
+----
+<1> Commit the changes
+<2> Tag the release
+<3> Push the commit
+<4> Push the tag
+
+IMPORTANT: In the case of a patch on the last major/minor version tagged on master, this version will become the
+`latest` version. In this case, add `ci_latest` instead of `ci_docker ci_documentation` to the commit message
+to also update the `latest` docker images on DockerHub and the `current` documentation on the website.

--- a/src/docs/asciidoc/community/workflow.adoc
+++ b/src/docs/asciidoc/community/workflow.adoc
@@ -43,23 +43,42 @@ for details).
 
 === `master` branch
 
-_"When the source code in the develop branch reaches a stable point and is ready to be released, all of the changes
+_"When the source code in the develop branch reaches a stable point and is ready to be released, all the changes
 should be merged back into master somehow and then tagged with a release number."_
 
-This means that any commit on master is a production-ready release, be it a patch, a minor or a major version.
+This means that any commit on master is a production-ready release, be it a minor or a major version.
 
 Any commit on `master` triggers a Travis build generating and pushing documentation and docker images for the
-corresponding release version. If the `ci_latest` keyword is used in the commit message, the docker images are also
-tagged with `latest`.
+corresponding release version. As a version released from master is also by design the latest version, it will also
+update the `latest` docker images and the `current` documentation folder on the website.
+
+=== Hotfix branches
+
+While minor and major versions are tagged in increasing and linear order on the `master` branch, it might be necessary
+to create patches on previous releases.
+
+To do so, we create hotfix branches branching off version commits on the `master` branch.
+
+For example, the `1.8.hotfixes` branch branches off the commit tagged `1.8.0.RELEASE` on the `master` branch, and will
+contain tags for `1.8.1.RELEASE`, `1.8.2.RELEASE` and so on.
+
+*Naming convention:* Hotfix branches names should always start with the two digits representing the minor version
+they're patching, followed by ".hotfixes".
+
+.Examples of valid feature branch names:
+* 1.8.hotfixes
+* 2.0.hotfixes
 
 === Feature branches
 
-Feature branches are used to develop new features or fix bugs *for the next release*. The version number for this next
-release is usually not known during the developments as it is its final contents that will determine whether it's a
-major or minor version (or even a simple patch).
-By contrast, hotfix branches fix bugs in existing releases and give rise to new patches.
+Feature branches are used to develop new features or fix bugs described in JIRA issues.
+They have two distinct use cases with similar workflows.
 
-The lifecycle of feature branches is as follows:
+==== Feature branches for the next release
+
+These feature branches are used to develop new features or fix bugs *for the next release*.
+
+Their lifecycle is as follows:
 
 . A new feature branch is branched off `develop` before starting work on a feature or bug.
 . Once the developments are deemed ready by the developer(s) working on the feature, a pull request should be created
@@ -69,6 +88,18 @@ for this branch.
 link:https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests[Git Hub pull requests]
 features (comments, proposed changes, etc.) to make changes to the PR until it meets the project requirements.
 . Once it is ready to be included in the next version, the pull request is then merged back into `develop`.
+
+==== Feature branches for hotfixes
+
+These feature branches fix bugs in existing releases and give rise to new patches.
+
+Their lifecycle is similar to regular feature branches, except they should be branched off (and merged back to) the
+`X.X.hotfixes` branch corresponding to the release they are fixing.
+
+Example: A feature branch working on bug OC-1234 affecting version 1.8.0.RELEASE should be branched off
+branch `1.8.hotfixes`.
+
+==== Common conventions
 
 *Naming convention:* Feature branches names should always start with the reference of the JIRA issue they're addressing,
 optionally followed by additional information if several branches are associated with a given JIRA issue.
@@ -108,31 +139,13 @@ is to detect any issue with this generation before moving to master.
 Finally, the `X.X.X.release` can be merged into `master`, triggering
 The resulting merge commit on `master` should then be tagged with `X.X.X.RELEASE`.
 
-All commits on `master` should be merge commits from `release` branches, direct pushes on master will be disabled.
+All commits on `master` should be merged commits from `release` branches, direct pushes on master will be disabled in
+the future.
 
 *Naming convention:* The name of a release branch should match the repository version it is meant to merge into
 `master` but in lower case to avoid confusion with release tags on master.
 
 Example: The valid branch name for the branch bringing 1.3.0.RELEASE into `master` is 1.3.0.release
-
-=== Hotfix branches
-
-Work in progress: detail hotfix branches lifecycle and constraints.
-
-*Naming convention:* Hotfix branches names should always start with "HF_" and the reference of the JIRA issue they're
-addressing, optionally followed by additional information if several branches are associated with a given JIRA issue.
-
-.Examples of valid hotfix branch names:
-* HF_OC-123
-* HF_OC-123_Documentation
-* HF_OC-123_1
-
-.Examples of invalid hotfix branch names:
-* 123
-* OC-123
-* OC123
-* HF_SomeTextDescribingTheFix
-* SomeTextDescribingTheFix
 
 == Examples and commands
 
@@ -147,7 +160,7 @@ The repository version in `master` is `1.3.0.RELEASE`, and the `develop` branch 
 have been added to `develop` to change the repository version to `SNAPSHOT` and implement the changes necessary for
 Git flow.
 
-=== Starting work on a new feature
+=== Starting work on a new feature for the next version
 
 Let's say we want to start working on feature OC-Feature1 described in our JIRA.
 
@@ -207,7 +220,7 @@ Feel free to add a copyright header (on top of the existing ones) to files you c
 for examples.
 ====
 
-=== Submitting a pull request
+=== Submitting a pull request to develop
 
 Once you are satisfied with the state of your developments, you can submit it as a pull request.
 
@@ -231,8 +244,7 @@ Click the "New Pull Request" button for your branch.
 
 image::feature1_new_PR.png[]
 
-If you haven't done so before, *read through the PR checklist* pasted in the comment block, and then *replace it with your
-own comment* containing a short summary of the PR goal and any information that should go into the release notes.
+Add a comment containing a short summary of the PR goal and any information that should go into the release notes.
 It's especially important for PRs that have a direct impact on existing OperatorFabric deployments, to alert administrators
 of the impacts of deploying a new version and help them with the migration.
 Whenever possible/relevant, a link to the corresponding documentation is appreciated.
@@ -316,12 +328,16 @@ automatically.
 
 image::feature1_PR_autom_merge_OK.png[]
 
+[[working_on_hotfix]]
+=== Working on a fix for a previous version
+
+To work on a fix for an existing version, the steps are similar to those described above, substituting `X.X.hotfix` for
+`develop`.
+
 === Reviewing a Pull Request
 
-As of today, only developers from the `reviewers` group can merge pull requests into `develop`, but this shouldn't
+Only developers from the `reviewers` group can merge pull requests into `develop`, but this shouldn't
 stop anyone interested in the topic of a PR to comment and review it.
-
-
 
 ==== Reviewer check list 
 
@@ -371,7 +387,7 @@ To automate build and API testing, you can use `${OF_HOME}/src/test/api/karate/b
 Once the pull request meets all the criteria from the above check list, you can merge it into the `develop` branch.
 
 . Go to the pull request page on GitHub
-. Check that the base branch for the pull request is `develop`. This information is visible at the top of the page.
+. Check that the base branch for the pull request is `develop` (or `X.X.hotfixes`). This information is visible at the top of the page.
 +
 image::existing_PR_check_base.png[]
 
@@ -381,7 +397,7 @@ image::existing_PR_check_base.png[]
 
 . Go to the https://opfab.atlassian.net[JIRA] page for the corresponding issue and
 +
-* Set the `Fix version` field to `Next Version`
+* Set the `Fix version` field to `Next Version` (or the corresponding `X.X.X.RELEASE` in the case of a hotfix)
 * Set the `Status` field to `Done`
 
 . Go to the link:https://github.com/opfab/release-notes/[release-notes repository] and add the issue to the list with


### PR DESCRIPTION
It changes a few things on the CICD worflow (see doc), especially the use of the ci_latest hook, but I don't think it's necessary to highlight these changes on the release notes as it won't affect users?

In the release notes under "Tasks":
[OC-1554] Adapting CICD for hotfixes

[OC-1554]: https://opfab.atlassian.net/browse/OC-1554