### PR TITLE
[OC-1522] Is SpringFox dependency still used?

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -81,8 +81,6 @@ ext {
             swagger                 : "io.swagger:swagger-codegen-cli:${versions['swagger']}",
             swaggerGeneratorPlugin  : "gradle.plugin.org.hidetake:gradle-swagger-generator-plugin:${versions['swagger.generator.plugin']}",
             swaggerUI               : "org.webjars:swagger-ui:${versions['swaggerUI']}",
-            springfoxSwagger2       : "io.springfox:springfox-swagger2:${versions['springfox']}",
-            springfoxSwaggerUI      : "io.springfox:springfox-swagger-ui:${versions['springfox']}"
     ]
 
     plugin = [

--- a/client/client.gradle
+++ b/client/client.gradle
@@ -30,7 +30,6 @@ subprojects {
     dependencies {
         swaggerCodegen generator.swagger, project(':tools:swagger-spring-generators')
         swaggerUI generator.swaggerUI
-//        compile generator.springfoxSwagger2
         annotationProcessor misc.lombok
         implementation misc.lombok
         // compileOnly misc.lombok


### PR DESCRIPTION
Executing "gradle generateSwaggerUI" generates API documentation, with the usual format. Generated files are visible in build directory, for example, here : 
operatorfabric-core/services/core/businessconfig/build/docs/api/index.html

I propose to add nothing in release_notes ?

[OC-1522 ](https://opfab.atlassian.net/browse/OC-1522): Is SpringFox dependency still used ?