### PR TITLE
[OC-1585] Authorization mode 'NONE' fix with CardService and Perimeters.

### DIFF
--- a/ui/main/src/app/services/card.service.ts
+++ b/ui/main/src/app/services/card.service.ts
@@ -108,10 +108,14 @@ export class CardService {
 
     private getCardSubscription(): Observable<CardOperation> {
         // security header needed here as SSE request are not intercepted by our header interceptor
+        let securityHeader;
+        if (!this.authService.isAuthModeNone()) {
+            securityHeader = this.authService.getSecurityHeader();
+        }
         const eventSource = new EventSourcePolyfill(
             `${this.cardOperationsUrl}&notification=true`
             , {
-                headers: this.authService.getSecurityHeader(),
+                headers: securityHeader,
                 // if necessary , we cans set here  heartbeatTimeout: xxx (in ms)
             });
         return Observable.create(observer => {
@@ -229,8 +233,7 @@ export class CardService {
     }
 
     postCard(card: CardForPublishing): any {
-        const headers = this.authService.getSecurityHeader();
-        return this.httpClient.post<CardForPublishing>(`${this.cardsPubUrl}/userCard`, card, {headers});
+        return this.httpClient.post<CardForPublishing>(`${this.cardsPubUrl}/userCard`, card);
     }
 
     postUserAcknowledgement(cardUid: string): Observable<HttpResponse<void>> {


### PR DESCRIPTION
Added isAuthModeNone check to getSecurityHeader function. This fixes an issue while using authorization mode 'NONE' in combination with the checking of perimeters in the Cards Publication backend. The CardService has two functions that call the getSecurityHeader function. This causes the Authorization header to be overwritten, thereby causing the Cards Publication backend to not allow the user to publish a card. Bonus fix: added a space to a logger in the CardService to format the text the same as the other loggers.

Signed-off-by: Gerben Danen <gerben.danen@alliander.com>