### PR TITLE
[OC-666] Execute api none regression tests in travis build process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,13 +68,20 @@ jobs:
       script:
         - docker login --username ${DOCKER_CLOUD_USER} --password ${DOCKER_CLOUD_PWD}
         - docker-compose -f src/main/docker/test-environment/docker-compose.yml up -d
-        - ./gradlew --build-cache copyDependencies test jacocoTestReport
+        - ./gradlew --build-cache copyDependencies test jacocoTestReport dockerTag${OF_VERSION}
         # [OC-865] Dropping dependency messing with typescript version as a workaround until sonar bug is fixed
         # See https://github.com/SonarSource/SonarJS/issues/1928 and https://community.sonarsource.com/t/error-about-unsupported-ts-version-while-project-is-using-supported-version/15776
         - rm -r ui/main/node_modules/@compodoc/ngd-core
         - rm -r ui/main/node_modules/ts-simple-ast
         - sonar-scanner
         - docker-compose -f src/main/docker/test-environment/docker-compose.yml down
+        - cd config/docker
+        - ./docker-compose.sh
+        - cd ../../src/test/api/karate
+        - ./waitForOpfabToStart.sh
+        - ./launchAll.sh
+        - cd ../../../../config/docker
+        - docker-compose down
     - stage: doc
       script:
         - ./gradlew --build-cache generateSwaggerUI asciidoctor

--- a/src/test/api/karate/admin/getPrometheusMonitoring.feature
+++ b/src/test/api/karate/admin/getPrometheusMonitoring.feature
@@ -3,23 +3,19 @@ Feature: get prometheus monitoring
   Scenario: get monitoring for users
     Given url opfabUserUrl + 'actuator/prometheus'
     When method get
-    Then print response
-    And status 200
+    Then status 200
 
   Scenario: get monitoring for businessConfig
     Given url opfabBusinessConfigUrl + 'actuator/prometheus'
     When method get
-    Then print response
-    And status 200
+    Then status 200
 
   Scenario: get monitoring for cards-publication
     Given url opfabCardsPublicationUrl + 'actuator/prometheus'
     When method get
-    Then print response
-    And status 200
+    Then status 200
 
   Scenario: get monitoring for cards-consultation
     Given url opfabCardsConsultationUrl + 'actuator/prometheus'
     When method get
-    Then print response
-    And status 200
+    Then status 200

--- a/src/test/api/karate/buildAndLaunchAll.sh
+++ b/src/test/api/karate/buildAndLaunchAll.sh
@@ -31,9 +31,9 @@ echo "Start opfab"
 cd config/docker
 ./docker-compose.sh
 echo "Starting in progress..."
-sleep 90 
-echo "Start karate testing"
 cd ../../src/test/api/karate
+./waitForOpfabToStart.sh
+echo "Start karate testing"
 ./launchAll.sh
 google-chrome target/karate-reports/karate-summary.html &
 )

--- a/src/test/api/karate/businessconfig/deleteBundle.feature
+++ b/src/test/api/karate/businessconfig/deleteBundle.feature
@@ -17,23 +17,20 @@ Feature: deleteBundle
       And header Authorization = 'Bearer ' + authToken
       And multipart file file = {read:'resources/bundle_api_test.tar.gz', contentType: 'application/gzip'}
       When method post
-      Then print response
-      And status 201
+      Then status 201
 
   Scenario: Delete a Businessconfig without authentication
     # Delete bundle
     Given url opfabUrl + '/businessconfig/processes/api_test'
     When method DELETE
-    Then print response
-    And status 401
+    Then status 401
 
   Scenario: Delete a Businessconfig Version with a authentication having insufficient privileges
     # Delete bundle
     Given url opfabUrl + '/businessconfig/processes/api_test'
     And header Authorization = 'Bearer ' + authTokenAsTSO
     When method DELETE
-    Then print response
-    And status 403
+    Then status 403
 
   Scenario: Delete a Businessconfig
     # Delete bundle
@@ -41,7 +38,6 @@ Feature: deleteBundle
     And header Authorization = 'Bearer ' + authToken
     When method DELETE
     Then status 204
-    And print response
     And assert response.length == 0
 
   Scenario: check bundle doesn't exist anymore
@@ -57,6 +53,5 @@ Feature: deleteBundle
     And header Authorization = 'Bearer ' + authToken
     When method DELETE
     Then status 404
-    And print response
 
 

--- a/src/test/api/karate/businessconfig/deleteBundleVersion.feature
+++ b/src/test/api/karate/businessconfig/deleteBundleVersion.feature
@@ -17,8 +17,7 @@ Feature: deleteBundleVersion
       And header Authorization = 'Bearer ' + authToken
       And multipart file file = {read:'resources/bundle_api_test.tar.gz', contentType: 'application/gzip'}
       When method post
-      Then print response
-      And status 201
+      Then status 201
 
     Scenario: Push a bundle v2
           # Push bundle
@@ -26,23 +25,20 @@ Feature: deleteBundleVersion
       And header Authorization = 'Bearer ' + authToken
       And multipart file file = {read:'resources/bundle_api_test_v2.tar.gz', contentType: 'application/gzip'}
       When method post
-      Then print response
-      And status 201
+      Then status 201
 
   Scenario: Delete a Businessconfig Version without authentication
     # Delete bundle
     Given url opfabUrl + '/businessconfig/processes/api_test/versions/1'
     When method DELETE
-    Then print response
-    And status 401
+    Then status 401
 
   Scenario: Delete a Businessconfig Version with a authentication having insufficient privileges
     # Delete bundle
     Given url opfabUrl + '/businessconfig/processes/api_test/versions/1'
     And header Authorization = 'Bearer ' + authTokenAsTSO
     When method DELETE
-    Then print response
-    And status 403
+    Then status 403
 
   Scenario: check bundle default version
 
@@ -60,7 +56,6 @@ Feature: deleteBundleVersion
     And header Authorization = 'Bearer ' + authToken
     When method DELETE
     Then status 204
-    And print response
     And assert response.length == 0
 
   Scenario: check bundle default version is changed
@@ -72,7 +67,6 @@ Feature: deleteBundleVersion
     Then status 200
     And match response.id == 'api_test'
     And match response.version != '2'
-    And print 'new default version for api_test bundle is ', response.version
 
   Scenario: check bundle version 2 doesn't exist anymore
 
@@ -88,8 +82,7 @@ Feature: deleteBundleVersion
       And header Authorization = 'Bearer ' + authToken
       And multipart file file = {read:'resources/bundle_api_test_v2.tar.gz', contentType: 'application/gzip'}
       When method post
-      Then print response
-      And status 201
+      Then status 201
 
   Scenario: check bundle default version is not 1
 
@@ -100,7 +93,6 @@ Feature: deleteBundleVersion
     Then status 200
     And match response.id == 'api_test'
     And match response.version != '1'
-    And print 'New default version for api_test bundle is ', response.version
 
 Scenario: Delete a Businessconfig Version is not being the default version
     # Delete bundle
@@ -108,7 +100,6 @@ Scenario: Delete a Businessconfig Version is not being the default version
     And header Authorization = 'Bearer ' + authToken
     When method DELETE
     Then status 204
-    And print response
     And assert response.length == 0
 
   Scenario: check bundle default version is not 1
@@ -135,7 +126,6 @@ Scenario: Delete a Businessconfig Version is not being the default version
     And header Authorization = 'Bearer ' + authToken
     When method DELETE
     Then status 404
-    And print response
 
 Scenario: Delete a Businessconfig Version is being also the only one hold in the bundle
     # Delete bundle
@@ -143,7 +133,6 @@ Scenario: Delete a Businessconfig Version is being also the only one hold in the
     And header Authorization = 'Bearer ' + authToken
     When method DELETE
     Then status 204
-    And print response
     And assert response.length == 0
 
 Scenario: check bundle doesn't exist anymore

--- a/src/test/api/karate/businessconfig/getABusinessconfig.feature
+++ b/src/test/api/karate/businessconfig/getABusinessconfig.feature
@@ -2,7 +2,7 @@ Feature: Bundle
 
   Background:
     # Get admin token
-    * def signIn = call read('../common/getToken.feature') { username: 'admin'}
+    * def signIn = callonce read('../common/getToken.feature') { username: 'admin'}
     * def authToken = signIn.authToken
 
   Scenario: check bundle
@@ -39,5 +39,4 @@ Feature: Bundle
     # Check bundle
     Given url opfabUrl + '/businessconfig/processes/api_test'
     When method GET
-    Then print response
-    And status 401
+    Then status 401

--- a/src/test/api/karate/businessconfig/getBusinessconfig.feature
+++ b/src/test/api/karate/businessconfig/getBusinessconfig.feature
@@ -2,9 +2,9 @@ Feature: getBusinessconfig
 
   Background:
    #Getting token for admin and operator1 user calling getToken.feature
-    * def signIn = call read('../common/getToken.feature') { username: 'admin'}
+    * def signIn = callonce read('../common/getToken.feature') { username: 'admin'}
     * def authToken = signIn.authToken
-    * def signInAsTSO = call read('../common/getToken.feature') { username: 'operator1'}
+    * def signInAsTSO = callonce read('../common/getToken.feature') { username: 'operator1'}
     * def authTokenAsTSO = signInAsTSO.authToken
 
 
@@ -14,8 +14,7 @@ Feature: getBusinessconfig
       And header Authorization = 'Bearer ' + authToken
       And multipart file file = {read:'resources/bundle_api_test.tar.gz', contentType: 'application/gzip'}
       When method post
-      Then print response
-      And status 201
+      Then status 201
 
   Scenario: List existing Businessconfig
 
@@ -24,7 +23,6 @@ Feature: getBusinessconfig
     And header Authorization = 'Bearer ' + authToken
     When method GET
     Then status 200
-    And print response
     And assert response.length >= 1
 
   Scenario: List existing Businessconfig without authentication
@@ -33,7 +31,6 @@ Feature: getBusinessconfig
 
     Given url opfabUrl + '/businessconfig/processes/'
     When method GET
-    Then print response
-    And status 401
+    Then status 401
 
 

--- a/src/test/api/karate/businessconfig/getBusinessconfigTemplate.feature
+++ b/src/test/api/karate/businessconfig/getBusinessconfigTemplate.feature
@@ -1,10 +1,9 @@
 Feature: getBusinessconfigTemplate
 
   Background:
-   #Getting token for admin and operator1 user calling getToken.feature
-    * def signIn = call read('../common/getToken.feature') { username: 'admin'}
+    * def signIn = callonce read('../common/getToken.feature') { username: 'admin'}
     * def authToken = signIn.authToken
-    * def signInAsTSO = call read('../common/getToken.feature') { username: 'operator1'}
+    * def signInAsTSO = callonce read('../common/getToken.feature') { username: 'operator1'}
     * def authTokenAsTSO = signInAsTSO.authToken
     * def process = 'api_test'
     * def templateName = 'template'
@@ -19,7 +18,6 @@ Given url opfabUrl + '/businessconfig/processes/'+ process +'/templates/' + temp
 And header Authorization = 'Bearer ' + authToken
 When method GET
 Then status 200
-And print response
 And match response contains '{{card.data.message}}'
 
 
@@ -37,7 +35,6 @@ And match response contains '{{card.data.message}}'
     And header Authorization = 'Bearer ' + authToken
     When method GET
     Then status 404
-    And print response
 
 
   Scenario: Check wrong language
@@ -47,7 +44,6 @@ And match response contains '{{card.data.message}}'
     And header Authorization = 'Bearer ' + authToken
     When method GET
     Then status 404
-    And print response
 
   Scenario: Check wrong Template
 
@@ -55,4 +51,3 @@ And match response contains '{{card.data.message}}'
     And header Authorization = 'Bearer ' + authToken
     When method GET
     Then status 404
-    And print response

--- a/src/test/api/karate/businessconfig/getCss.feature
+++ b/src/test/api/karate/businessconfig/getCss.feature
@@ -2,11 +2,11 @@ Feature: get stylesheet
 
   Background:
     # Get admin token
-    * def signIn = call read('../common/getToken.feature') { username: 'admin'}
+    * def signIn = callonce read('../common/getToken.feature') { username: 'admin'}
     * def authToken = signIn.authToken
 
     # Get TSO-operator
-    * def signInAsTSO = call read('../common/getToken.feature') { username: 'operator1'}
+    * def signInAsTSO = callonce read('../common/getToken.feature') { username: 'operator1'}
     * def authTokenAsTSO = signInAsTSO.authToken
 
     * def process = 'api_test'
@@ -40,13 +40,11 @@ Scenario:Check stylesheet
     Given url opfabUrl + '/businessconfig/processes/' + process + '/css/' + cssName + '?version=9999999999'
     And header Authorization = 'Bearer ' + authToken
     When method GET
-    Then print response
-    And status 404
+    Then status 404
 
   Scenario: Check stylesheet for an nonexisting businessconfig
 
    Given url opfabUrl + '/businessconfig/processes/unknownBusinessconfig/css/style?version=2'
     And header Authorization = 'Bearer ' + authToken
     When method GET
-    Then print response
-    And status 404
+    Then status 404

--- a/src/test/api/karate/businessconfig/getI18n.feature
+++ b/src/test/api/karate/businessconfig/getI18n.feature
@@ -2,9 +2,9 @@ Feature: getI18n
 
   Background:
    #Getting token for admin and operator1 user calling getToken.feature
-    * def signIn = call read('../common/getToken.feature') { username: 'admin'}
+    * def signIn = callonce read('../common/getToken.feature') { username: 'admin'}
     * def authToken = signIn.authToken
-    * def signInAsTSO = call read('../common/getToken.feature') { username: 'operator1'}
+    * def signInAsTSO = callonce read('../common/getToken.feature') { username: 'operator1'}
     * def authTokenAsTSO = signInAsTSO.authToken
     * def process = 'api_test'
     * def templateName = 'template'
@@ -18,23 +18,19 @@ Feature: getI18n
     And header Authorization = 'Bearer ' + authToken
     When method GET
     Then status 200
-    And print response
 
   Scenario: Check i18n file without authentication
 
     Given url opfabUrl + '/businessconfig/processes/'+ process +'/i18n/' + '?locale=' + fileLanguage + '&version='+ businessconfigVersion
     When method GET
     Then status 401
-    And print response
 
   Scenario: Check unknown i18n file version
 
     Given url opfabUrl + '/businessconfig/processes/'+ process +'/i18n/' + '?locale=' + fileLanguage + '&version=9999999'
     And header Authorization = 'Bearer ' + authToken
     When method GET
-   Then print response
-   And status 404
-
+   Then status 404
 
 
   Scenario: Check unknown i18n file language
@@ -42,13 +38,11 @@ Feature: getI18n
     Given url opfabUrl + '/businessconfig/processes/'+ process +'/i18n/' + '?locale=DD' + '&version='+ businessconfigVersion
     And header Authorization = 'Bearer ' + authToken
     When method GET
-    Then print response
-    And status 404
+    Then status 404
 
   Scenario: Check i18n for an unknown businessconfig
 
     Given url opfabUrl + '/businessconfig/processes/unknownBusinessconfig/i18n/' + '?locale=fr' + '&version='+ businessconfigVersion
     And header Authorization = 'Bearer ' + authToken
     When method GET
-    Then print response
-    And status 404
+    Then  status 404

--- a/src/test/api/karate/businessconfig/getProcessGroups.feature
+++ b/src/test/api/karate/businessconfig/getProcessGroups.feature
@@ -2,9 +2,9 @@ Feature: getProcessGroups
 
   Background:
    #Getting token for admin and operator1 user calling getToken.feature
-    * def signIn = call read('../common/getToken.feature') { username: 'admin'}
+    * def signIn = callonce read('../common/getToken.feature') { username: 'admin'}
     * def authToken = signIn.authToken
-    * def signInAsTSO = call read('../common/getToken.feature') { username: 'operator1'}
+    * def signInAsTSO = callonce read('../common/getToken.feature') { username: 'operator1'}
     * def authTokenAsTSO = signInAsTSO.authToken
 
 
@@ -55,5 +55,4 @@ Feature: getProcessGroups
   Scenario: List existing process groups without authentication
     Given url opfabUrl + '/businessconfig/processgroups'
     When method GET
-    Then print response
-    And status 401
+    Then status 401

--- a/src/test/api/karate/businessconfig/getResponseBusinessconfig.feature
+++ b/src/test/api/karate/businessconfig/getResponseBusinessconfig.feature
@@ -1,12 +1,10 @@
 Feature: getResponseBusinessconfig
 
   Background:
-   #Getting token for admin and operator1 user calling getToken.feature
-    * def signIn = call read('../common/getToken.feature') { username: 'admin'}
+    * def signIn = callonce read('../common/getToken.feature') { username: 'admin'}
     * def authToken = signIn.authToken
-    * def signInAsTSO = call read('../common/getToken.feature') { username: 'operator1'}
+    * def signInAsTSO = callonce read('../common/getToken.feature') { username: 'operator1'}
     * def authTokenAsTSO = signInAsTSO.authToken
-
     * def process = 'processAction'
     * def state = 'response_full'
     * def version = 1
@@ -16,18 +14,15 @@ Feature: getResponseBusinessconfig
       Given url opfabUrl + '/businessconfig/processes/' + process + '/' + state + '/response?version=' + version
       And header Authorization = 'Bearer ' + authToken
       When method get
-      Then print response
-      And status 200
+      Then status 200
       And match response == {"btnText":{"parameters":null,"key":"action.text"},"btnColor":"RED","lock":true,"state":"responseState","externalRecipients":["externalRecipient1","externalRecipient2"]}
-
 
 
   Scenario: get businessconfig response without authentication
 
     Given url opfabUrl + '/businessconfig/processes/' + process + '/' + state + '/response?version=' + version
     When method get
-    Then print response
-    And status 401
+    Then status 401
 
 
   Scenario: get businessconfig response without authentication
@@ -35,5 +30,4 @@ Feature: getResponseBusinessconfig
     Given url opfabUrl + '/businessconfig/unknownBusinessconfig/' + process + '/' + state + '/response?version=' + version
     And header Authorization = 'Bearer ' + authToken
     When method get
-    Then print response
-    And status 404
+    Then status 404

--- a/src/test/api/karate/businessconfig/security.feature
+++ b/src/test/api/karate/businessconfig/security.feature
@@ -2,7 +2,7 @@ Feature: Security
 
   Background:
    #Getting token for admin and operator1 user calling getToken.feature
-    * def signInAsTSO = call read('../common/getToken.feature') { username: 'operator1'}
+    * def signInAsTSO = callonce read('../common/getToken.feature') { username: 'operator1'}
     * def authTokenAsTSO = signInAsTSO.authToken
     * def process = 'api_test'
     * def templateName = 'template'
@@ -24,4 +24,3 @@ Given url opfabUrl + '/businessconfig/processes/'+ process +'/templates/' + wron
 And header Authorization = 'Bearer ' + authTokenAsTSO
 When method GET
 Then status 401
-And print response

--- a/src/test/api/karate/businessconfig/uploadBundle.feature
+++ b/src/test/api/karate/businessconfig/uploadBundle.feature
@@ -2,11 +2,11 @@ Feature: Bundle
 
   Background:
     # Get admin token
-    * def signIn = call read('../common/getToken.feature') { username: 'admin'}
+    * def signIn = callonce read('../common/getToken.feature') { username: 'admin'}
     * def authToken = signIn.authToken
 
     # Get TSO-operator
-    * def signInAsTSO = call read('../common/getToken.feature') { username: 'operator1'}
+    * def signInAsTSO = callonce read('../common/getToken.feature') { username: 'operator1'}
     * def authTokenAsTSO = signInAsTSO.authToken
 
   Scenario: Post Bundle
@@ -16,16 +16,14 @@ Feature: Bundle
     And header Authorization = 'Bearer ' + authToken
     And multipart file file = {read:'resources/bundle_api_test.tar.gz', contentType: 'application/gzip'}
     When method post
-    Then print response
-    And status 201
+    Then status 201
 
   Scenario: Post Bundle without authentication
     # for the time being returns 403 instead of 401
     Given url opfabUrl + '/businessconfig/processes'
     And multipart file file = {read:'resources/bundle_api_test.tar.gz', contentType: 'application/gzip'}
     When method post
-    Then print response
-    And status 401
+    Then status 401
 
 
   Scenario: Post Bundle without admin role
@@ -34,8 +32,7 @@ Feature: Bundle
     And header Authorization = 'Bearer ' + authTokenAsTSO
     And multipart file file = {read:'resources/bundle_api_test.tar.gz', contentType: 'application/gzip'}
     When method post
-    Then print response
-    And status 403
+    Then status 403
 
 
   Scenario: Post Bundle for the same publisher but with another version
@@ -45,8 +42,7 @@ Feature: Bundle
     And header Authorization = 'Bearer ' + authToken
     And multipart file file = {read:'resources/bundle_api_test_v2.tar.gz', contentType: 'application/gzip'}
     When method post
-    Then print response
-    And status 201
+    Then status 201
   
   
   Scenario: Post Bundle for testing the action
@@ -56,8 +52,7 @@ Feature: Bundle
     And header Authorization = 'Bearer ' + authToken
     And multipart file file = {read:'resources/bundle_test_action.tar.gz', contentType: 'application/gzip'}
     When method post
-    Then print response
-    And status 201
+    Then status 201
 
     Scenario: Post Bundle for big card (apogee)
 
@@ -66,6 +61,5 @@ Feature: Bundle
     And header Authorization = 'Bearer ' + authToken
     And multipart file file = {read:'resources/bundle_api_test_apogee.tar.gz', contentType: 'application/gzip'}
     When method post
-    Then print response
-    And status 201
+    Then status 201
 

--- a/src/test/api/karate/businessconfig/uploadProcessGroupsFile.feature
+++ b/src/test/api/karate/businessconfig/uploadProcessGroupsFile.feature
@@ -2,11 +2,11 @@ Feature: uploadProcessGroups
 
   Background:
     # Get admin token
-    * def signIn = call read('../common/getToken.feature') { username: 'admin'}
+    * def signIn = callonce read('../common/getToken.feature') { username: 'admin'}
     * def authToken = signIn.authToken
 
     # Get TSO-operator
-    * def signInAsTSO = call read('../common/getToken.feature') { username: 'operator1'}
+    * def signInAsTSO = callonce read('../common/getToken.feature') { username: 'operator1'}
     * def authTokenAsTSO = signInAsTSO.authToken
 
 

--- a/src/test/api/karate/cards/cards.feature
+++ b/src/test/api/karate/cards/cards.feature
@@ -3,9 +3,9 @@ Feature: Cards
 
   Background:
 
-    * def signIn = call read('../common/getToken.feature') { username: 'operator1'}
+    * def signIn = callonce read('../common/getToken.feature') { username: 'operator1'}
     * def authToken = signIn.authToken
-    * def signInUserWithNoGroupNoEntity = call read('../common/getToken.feature') { username: 'userwithnogroupnoentity'}
+    * def signInUserWithNoGroupNoEntity = callonce read('../common/getToken.feature') { username: 'userwithnogroupnoentity'}
     * def authTokenUserWithNoGroupNoEntity = signInUserWithNoGroupNoEntity.authToken
 
   Scenario: Post card

--- a/src/test/api/karate/cards/cardsWithTimespans.feature
+++ b/src/test/api/karate/cards/cardsWithTimespans.feature
@@ -2,7 +2,7 @@ Feature: Cards with timespans
 
   Background:
 
-    * def signIn = call read('../common/getToken.feature') { username: 'operator1'}
+    * def signIn = callonce read('../common/getToken.feature') { username: 'operator1'}
     * def authToken = signIn.authToken
 
   Scenario: Post a card with timepans and recurrence

--- a/src/test/api/karate/cards/deleteUserCard.feature
+++ b/src/test/api/karate/cards/deleteUserCard.feature
@@ -2,11 +2,11 @@ Feature: deleteUserCards tests
 
   Background:
    #Getting token for admin and operator1 user calling getToken.feature
-    * def signIn = call read('../common/getToken.feature') { username: 'admin'}
+    * def signIn = callonce read('../common/getToken.feature') { username: 'admin'}
     * def authToken = signIn.authToken
-    * def signInAsTSO = call read('../common/getToken.feature') { username: 'operator1'}
+    * def signInAsTSO = callonce read('../common/getToken.feature') { username: 'operator1'}
     * def authTokenAsTSO = signInAsTSO.authToken
-    * def signInAsTSO2 = call read('../common/getToken.feature') { username: 'operator2'}
+    * def signInAsTSO2 = callonce read('../common/getToken.feature') { username: 'operator2'}
     * def authTokenAsTSO2 = signInAsTSO2.authToken
 
     * def groupKarate =

--- a/src/test/api/karate/cards/fetchArchivedCard.feature
+++ b/src/test/api/karate/cards/fetchArchivedCard.feature
@@ -2,9 +2,9 @@ Feature: fetchArchive
 
   Background:
 
-    * def signIn = call read('../common/getToken.feature') { username: 'operator1'}
+    * def signIn = callonce read('../common/getToken.feature') { username: 'operator1'}
     * def authToken = signIn.authToken
-    * def signInTSO2 = call read('../common/getToken.feature') { username: 'operator2'}
+    * def signInTSO2 = callonce read('../common/getToken.feature') { username: 'operator2'}
     * def authTokenTSO2 = signInTSO2.authToken
 
   Scenario: fetchArchive

--- a/src/test/api/karate/cards/fetchArchivedCardsWithParams.feature
+++ b/src/test/api/karate/cards/fetchArchivedCardsWithParams.feature
@@ -3,7 +3,7 @@ Feature: Archives
 
   Background:
 
-    * def signInAsTSO = call read('../common/getToken.feature') { username: 'operator1'}
+    * def signInAsTSO = callonce read('../common/getToken.feature') { username: 'operator1'}
     * def authTokenAsTSO = signInAsTSO.authToken
 
   Scenario: Post 10 cards, fill the archive
@@ -197,7 +197,6 @@ Feature: Archives
     And header Authorization = 'Bearer ' + authTokenAsTSO
     Then method get
     Then status 200
-    And print response
     And match response.numberOfElements == 9
 
     Scenario: change number of elements
@@ -206,7 +205,6 @@ Feature: Archives
     And header Authorization = 'Bearer ' + authTokenAsTSO
     When method get
     Then status 200
-    And print response
     And match response.size == 5
     And match response.numberOfElements == 5
 
@@ -216,28 +214,24 @@ Feature: Archives
     And header Authorization = 'Bearer ' + authTokenAsTSO
     When method get
     Then status 200
-    And print response
     And assert response.numberOfElements == 9
 
    Scenario: without authentication
     Given url opfabUrl + 'cards/archives/' +'?publisher=api_test'
     When method get
     Then status 401
-    And print response
 
    Scenario: filter on tag
       Given url opfabUrl + 'cards/archives/' +'?tags=API'
     And header Authorization = 'Bearer ' + authTokenAsTSO
     When method get
     Then status 200
-    And print response
 
    Scenario: filter on a given publish date
     Given url opfabUrl + 'cards/archives/' +'?publishDateFrom=1553186770481'
     And header Authorization = 'Bearer ' + authTokenAsTSO
     When method get
     Then status 200
-    And print response
     And assert response.numberOfElements == 9
 
    Scenario: filter by activeFrom
@@ -245,7 +239,6 @@ Feature: Archives
     And header Authorization = 'Bearer ' + authTokenAsTSO
     When method get
     Then status 200
-    And print response
      And assert response.numberOfElements == 9
 
    Scenario: filter by activeFrom after startDate of card with no endDate
@@ -253,7 +246,6 @@ Feature: Archives
     And header Authorization = 'Bearer ' + authTokenAsTSO
     When method get
     Then status 200
-    And print response
      And assert response.numberOfElements == 8
 
    Scenario: filter by activeTo
@@ -261,7 +253,6 @@ Feature: Archives
      And header Authorization = 'Bearer ' + authTokenAsTSO
      When method get
      Then status 200
-     And print response
      And assert response.numberOfElements == 9
 
   Scenario: filter process
@@ -269,7 +260,6 @@ Feature: Archives
     And header Authorization = 'Bearer ' + authTokenAsTSO
     When method get
     Then status 200
-    And print response
     And assert response.numberOfElements == 9
 
   Scenario: fetch all archived cards, child cards included
@@ -277,7 +267,6 @@ Feature: Archives
     And header Authorization = 'Bearer ' + authTokenAsTSO
     When method get
     Then status 200
-    And print response
     And assert response.numberOfElements == 10
 
   Scenario: fetch archived cards, child cards excluded
@@ -285,7 +274,6 @@ Feature: Archives
     And header Authorization = 'Bearer ' + authTokenAsTSO
     When method get
     Then status 200
-    And print response
     And assert response.numberOfElements == 9
 
   Scenario: fetch archived cards (child cards excluded by default)
@@ -293,5 +281,4 @@ Feature: Archives
     And header Authorization = 'Bearer ' + authTokenAsTSO
     When method get
     Then status 200
-    And print response
     And assert response.numberOfElements == 9

--- a/src/test/api/karate/cards/getArchive.feature
+++ b/src/test/api/karate/cards/getArchive.feature
@@ -3,7 +3,7 @@ Feature: Cards
 
 Background: 
 
-  * def signIn = call read('../common/getToken.feature') { username: 'operator1'}
+  * def signIn = callonce read('../common/getToken.feature') { username: 'operator1'}
   * def authToken = signIn.authToken
 
 Scenario: Check Archives / must insert 10 cards first with other scenarios

--- a/src/test/api/karate/cards/getCardSubscription.feature
+++ b/src/test/api/karate/cards/getCardSubscription.feature
@@ -2,9 +2,9 @@ Feature: get card Subscription
 
   Background:
    #Getting token for admin and operator1 user calling getToken.feature
-    * def signIn = call read('../common/getToken.feature') { username: 'admin'}
+    * def signIn = callonce read('../common/getToken.feature') { username: 'admin'}
     * def authToken = signIn.authToken
-    * def signInAsTSO = call read('../common/getToken.feature') { username: 'operator1'}
+    * def signInAsTSO = callonce read('../common/getToken.feature') { username: 'operator1'}
     * def authTokenAsTSO = signInAsTSO.authToken
 
 
@@ -41,14 +41,12 @@ Feature: get card Subscription
       Given url opfabUrl + 'cards/cardSubscription' +'?clientId=abc0123456789def'
       And header Authorization = 'Bearer ' + authToken
       When method get
-      Then print response
-      And status 200
+      Then status 200
 
     Scenario: Without authentication
       Given url opfabUrl + 'cards/cardSubscription'
       When method get
-      Then print response
-      And status 401
+      Then status 401
 
     Scenario: get card subscription with user operator1
 
@@ -72,16 +70,14 @@ Feature: get card Subscription
       Given url opfabUrl + 'cards/cardSubscription' +'?notification=false&clientId=ghi0123456789jkl&rangeStart='+ pastStartDate + '&rangeEnd=' + pastEndDate
       And header Authorization = 'Bearer ' + authTokenAsTSO
       When method get
-      Then print response
-      And status 200
+      Then status 200
       And match response == ''
 
     # Get subscription and check that card is returned
       Given url opfabUrl + 'cards/cardSubscription' +'?notification=false&clientId=ghi0123456789jkl&rangeStart='+ startDate + '&rangeEnd=' + endDate
       And header Authorization = 'Bearer ' + authTokenAsTSO
       When method get
-      Then print response
-      And status 200
+      Then status 200
       And match response contains '"card":{"uid":"' + cardUid + '"'
 
     # delete card
@@ -94,6 +90,5 @@ Feature: get card Subscription
       Given url opfabUrl + 'cards/cardSubscription' +'?notification=false&clientId=ghi0123456789jkl&rangeStart='+ startDate + '&rangeEnd=' + endDate
       And header Authorization = 'Bearer ' + authTokenAsTSO
       When method get
-      Then print response
-      And status 200
+      Then status 200
       And match response == ''

--- a/src/test/api/karate/cards/post1BigCards.feature
+++ b/src/test/api/karate/cards/post1BigCards.feature
@@ -3,7 +3,7 @@ Feature: Cards
 
 Background: 
 
-  * def signIn = call read('../common/getToken.feature') { username: 'operator1'}
+  * def signIn = callonce read('../common/getToken.feature') { username: 'operator1'}
   * def authToken = signIn.authToken
 
 Scenario: Post a big Card

--- a/src/test/api/karate/cards/post1CardThenUpdateThenDelete.feature
+++ b/src/test/api/karate/cards/post1CardThenUpdateThenDelete.feature
@@ -3,7 +3,7 @@ Feature: Cards
 
 Background: 
 
-  * def signIn = call read('../common/getToken.feature') { username: 'operator1'}
+  * def signIn = callonce read('../common/getToken.feature') { username: 'operator1'}
   * def authToken = signIn.authToken
 
 Scenario: Post Card

--- a/src/test/api/karate/cards/post2CardsGroupRouting.feature
+++ b/src/test/api/karate/cards/post2CardsGroupRouting.feature
@@ -3,9 +3,9 @@ Feature: Cards routing
 
 Background: 
 
-  * def signInTso1 = call read('../common/getToken.feature') { username: 'operator1'}
+  * def signInTso1 = callonce read('../common/getToken.feature') { username: 'operator1'}
   * def authTokenTso1 = signInTso1.authToken
-  * def signInTso2 = call read('../common/getToken.feature') { username: 'operator2'}
+  * def signInTso2 = callonce read('../common/getToken.feature') { username: 'operator2'}
   * def authTokenTso2 = signInTso2.authToken
 
 

--- a/src/test/api/karate/cards/post2CardsGroupRoutingDeprecated.feature
+++ b/src/test/api/karate/cards/post2CardsGroupRoutingDeprecated.feature
@@ -3,9 +3,9 @@ Feature: Cards routing
 
 Background: 
 
-  * def signInTso1 = call read('../common/getToken.feature') { username: 'operator1'}
+  * def signInTso1 = callonce read('../common/getToken.feature') { username: 'operator1'}
   * def authTokenTso1 = signInTso1.authToken
-  * def signInTso2 = call read('../common/getToken.feature') { username: 'operator2'}
+  * def signInTso2 = callonce read('../common/getToken.feature') { username: 'operator2'}
   * def authTokenTso2 = signInTso2.authToken
 
 

--- a/src/test/api/karate/cards/post2CardsInOneRequest.feature
+++ b/src/test/api/karate/cards/post2CardsInOneRequest.feature
@@ -3,7 +3,7 @@ Feature: Cards
 
 Background:
 
-    * def signIn = call read('../common/getToken.feature') { username: 'operator1'}
+    * def signIn = callonce read('../common/getToken.feature') { username: 'operator1'}
     * def authToken = signIn.authToken
 
 Scenario: Post two  Cards in one request

--- a/src/test/api/karate/cards/post3BigCardsAsync.feature
+++ b/src/test/api/karate/cards/post3BigCardsAsync.feature
@@ -3,7 +3,7 @@ Feature: Cards
 
 Background: 
 
-  * def signIn = call read('../common/getToken.feature') { username: 'operator1'}
+  * def signIn = callonce read('../common/getToken.feature') { username: 'operator1'}
   * def authToken = signIn.authToken
 
 Scenario: Post a big Card

--- a/src/test/api/karate/cards/postCardFor3Users.feature
+++ b/src/test/api/karate/cards/postCardFor3Users.feature
@@ -3,7 +3,7 @@ Feature: Cards
 
 Background: 
 
-  * def signIn = call read('../common/getToken.feature') { username: 'operator1'}
+  * def signIn = callonce read('../common/getToken.feature') { username: 'operator1'}
   * def authToken = signIn.authToken
 
 Scenario: Post Card

--- a/src/test/api/karate/cards/postCardFor3UsersDeprecated.feature
+++ b/src/test/api/karate/cards/postCardFor3UsersDeprecated.feature
@@ -3,7 +3,7 @@ Feature: Cards
 
 Background: 
 
-  * def signIn = call read('../common/getToken.feature') { username: 'operator1'}
+  * def signIn = callonce read('../common/getToken.feature') { username: 'operator1'}
   * def authToken = signIn.authToken
 
 Scenario: Post Card

--- a/src/test/api/karate/cards/postCardWithNoProcess.feature
+++ b/src/test/api/karate/cards/postCardWithNoProcess.feature
@@ -3,7 +3,7 @@ Feature: Cards
 
   Background:
 
-    * def signIn = call read('../common/getToken.feature') { username: 'operator1'}
+    * def signIn = callonce read('../common/getToken.feature') { username: 'operator1'}
     * def authToken = signIn.authToken
 
   Scenario: Post card

--- a/src/test/api/karate/cards/postCardWithNoState.feature
+++ b/src/test/api/karate/cards/postCardWithNoState.feature
@@ -3,7 +3,7 @@ Feature: Cards
 
   Background:
 
-    * def signIn = call read('../common/getToken.feature') { username: 'operator1'}
+    * def signIn = callonce read('../common/getToken.feature') { username: 'operator1'}
     * def authToken = signIn.authToken
 
   Scenario: Post card

--- a/src/test/api/karate/cards/postCardsEntitiesToRespond.feature
+++ b/src/test/api/karate/cards/postCardsEntitiesToRespond.feature
@@ -2,7 +2,7 @@ Feature: Post cards with entitiesAllowedToRespond and/or entitiesRequiredToRespo
 
   Background:
    #Getting token for admin and operator1 user calling getToken.feature
-    * def signInAsTSO = call read('../common/getToken.feature') { username: 'operator1'}
+    * def signInAsTSO = callonce read('../common/getToken.feature') { username: 'operator1'}
     * def authTokenAsTSO = signInAsTSO.authToken
 
 

--- a/src/test/api/karate/cards/updateCardSubscription.feature
+++ b/src/test/api/karate/cards/updateCardSubscription.feature
@@ -2,9 +2,9 @@ Feature: Update card Subscription
 
   Background:
    #Getting token for admin and operator1 user calling getToken.feature
-    * def signIn = call read('../common/getToken.feature') { username: 'admin'}
+    * def signIn = callonce read('../common/getToken.feature') { username: 'admin'}
     * def authToken = signIn.authToken
-    * def signInAsTSO = call read('../common/getToken.feature') { username: 'operator1'}
+    * def signInAsTSO = callonce read('../common/getToken.feature') { username: 'operator1'}
 
 
     Scenario: update card subscription

--- a/src/test/api/karate/cards/userCards.feature
+++ b/src/test/api/karate/cards/userCards.feature
@@ -2,9 +2,9 @@ Feature: UserCards tests
 
   Background:
    #Getting token for admin and operator1 user calling getToken.feature
-    * def signIn = call read('../common/getToken.feature') { username: 'admin'}
+    * def signIn = callonce read('../common/getToken.feature') { username: 'admin'}
     * def authToken = signIn.authToken
-    * def signInAsTSO = call read('../common/getToken.feature') { username: 'operator1'}
+    * def signInAsTSO = callonce read('../common/getToken.feature') { username: 'operator1'}
     * def authTokenAsTSO = signInAsTSO.authToken
 
     * def groupKarate =

--- a/src/test/api/karate/karate-config.js
+++ b/src/test/api/karate/karate-config.js
@@ -20,7 +20,7 @@ function() {
       opfabCardsPublicationUrl: opfab_server +":2102/"
     };
 
-    karate.log('url opfab :' + config.opfabUrl );
+    karate.logger.debug('url opfab :' + config.opfabUrl );
     // don't waste time waiting for a connection or if servers don't respond within 5 seconds
     karate.configure('connectTimeout', 5000);
     karate.configure('readTimeout', 5000);

--- a/src/test/api/karate/launchAll.sh
+++ b/src/test/api/karate/launchAll.sh
@@ -13,4 +13,4 @@ echo "Zip all bundles"
 cd businessconfig/resources
 ./packageBundles.sh
 cd ../..
-gradle karate --args="`cat businessConfigTests.txt` `cat cardTests.txt` `cat userTests.txt` `cat adminTests.txt`"
+../../../../gradlew karate --args="`cat adminTests.txt` `cat businessConfigTests.txt` `cat cardTests.txt` `cat userTests.txt`"

--- a/src/test/api/karate/launchAllAdmin.sh
+++ b/src/test/api/karate/launchAllAdmin.sh
@@ -9,4 +9,4 @@
 # This file is part of the OperatorFabric project.
 
 
-gradle karate --args="`cat adminTests.txt`"
+../../../../gradlew karate --args="`cat adminTests.txt`"

--- a/src/test/api/karate/launchAllBusinessconfig.sh
+++ b/src/test/api/karate/launchAllBusinessconfig.sh
@@ -18,4 +18,4 @@ cd businessconfig/resources
 cd ../..
 
 echo "Launch Karate test"
-gradle karate --args="`cat businessConfigTests.txt`" 
+../../../../gradlew karate --args="`cat businessConfigTests.txt`" 

--- a/src/test/api/karate/launchAllCards.sh
+++ b/src/test/api/karate/launchAllCards.sh
@@ -9,5 +9,5 @@
 # This file is part of the OperatorFabric project.
 
 
-gradle karate --args="`cat cardTests.txt`"
+../../../../gradlew karate --args="`cat cardTests.txt`"
 

--- a/src/test/api/karate/launchAllUsers.sh
+++ b/src/test/api/karate/launchAllUsers.sh
@@ -8,4 +8,4 @@
 # SPDX-License-Identifier: MPL-2.0
 # This file is part of the OperatorFabric project.
 
-gradle karate --args="`cat userTests.txt`"
+../../../../gradlew karate --args="`cat userTests.txt`"

--- a/src/test/api/karate/launchAllUsers_JWTMode.sh
+++ b/src/test/api/karate/launchAllUsers_JWTMode.sh
@@ -9,6 +9,6 @@
 # This file is part of the OperatorFabric project.
 
 
-gradle karate --args="`cat userJwtModeTests.txt`"
+../../../../gradlew karate --args="`cat userJwtModeTests.txt`"
 
 

--- a/src/test/api/karate/logback-test.xml
+++ b/src/test/api/karate/logback-test.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+ 
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+  
+    <appender name="FILE" class="ch.qos.logback.core.FileAppender">
+        <file>target/karate.log</file>
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>    
+   
+    <logger name="com.intuit.karate" level="INFO"/>
+   
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+        <appender-ref ref="FILE" />
+    </root>
+  
+</configuration>

--- a/src/test/api/karate/users/createUsers.feature
+++ b/src/test/api/karate/users/createUsers.feature
@@ -2,9 +2,9 @@ Feature: CreateUsers
 
   Background:
    #Getting token for admin and operator1 user calling getToken.feature
-    * def signIn = call read('../common/getToken.feature') { username: 'admin'}
+    * def signIn = callonce read('../common/getToken.feature') { username: 'admin'}
     * def authToken = signIn.authToken
-    * def signInAsTSO = call read('../common/getToken.feature') { username: 'operator1'}
+    * def signInAsTSO = callonce read('../common/getToken.feature') { username: 'operator1'}
     * def authTokenAsTSO = signInAsTSO.authToken
 
         # defining users to create
@@ -66,7 +66,6 @@ Feature: CreateUsers
     And request userKarate
     When method post
     Then status 401
-    And print response
 
   Scenario: create a user with a normal account
    #authenticated as TSO, expected response 403

--- a/src/test/api/karate/users/deleteUser.feature
+++ b/src/test/api/karate/users/deleteUser.feature
@@ -2,9 +2,9 @@ Feature: deleteUser
 
   Background:
    #Getting token for admin and operator1 user calling getToken.feature
-    * def signIn = call read('../common/getToken.feature') { username: 'admin'}
+    * def signIn = callonce read('../common/getToken.feature') { username: 'admin'}
     * def authToken = signIn.authToken
-    * def signInAsTSO = call read('../common/getToken.feature') { username: 'operator1'}
+    * def signInAsTSO = callonce read('../common/getToken.feature') { username: 'operator1'}
     * def authTokenAsTSO = signInAsTSO.authToken
 
 

--- a/src/test/api/karate/users/entities/addUsersToEntity.feature
+++ b/src/test/api/karate/users/entities/addUsersToEntity.feature
@@ -2,9 +2,9 @@ Feature: Add users to an entity
 
   Background:
    #Getting token for admin and operator1 user calling getToken.feature
-    * def signIn = call read('../../common/getToken.feature') { username: 'admin'}
+    * def signIn = callonce read('../../common/getToken.feature') { username: 'admin'}
     * def authToken = signIn.authToken
-    * def signInAsTSO = call read('../../common/getToken.feature') { username: 'operator1'}
+    * def signInAsTSO = callonce read('../../common/getToken.feature') { username: 'operator1'}
     * def authTokenAsTSO = signInAsTSO.authToken
     * def myentity = 'entityKarate1'
 

--- a/src/test/api/karate/users/entities/checkEntityGroupManagement.feature
+++ b/src/test/api/karate/users/entities/checkEntityGroupManagement.feature
@@ -2,7 +2,7 @@ Feature: CheckEntityGroupManagement
 
     Background:
     #Getting token for admin
-    * def signIn = call read('../../common/getToken.feature') {username: 'admin' }
+    * def signIn = callonce read('../../common/getToken.feature') {username: 'admin' }
     * def adminAuthToken = signIn.authToken
     # entity definition
     * def entity0_With1UnknownParent =

--- a/src/test/api/karate/users/entities/createEntities.feature
+++ b/src/test/api/karate/users/entities/createEntities.feature
@@ -2,9 +2,9 @@ Feature: CreateEntities
 
   Background:
    #Getting token for admin and operator1 user calling getToken.feature
-    * def signIn = call read('../../common/getToken.feature') { username: 'admin'}
+    * def signIn = callonce read('../../common/getToken.feature') { username: 'admin'}
     * def authToken = signIn.authToken
-    * def signInAsTSO = call read('../../common/getToken.feature') { username: 'operator1'}
+    * def signInAsTSO = callonce read('../../common/getToken.feature') { username: 'operator1'}
     * def authTokenAsTSO = signInAsTSO.authToken
       #defining entities
     * def entity =

--- a/src/test/api/karate/users/entities/deleteAllUsersFromAnEntity.feature
+++ b/src/test/api/karate/users/entities/deleteAllUsersFromAnEntity.feature
@@ -2,9 +2,9 @@ Feature: Delete all users from an entity
 
   Background:
    #Getting token for admin and operator1 user calling getToken.feature
-    * def signIn = call read('../../common/getToken.feature') { username: 'admin'}
+    * def signIn = callonce read('../../common/getToken.feature') { username: 'admin'}
     * def authToken = signIn.authToken
-    * def signInAsTSO = call read('../../common/getToken.feature') { username: 'operator1'}
+    * def signInAsTSO = callonce read('../../common/getToken.feature') { username: 'operator1'}
     * def authTokenAsTSO = signInAsTSO.authToken
     * def entityDeletedFrom = 'entityKarate1'
 

--- a/src/test/api/karate/users/entities/deleteEntity.feature
+++ b/src/test/api/karate/users/entities/deleteEntity.feature
@@ -2,9 +2,9 @@ Feature: deleteEntity
 
   Background:
    #Getting token for admin and operator1 user calling getToken.feature
-    * def signIn = call read('../../common/getToken.feature') { username: 'admin'}
+    * def signIn = callonce read('../../common/getToken.feature') { username: 'admin'}
     * def authToken = signIn.authToken
-    * def signInAsTSO = call read('../../common/getToken.feature') { username: 'operator1'}
+    * def signInAsTSO = callonce read('../../common/getToken.feature') { username: 'operator1'}
     * def authTokenAsTSO = signInAsTSO.authToken
 
 

--- a/src/test/api/karate/users/entities/deleteUserFromEntity.feature
+++ b/src/test/api/karate/users/entities/deleteUserFromEntity.feature
@@ -2,9 +2,9 @@ Feature: deleteUserFromEntity
 
   Background:
    #Getting token for admin and operator1 user calling getToken.feature
-    * def signIn = call read('../../common/getToken.feature') { username: 'admin'}
+    * def signIn = callonce read('../../common/getToken.feature') { username: 'admin'}
     * def authToken = signIn.authToken
-    * def signInAsTSO = call read('../../common/getToken.feature') { username: 'operator1'}
+    * def signInAsTSO = callonce read('../../common/getToken.feature') { username: 'operator1'}
     * def authTokenAsTSO = signInAsTSO.authToken
 
 

--- a/src/test/api/karate/users/entities/getEntities.feature
+++ b/src/test/api/karate/users/entities/getEntities.feature
@@ -2,9 +2,9 @@ Feature: Get Entities
 
   Background:
    #Getting token for admin and operator1 user calling getToken.feature
-    * def signIn = call read('../../common/getToken.feature') { username: 'admin'}
+    * def signIn = callonce read('../../common/getToken.feature') { username: 'admin'}
     * def authToken = signIn.authToken
-    * def signInAsTSO = call read('../../common/getToken.feature') { username: 'operator1'}
+    * def signInAsTSO = callonce read('../../common/getToken.feature') { username: 'operator1'}
     * def authTokenAsTSO = signInAsTSO.authToken
 
 
@@ -15,7 +15,6 @@ Feature: Get Entities
     And header Authorization = 'Bearer ' + authToken
     When method get
     Then status 200
-    And print response
     And def entityId = response[0].id
 
 

--- a/src/test/api/karate/users/entities/getEntityDetails.feature
+++ b/src/test/api/karate/users/entities/getEntityDetails.feature
@@ -2,9 +2,9 @@ Feature: Get Entity details
 
   Background:
    #Getting token for admin and operator1 user calling getToken.feature
-    * def signIn = call read('../../common/getToken.feature') { username: 'admin'}
+    * def signIn = callonce read('../../common/getToken.feature') { username: 'admin'}
     * def authToken = signIn.authToken
-    * def signInAsTSO = call read('../../common/getToken.feature') { username: 'operator1'}
+    * def signInAsTSO = callonce read('../../common/getToken.feature') { username: 'operator1'}
     * def authTokenAsTSO = signInAsTSO.authToken
 
        #defining entities

--- a/src/test/api/karate/users/entities/transitive-entities-in-currentUser.feature
+++ b/src/test/api/karate/users/entities/transitive-entities-in-currentUser.feature
@@ -1,15 +1,15 @@
 Feature: Check addition of transitive entities to user
 
     Background:
-        * def adminSignIn = call read('../../common/getToken.feature') { username: 'admin'}
+        * def adminSignIn = callonce read('../../common/getToken.feature') { username: 'admin'}
         * def adminToken = adminSignIn.authToken
-        * def rootSignIn = call read('../../common/getToken.feature') { username: 'user_test_api_2'}
+        * def rootSignIn = callonce read('../../common/getToken.feature') { username: 'user_test_api_2'}
         * def rootToken = rootSignIn.authToken
-		* def singleSignIn = call read('../../common/getToken.feature') { username: 'user_test_api_1'}
+		* def singleSignIn = callonce read('../../common/getToken.feature') { username: 'user_test_api_1'}
 		* def singleToken =  singleSignIn.authToken
-		* def childAndGrandChildSignIn = call read('../../common/getToken.feature') { username: 'user_test_api_3'}
+		* def childAndGrandChildSignIn = callonce read('../../common/getToken.feature') { username: 'user_test_api_3'}
 		* def childAndGrandChildToken = childAndGrandChildSignIn.authToken
-		* def withoutChildSignIn = call read('../../common/getToken.feature') { username: 'user_test_api_4'}
+		* def withoutChildSignIn = callonce read('../../common/getToken.feature') { username: 'user_test_api_4'}
 		* def withoutChildToken = withoutChildSignIn.authToken
 
         # entities

--- a/src/test/api/karate/users/entities/updateExistingEntity.feature
+++ b/src/test/api/karate/users/entities/updateExistingEntity.feature
@@ -2,9 +2,9 @@ Feature: Update existing entity
 
   Background:
    #Getting token for admin and operator1 user calling getToken.feature
-    * def signIn = call read('../../common/getToken.feature') { username: 'admin'}
+    * def signIn = callonce read('../../common/getToken.feature') { username: 'admin'}
     * def authToken = signIn.authToken
-    * def signInAsTSO = call read('../../common/getToken.feature') { username: 'operator1'}
+    * def signInAsTSO = callonce read('../../common/getToken.feature') { username: 'operator1'}
     * def authTokenAsTSO = signInAsTSO.authToken
 
            #defining entities

--- a/src/test/api/karate/users/entities/updateListOfEntityUsers.feature
+++ b/src/test/api/karate/users/entities/updateListOfEntityUsers.feature
@@ -2,9 +2,9 @@ Feature: Update list of entity users
 
   Background:
    #Getting token for admin and operator1 user calling getToken.feature
-    * def signIn = call read('../../common/getToken.feature') { username: 'admin'}
+    * def signIn = callonce read('../../common/getToken.feature') { username: 'admin'}
     * def authToken = signIn.authToken
-    * def signInAsTSO = call read('../../common/getToken.feature') { username: 'operator1'}
+    * def signInAsTSO = callonce read('../../common/getToken.feature') { username: 'operator1'}
     * def authTokenAsTSO = signInAsTSO.authToken
 
        #defining entities

--- a/src/test/api/karate/users/fetchExistingUser.feature
+++ b/src/test/api/karate/users/fetchExistingUser.feature
@@ -2,9 +2,9 @@ Feature: Fetch users
 
   Background:
    #Getting token for admin and operator1 user calling getToken.feature
-    * def signIn = call read('../common/getToken.feature') { username: 'admin'}
+    * def signIn = callonce read('../common/getToken.feature') { username: 'admin'}
     * def authToken = signIn.authToken
-    * def signInAsTSO = call read('../common/getToken.feature') { username: 'operator1'}
+    * def signInAsTSO = callonce read('../common/getToken.feature') { username: 'operator1'}
     * def authTokenAsTSO = signInAsTSO.authToken
     * def username = 'admin'
 

--- a/src/test/api/karate/users/fetchUserSettings.feature
+++ b/src/test/api/karate/users/fetchUserSettings.feature
@@ -2,9 +2,9 @@ Feature: fetch user settings
 
   Background:
    #Getting token for admin and operator1 user calling getToken.feature
-    * def signIn = call read('../common/getToken.feature') { username: 'admin'}
+    * def signIn = callonce read('../common/getToken.feature') { username: 'admin'}
     * def authToken = signIn.authToken
-    * def signInAsTSO = call read('../common/getToken.feature') { username: 'operator1'}
+    * def signInAsTSO = callonce read('../common/getToken.feature') { username: 'operator1'}
     * def authTokenAsTSO = signInAsTSO.authToken
     * def userToFetch = 'loginKarate1'
 

--- a/src/test/api/karate/users/getUsers.feature
+++ b/src/test/api/karate/users/getUsers.feature
@@ -2,9 +2,9 @@ Feature: Add users to a group
 
   Background:
    #Getting token for admin and operator1 user calling getToken.feature
-    * def signIn = call read('../common/getToken.feature') { username: 'admin'}
+    * def signIn = callonce read('../common/getToken.feature') { username: 'admin'}
     * def authToken = signIn.authToken
-    * def signInAsTSO = call read('../common/getToken.feature') { username: 'operator1'}
+    * def signInAsTSO = callonce read('../common/getToken.feature') { username: 'operator1'}
     * def authTokenAsTSO = signInAsTSO.authToken
 
 

--- a/src/test/api/karate/users/groups/addUsersToGroup.feature
+++ b/src/test/api/karate/users/groups/addUsersToGroup.feature
@@ -2,9 +2,9 @@ Feature: Add users to a group
 
   Background:
    #Getting token for admin and operator1 user calling getToken.feature
-    * def signIn = call read('../../common/getToken.feature') { username: 'admin'}
+    * def signIn = callonce read('../../common/getToken.feature') { username: 'admin'}
     * def authToken = signIn.authToken
-    * def signInAsTSO = call read('../../common/getToken.feature') { username: 'operator1'}
+    * def signInAsTSO = callonce read('../../common/getToken.feature') { username: 'operator1'}
     * def authTokenAsTSO = signInAsTSO.authToken
     * def mygroup = 'groupKarate1'
 

--- a/src/test/api/karate/users/groups/createGroups.feature
+++ b/src/test/api/karate/users/groups/createGroups.feature
@@ -2,9 +2,9 @@ Feature: CreateGroups
 
   Background:
    #Getting token for admin and operator1 user calling getToken.feature
-    * def signIn = call read('../../common/getToken.feature') { username: 'admin'}
+    * def signIn = callonce read('../../common/getToken.feature') { username: 'admin'}
     * def authToken = signIn.authToken
-    * def signInAsTSO = call read('../../common/getToken.feature') { username: 'operator1'}
+    * def signInAsTSO = callonce read('../../common/getToken.feature') { username: 'operator1'}
     * def authTokenAsTSO = signInAsTSO.authToken
       #defining groups
     * def group =

--- a/src/test/api/karate/users/groups/deleteAllUsersFromAGroup.feature
+++ b/src/test/api/karate/users/groups/deleteAllUsersFromAGroup.feature
@@ -2,9 +2,9 @@ Feature: Delete all users from a group
 
   Background:
    #Getting token for admin and operator1 user calling getToken.feature
-    * def signIn = call read('../../common/getToken.feature') { username: 'admin'}
+    * def signIn = callonce read('../../common/getToken.feature') { username: 'admin'}
     * def authToken = signIn.authToken
-    * def signInAsTSO = call read('../../common/getToken.feature') { username: 'operator1'}
+    * def signInAsTSO = callonce read('../../common/getToken.feature') { username: 'operator1'}
     * def authTokenAsTSO = signInAsTSO.authToken
     * def groupDeletedFrom = 'groupKarate1'
 

--- a/src/test/api/karate/users/groups/deleteGroup.feature
+++ b/src/test/api/karate/users/groups/deleteGroup.feature
@@ -2,9 +2,9 @@ Feature: deleteGroup
 
   Background:
    #Getting token for admin and operator1 user calling getToken.feature
-    * def signIn = call read('../../common/getToken.feature') { username: 'admin'}
+    * def signIn = callonce read('../../common/getToken.feature') { username: 'admin'}
     * def authToken = signIn.authToken
-    * def signInAsTSO = call read('../../common/getToken.feature') { username: 'operator1'}
+    * def signInAsTSO = callonce read('../../common/getToken.feature') { username: 'operator1'}
     * def authTokenAsTSO = signInAsTSO.authToken
 
 

--- a/src/test/api/karate/users/groups/deleteUserFromGroup.feature
+++ b/src/test/api/karate/users/groups/deleteUserFromGroup.feature
@@ -2,9 +2,9 @@ Feature: deleteUserFromGroup
 
   Background:
    #Getting token for admin and operator1 user calling getToken.feature
-    * def signIn = call read('../../common/getToken.feature') { username: 'admin'}
+    * def signIn = callonce read('../../common/getToken.feature') { username: 'admin'}
     * def authToken = signIn.authToken
-    * def signInAsTSO = call read('../../common/getToken.feature') { username: 'operator1'}
+    * def signInAsTSO = callonce read('../../common/getToken.feature') { username: 'operator1'}
     * def authTokenAsTSO = signInAsTSO.authToken
 
 

--- a/src/test/api/karate/users/groups/getGroupDetails.feature
+++ b/src/test/api/karate/users/groups/getGroupDetails.feature
@@ -2,9 +2,9 @@ Feature: Get Group details
 
   Background:
    #Getting token for admin and operator1 user calling getToken.feature
-    * def signIn = call read('../../common/getToken.feature') { username: 'admin'}
+    * def signIn = callonce read('../../common/getToken.feature') { username: 'admin'}
     * def authToken = signIn.authToken
-    * def signInAsTSO = call read('../../common/getToken.feature') { username: 'operator1'}
+    * def signInAsTSO = callonce read('../../common/getToken.feature') { username: 'operator1'}
     * def authTokenAsTSO = signInAsTSO.authToken
 
        #defining groups

--- a/src/test/api/karate/users/groups/getGroups.feature
+++ b/src/test/api/karate/users/groups/getGroups.feature
@@ -2,9 +2,9 @@ Feature: Get Groups
 
   Background:
    #Getting token for admin and operator1 user calling getToken.feature
-    * def signIn = call read('../../common/getToken.feature') { username: 'admin'}
+    * def signIn = callonce read('../../common/getToken.feature') { username: 'admin'}
     * def authToken = signIn.authToken
-    * def signInAsTSO = call read('../../common/getToken.feature') { username: 'operator1'}
+    * def signInAsTSO = callonce read('../../common/getToken.feature') { username: 'operator1'}
     * def authTokenAsTSO = signInAsTSO.authToken
 
 
@@ -15,7 +15,6 @@ Feature: Get Groups
     And header Authorization = 'Bearer ' + authToken
     When method get
     Then status 200
-    And print response
     And def groupId = response[0].id
     And def groupName = response[0].name
     And def groupDescription = response[0].description

--- a/src/test/api/karate/users/groups/updateExistingGroup.feature
+++ b/src/test/api/karate/users/groups/updateExistingGroup.feature
@@ -2,9 +2,9 @@ Feature: Update existing group
 
   Background:
    #Getting token for admin and operator1 user calling getToken.feature
-    * def signIn = call read('../../common/getToken.feature') { username: 'admin'}
+    * def signIn = callonce read('../../common/getToken.feature') { username: 'admin'}
     * def authToken = signIn.authToken
-    * def signInAsTSO = call read('../../common/getToken.feature') { username: 'operator1'}
+    * def signInAsTSO = callonce read('../../common/getToken.feature') { username: 'operator1'}
     * def authTokenAsTSO = signInAsTSO.authToken
 
            #defining groups

--- a/src/test/api/karate/users/groups/updateListOfGroupUsers.feature
+++ b/src/test/api/karate/users/groups/updateListOfGroupUsers.feature
@@ -2,9 +2,9 @@ Feature: Update list of group users
 
   Background:
    #Getting token for admin and operator1 user calling getToken.feature
-    * def signIn = call read('../../common/getToken.feature') { username: 'admin'}
+    * def signIn = callonce read('../../common/getToken.feature') { username: 'admin'}
     * def authToken = signIn.authToken
-    * def signInAsTSO = call read('../../common/getToken.feature') { username: 'operator1'}
+    * def signInAsTSO = callonce read('../../common/getToken.feature') { username: 'operator1'}
     * def authTokenAsTSO = signInAsTSO.authToken
 
        #defining groups

--- a/src/test/api/karate/users/patchUserSettings.feature
+++ b/src/test/api/karate/users/patchUserSettings.feature
@@ -2,11 +2,11 @@ Feature: patch user settings
 
   Background:
    #Getting token for admin and operator1 user calling getToken.feature
-    * def signIn = call read('../common/getToken.feature') { username: 'admin'}
+    * def signIn = callonce read('../common/getToken.feature') { username: 'admin'}
     * def authToken = signIn.authToken
-    * def signInAsTSO = call read('../common/getToken.feature') { username: 'operator1'}
+    * def signInAsTSO = callonce read('../common/getToken.feature') { username: 'operator1'}
     * def authTokenAsTSO = signInAsTSO.authToken
-   # * def signInAsUser = call read('getToken.feature') { username: 'user'}
+   # * def signInAsUser = callonce read('getToken.feature') { username: 'user'}
    # * def authTokenAsUser = signInAsUser.authToken
 
 
@@ -71,8 +71,7 @@ Feature: patch user settings
     And header Authorization = 'Bearer ' + authToken
     And request userSettings
     When method patch
-    Then print response
-    And status 200
+    Then status 200
     And match response.login == userSettings.login
     And match response.description == userSettings.description
     And match response.timeZone == userSettings.timeZone
@@ -87,8 +86,7 @@ Feature: patch user settings
     And header Authorization = 'Bearer ' + authTokenAsTSO
     And request userSettingsDispatcher
     When method patch
-    Then print response
-    And status 200
+    Then status 200
     And match response.login == userSettingsDispatcher.login
     And match response.description == userSettingsDispatcher.description
     And match response.timeZone == userSettingsDispatcher.timeZone

--- a/src/test/api/karate/users/perimeters/addGroupsToPerimeter.feature
+++ b/src/test/api/karate/users/perimeters/addGroupsToPerimeter.feature
@@ -2,9 +2,9 @@ Feature: Add groups to a perimeter (endpoint tested : PATCH /perimeters/{id}/gro
 
   Background:
    #Getting token for admin and operator1 user calling getToken.feature
-    * def signIn = call read('../../common/getToken.feature') { username: 'admin'}
+    * def signIn = callonce read('../../common/getToken.feature') { username: 'admin'}
     * def authToken = signIn.authToken
-    * def signInAsTSO = call read('../../common/getToken.feature') { username: 'operator1'}
+    * def signInAsTSO = callonce read('../../common/getToken.feature') { username: 'operator1'}
     * def authTokenAsTSO = signInAsTSO.authToken
     * def myperimeter = 'perimeterKarate1_1'
 

--- a/src/test/api/karate/users/perimeters/addPerimetersForAGroup.feature
+++ b/src/test/api/karate/users/perimeters/addPerimetersForAGroup.feature
@@ -2,9 +2,9 @@ Feature: Add perimeters for a group (endpoint tested : PATCH /groups/{id}/perime
 
   Background:
    #Getting token for admin and operator1 user calling getToken.feature
-    * def signIn = call read('../../common/getToken.feature') { username: 'admin'}
+    * def signIn = callonce read('../../common/getToken.feature') { username: 'admin'}
     * def authToken = signIn.authToken
-    * def signInAsTSO = call read('../../common/getToken.feature') { username: 'operator1'}
+    * def signInAsTSO = callonce read('../../common/getToken.feature') { username: 'operator1'}
     * def authTokenAsTSO = signInAsTSO.authToken
 
     * def group14 =

--- a/src/test/api/karate/users/perimeters/createPerimeters.feature
+++ b/src/test/api/karate/users/perimeters/createPerimeters.feature
@@ -2,9 +2,9 @@ Feature: CreatePerimeters (endpoint tested : POST /perimeters)
 
   Background:
    #Getting token for admin and operator1 user calling getToken.feature
-    * def signIn = call read('../../common/getToken.feature') { username: 'admin'}
+    * def signIn = callonce read('../../common/getToken.feature') { username: 'admin'}
     * def authToken = signIn.authToken
-    * def signInAsTSO = call read('../../common/getToken.feature') { username: 'operator1'}
+    * def signInAsTSO = callonce read('../../common/getToken.feature') { username: 'operator1'}
     * def authTokenAsTSO = signInAsTSO.authToken
       #defining perimeters
     * def perimeter =

--- a/src/test/api/karate/users/perimeters/deleteAllGroupsFromAPerimeter.feature
+++ b/src/test/api/karate/users/perimeters/deleteAllGroupsFromAPerimeter.feature
@@ -2,9 +2,9 @@ Feature: Delete all groups from a perimeter (endpoint tested : DELETE /perimeter
 
   Background:
    #Getting token for admin and operator1 user calling getToken.feature
-    * def signIn = call read('../../common/getToken.feature') { username: 'admin'}
+    * def signIn = callonce read('../../common/getToken.feature') { username: 'admin'}
     * def authToken = signIn.authToken
-    * def signInAsTSO = call read('../../common/getToken.feature') { username: 'operator1'}
+    * def signInAsTSO = callonce read('../../common/getToken.feature') { username: 'operator1'}
     * def authTokenAsTSO = signInAsTSO.authToken
     * def perimeterDeletedFrom = 'perimeterKarate1_1'
 

--- a/src/test/api/karate/users/perimeters/deleteGroupFromPerimeter.feature
+++ b/src/test/api/karate/users/perimeters/deleteGroupFromPerimeter.feature
@@ -2,9 +2,9 @@ Feature: delete group from a perimeter (endpoint tested : DELETE /perimeters/{id
 
   Background:
    #Getting token for admin and operator1 user calling getToken.feature
-    * def signIn = call read('../../common/getToken.feature') { username: 'admin'}
+    * def signIn = callonce read('../../common/getToken.feature') { username: 'admin'}
     * def authToken = signIn.authToken
-    * def signInAsTSO = call read('../../common/getToken.feature') { username: 'operator1'}
+    * def signInAsTSO = callonce read('../../common/getToken.feature') { username: 'operator1'}
     * def authTokenAsTSO = signInAsTSO.authToken
 
 

--- a/src/test/api/karate/users/perimeters/deletePerimeter.feature
+++ b/src/test/api/karate/users/perimeters/deletePerimeter.feature
@@ -2,9 +2,9 @@ Feature: deletePerimeter
 
   Background:
    #Getting token for admin and operator1 user calling getToken.feature
-    * def signIn = call read('../../common/getToken.feature') { username: 'admin'}
+    * def signIn = callonce read('../../common/getToken.feature') { username: 'admin'}
     * def authToken = signIn.authToken
-    * def signInAsTSO = call read('../../common/getToken.feature') { username: 'operator1'}
+    * def signInAsTSO = callonce read('../../common/getToken.feature') { username: 'operator1'}
     * def authTokenAsTSO = signInAsTSO.authToken
 
 

--- a/src/test/api/karate/users/perimeters/getCurrentUserWithPerimeters.feature
+++ b/src/test/api/karate/users/perimeters/getCurrentUserWithPerimeters.feature
@@ -2,9 +2,9 @@ Feature: Get current user with perimeters (endpoint tested : GET /CurrentUserWit
 
   Background:
    #Getting token for admin and operator1 user calling getToken.feature
-    * def signIn = call read('../../common/getToken.feature') { username: 'admin'}
+    * def signIn = callonce read('../../common/getToken.feature') { username: 'admin'}
     * def authToken = signIn.authToken
-    * def signInAsTSO = call read('../../common/getToken.feature') { username: 'operator1'}
+    * def signInAsTSO = callonce read('../../common/getToken.feature') { username: 'operator1'}
     * def authTokenAsTSO = signInAsTSO.authToken
 
     * def group15 =

--- a/src/test/api/karate/users/perimeters/getCurrentUserWithPerimeters_JWTMode.feature
+++ b/src/test/api/karate/users/perimeters/getCurrentUserWithPerimeters_JWTMode.feature
@@ -2,9 +2,9 @@ Feature: Get current user with perimeters (opfab in JWT mode)(endpoint tested : 
 
   Background:
    #Getting token for admin and operator1 user calling getToken.feature
-    * def signIn = call read('../../common/getToken.feature') { username: 'admin'}
+    * def signIn = callonce read('../../common/getToken.feature') { username: 'admin'}
     * def authToken = signIn.authToken
-    * def signInAsTSO = call read('../../common/getToken.feature') { username: 'operator1'}
+    * def signInAsTSO = callonce read('../../common/getToken.feature') { username: 'operator1'}
     * def authTokenAsTSO = signInAsTSO.authToken
 
 

--- a/src/test/api/karate/users/perimeters/getPerimeterDetails.feature
+++ b/src/test/api/karate/users/perimeters/getPerimeterDetails.feature
@@ -2,9 +2,9 @@ Feature: Get perimeter details (endpoint tested : GET /perimeters/{id})
 
   Background:
    #Getting token for admin and operator1 user calling getToken.feature
-    * def signIn = call read('../../common/getToken.feature') { username: 'admin'}
+    * def signIn = callonce read('../../common/getToken.feature') { username: 'admin'}
     * def authToken = signIn.authToken
-    * def signInAsTSO = call read('../../common/getToken.feature') { username: 'operator1'}
+    * def signInAsTSO = callonce read('../../common/getToken.feature') { username: 'operator1'}
     * def authTokenAsTSO = signInAsTSO.authToken
 
        #defining perimeters

--- a/src/test/api/karate/users/perimeters/getPerimeters.feature
+++ b/src/test/api/karate/users/perimeters/getPerimeters.feature
@@ -2,9 +2,9 @@ Feature: Get perimeters (endpoint tested : GET /perimeters)
 
   Background:
    #Getting token for admin and operator1 user calling getToken.feature
-    * def signIn = call read('../../common/getToken.feature') { username: 'admin'}
+    * def signIn = callonce read('../../common/getToken.feature') { username: 'admin'}
     * def authToken = signIn.authToken
-    * def signInAsTSO = call read('../../common/getToken.feature') { username: 'operator1'}
+    * def signInAsTSO = callonce read('../../common/getToken.feature') { username: 'operator1'}
     * def authTokenAsTSO = signInAsTSO.authToken
 
 

--- a/src/test/api/karate/users/perimeters/getPerimetersForAGroup.feature
+++ b/src/test/api/karate/users/perimeters/getPerimetersForAGroup.feature
@@ -2,9 +2,9 @@ Feature: Get perimeters for a group (endpoint tested : GET /groups/{id}/perimete
 
   Background:
    #Getting token for admin and operator1 user calling getToken.feature
-    * def signIn = call read('../../common/getToken.feature') { username: 'admin'}
+    * def signIn = callonce read('../../common/getToken.feature') { username: 'admin'}
     * def authToken = signIn.authToken
-    * def signInAsTSO = call read('../../common/getToken.feature') { username: 'operator1'}
+    * def signInAsTSO = callonce read('../../common/getToken.feature') { username: 'operator1'}
     * def authTokenAsTSO = signInAsTSO.authToken
 
     * def group12 =

--- a/src/test/api/karate/users/perimeters/getPerimetersForAUser.feature
+++ b/src/test/api/karate/users/perimeters/getPerimetersForAUser.feature
@@ -2,9 +2,9 @@ Feature: Get perimeters for a user (endpoint tested : GET /users/{login}/perimet
 
   Background:
    #Getting token for admin and operator1 user calling getToken.feature
-    * def signIn = call read('../../common/getToken.feature') { username: 'admin'}
+    * def signIn = callonce read('../../common/getToken.feature') { username: 'admin'}
     * def authToken = signIn.authToken
-    * def signInAsTSO = call read('../../common/getToken.feature') { username: 'operator1'}
+    * def signInAsTSO = callonce read('../../common/getToken.feature') { username: 'operator1'}
     * def authTokenAsTSO = signInAsTSO.authToken
 
     * def user10 =

--- a/src/test/api/karate/users/perimeters/postCardRoutingPerimeters.feature
+++ b/src/test/api/karate/users/perimeters/postCardRoutingPerimeters.feature
@@ -2,9 +2,9 @@ Feature: CreatePerimeters (endpoint tested : POST /perimeters)
 
   Background:
    #Getting token for admin and operator1 user calling getToken.feature
-    * def signIn = call read('../../common/getToken.feature') { username: 'admin'}
+    * def signIn = callonce read('../../common/getToken.feature') { username: 'admin'}
     * def authToken = signIn.authToken
-    * def signInAsTSO = call read('../../common/getToken.feature') { username: 'operator1'}
+    * def signInAsTSO = callonce read('../../common/getToken.feature') { username: 'operator1'}
     * def authTokenAsTSO = signInAsTSO.authToken
       #defining perimeters
     * def perimeter =

--- a/src/test/api/karate/users/perimeters/updateExistingPerimeter.feature
+++ b/src/test/api/karate/users/perimeters/updateExistingPerimeter.feature
@@ -2,9 +2,9 @@ Feature: Update existing perimeter (endpoint tested : PUT /perimeters/{id})
 
   Background:
    #Getting token for admin and operator1 user calling getToken.feature
-    * def signIn = call read('../../common/getToken.feature') { username: 'admin'}
+    * def signIn = callonce read('../../common/getToken.feature') { username: 'admin'}
     * def authToken = signIn.authToken
-    * def signInAsTSO = call read('../../common/getToken.feature') { username: 'operator1'}
+    * def signInAsTSO = callonce read('../../common/getToken.feature') { username: 'operator1'}
     * def authTokenAsTSO = signInAsTSO.authToken
 
            #defining perimeters

--- a/src/test/api/karate/users/perimeters/updateListOfPerimeterGroups.feature
+++ b/src/test/api/karate/users/perimeters/updateListOfPerimeterGroups.feature
@@ -2,9 +2,9 @@ Feature: Update list of perimeter groups (endpoint tested : PUT /perimeters/{id}
 
   Background:
    #Getting token for admin and operator1 user calling getToken.feature
-    * def signIn = call read('../../common/getToken.feature') { username: 'admin'}
+    * def signIn = callonce read('../../common/getToken.feature') { username: 'admin'}
     * def authToken = signIn.authToken
-    * def signInAsTSO = call read('../../common/getToken.feature') { username: 'operator1'}
+    * def signInAsTSO = callonce read('../../common/getToken.feature') { username: 'operator1'}
     * def authTokenAsTSO = signInAsTSO.authToken
 
        #defining perimeters

--- a/src/test/api/karate/users/perimeters/updatePerimetersForAGroup.feature
+++ b/src/test/api/karate/users/perimeters/updatePerimetersForAGroup.feature
@@ -2,9 +2,9 @@ Feature: Update perimeters for a group (endpoint tested : PUT /groups/{id}/perim
 
   Background:
    #Getting token for admin and operator1 user calling getToken.feature
-    * def signIn = call read('../../common/getToken.feature') { username: 'admin'}
+    * def signIn = callonce read('../../common/getToken.feature') { username: 'admin'}
     * def authToken = signIn.authToken
-    * def signInAsTSO = call read('../../common/getToken.feature') { username: 'operator1'}
+    * def signInAsTSO = callonce read('../../common/getToken.feature') { username: 'operator1'}
     * def authTokenAsTSO = signInAsTSO.authToken
 
     * def group13 =

--- a/src/test/api/karate/users/updateExistingUser.feature
+++ b/src/test/api/karate/users/updateExistingUser.feature
@@ -2,9 +2,9 @@ Feature: Update existing user
 
   Background:
    #Getting token for admin and operator1 user calling getToken.feature
-    * def signIn = call read('../common/getToken.feature') { username: 'admin'}
+    * def signIn = callonce read('../common/getToken.feature') { username: 'admin'}
     * def authToken = signIn.authToken
-    * def signInAsTSO = call read('../common/getToken.feature') { username: 'operator1'}
+    * def signInAsTSO = callonce read('../common/getToken.feature') { username: 'operator1'}
     * def authTokenAsTSO = signInAsTSO.authToken
     * def userToUpdate = "loginkarate5"
 

--- a/src/test/api/karate/waitForOpfabToStart.sh
+++ b/src/test/api/karate/waitForOpfabToStart.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+# Copyright (c) 2021, RTE (http://www.rte-france.com)
+# See AUTHORS.txt
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# SPDX-License-Identifier: MPL-2.0
+# This file is part of the OperatorFabric project.
+
+
+waitService() { 
+    while true; do
+        result=`curl -vs $2 2>&1 | grep -i content-length | cut -c 2-3` 
+        if [ -z $result ]
+        then
+            printf '%s' "."
+        else 
+            echo 
+            echo $(date) - "Opfab service $1 is started"
+            break;
+        fi  
+        sleep 5;
+    done
+}
+echo "Wait for opfab to start"
+waitService businessconfig localhost:2100
+waitService cards-publication localhost:2102
+waitService users localhost:2103
+waitService cards-consultation localhost:2104


### PR DESCRIPTION
- Remove unnecessary print in karate tests
- Set log level to INFO
- Limit the number of call to getToken.feature by using callOnce instead of call
- Use gradlew instead of gradle to launch karate
- Add a script to wait for opfab to start
- Add the api tests in travis task (when pushing a new commit or making a PR)

Signed-off-by: freddidierRTE <frederic-f.didier@rte-france.com>