### PR TITLE
[OC-1605] Stop angular building for IE11

### DIFF
--- a/ui/main/package.json
+++ b/ui/main/package.json
@@ -100,5 +100,15 @@
     "ts-node": "9.1.1",
     "tslint": "6.1.3",
     "typescript": "4.0.7"
-  }
+  },
+  "browserslist": [ 
+    "last 10 Chrome major version",
+    "last 10 Firefox major version",
+    "last 2 Edge major versions",
+    "last 2 Safari major versions",
+    "last 2 iOS major versions",
+    "last 2 Android major version ",
+    "Firefox ESR",
+    "not IE 11"
+  ]
 }


### PR DESCRIPTION
In release note : 
Tasks: 
[OC-1605] Stop angular building for IE11

[OC-1605]: https://opfab.atlassian.net/browse/OC-1605