### PR TITLE
[OC-1608] Timeline buttons : replace "7 Day" by "7 Days"

### DIFF
--- a/ui/main/src/assets/i18n/en.json
+++ b/ui/main/src/assets/i18n/en.json
@@ -25,7 +25,7 @@
     "buttonTitle": {
       "TR": "Real Time",
       "J": "Day",
-      "7D": "7 Day",
+      "7D": "7 Days",
       "W": "Week",
       "M": "Month",
       "Y": "Year"


### PR DESCRIPTION
Release notes : 

In bugs section : 

[OC-1608](https://opfab.atlassian.net/browse/OC-1608) : Timeline buttons : replace "7 Day" by "7 Days"