### PR TITLE
[OC-1631] Documentation : Error on title "Migration Guide from release 2.2.2 to release 2.3.0"

### DIFF
--- a/src/docs/asciidoc/resources/migration_guide_to_2.3.adoc
+++ b/src/docs/asciidoc/resources/migration_guide_to_2.3.adoc
@@ -5,7 +5,7 @@
 // file, You can obtain one at https://creativecommons.org/licenses/by/4.0/.
 // SPDX-License-Identifier: CC-BY-4.0
 
-= Migration Guide from release 2.2.2 to release 2.3.0
+= Migration Guide from release 2.2.0 to release 2.3.0
 
 == Communication between template and opfab
 


### PR DESCRIPTION
Nothing in release note.