### PR TITLE
[OC-1611] Adding localize back to polyfills file

### DIFF
--- a/ui/main/src/polyfills.ts
+++ b/ui/main/src/polyfills.ts
@@ -59,6 +59,10 @@
  */
 import 'zone.js/dist/zone';  // Included with Angular CLI.
 
+/***************************************************************************************************
+ * Load `$localize` onto the global scope - used if i18n tags appear in Angular templates.
+ */
+import '@angular/localize/init';
 
 /***************************************************************************************************
  * APPLICATION IMPORTS


### PR DESCRIPTION
This fixes the error message reported by @quinarygio:

```
Error: It looks like your application or one of its dependencies is using i18n.
Angular 9 introduced a global `$localize()` function that needs to be loaded.
Please run `ng add @angular/localize` from the Angular CLI.
(For non-CLI projects, add `import '@angular/localize/init';` to your `polyfills.ts` file.
For server-side rendering applications add the import to your `main.server.ts` file.)
```
I checked that I didn't remove any other import by mistake as part of removing the core-js dependency (OC-1611)
