### PR TITLE
[OC-1604] Acknowledge all cards : manage states with acknowledgmentAllowed set to "OnlyWhenResponseDisabledForUser"

### DIFF
--- a/ui/main/src/app/modules/cards/components/detail/detail.component.ts
+++ b/ui/main/src/app/modules/cards/components/detail/detail.component.ts
@@ -50,6 +50,7 @@ import {TimeService} from '@ofServices/time.service';
 import {AlertMessage} from '@ofStore/actions/alert.actions';
 import {MessageLevel} from '@ofModel/message.model';
 import {RightsEnum} from '@ofModel/perimeter.model';
+import {AcknowledgeService} from '@ofServices/acknowledge.service';
 
 
 declare const templateGateway: any;
@@ -162,7 +163,8 @@ export class DetailComponent implements OnChanges, OnInit, OnDestroy, AfterViewC
                 private entitiesService: EntitiesService,
                 private modalService: NgbModal,
                 private configService: ConfigService,
-                private time: TimeService) {
+                private time: TimeService,
+                private acknowledgeService: AcknowledgeService) {
     }
 
     get isLocked() {
@@ -368,7 +370,7 @@ export class DetailComponent implements OnChanges, OnInit, OnDestroy, AfterViewC
 
     acknowledge() {
         if (this.card.hasBeenAcknowledged) {
-            this.cardService.deleteUserAcknowledgement(this.card.uid).subscribe(resp => {
+            this.acknowledgeService.deleteUserAcknowledgement(this.card.uid).subscribe(resp => {
                 if (resp.status === 200 || resp.status === 204) {
                     this.card = {...this.card, hasBeenAcknowledged: false};
                     this.updateAcknowledgementOnLightCard(false);
@@ -378,7 +380,7 @@ export class DetailComponent implements OnChanges, OnInit, OnDestroy, AfterViewC
                 }
             });
         } else {
-            this.cardService.postUserAcknowledgement(this.card.uid).subscribe(resp => {
+            this.acknowledgeService.postUserAcknowledgement(this.card.uid).subscribe(resp => {
                 if (resp.status === 201 || resp.status === 200) {
                     this.updateAcknowledgementOnLightCard(true);
                     this.closeDetails();

--- a/ui/main/src/app/modules/feed/components/card-list/card-list.component.ts
+++ b/ui/main/src/app/modules/feed/components/card-list/card-list.component.ts
@@ -15,14 +15,16 @@ import {NgbModalRef} from '@ng-bootstrap/ng-bootstrap/modal/modal-ref';
 import {NgbModal} from '@ng-bootstrap/ng-bootstrap';
 import {ConfigService} from '@ofServices/config.service';
 import {MessageLevel} from '@ofModel/message.model';
-import {CardService} from '@ofServices/card.service';
 import {AlertMessage} from '@ofActions/alert.actions';
 import {Store} from '@ngrx/store';
 import {AppState} from '@ofStore/index';
-import {UpdateALightCard} from '@ofActions/light-card.actions';
-import {AcknowledgmentAllowedEnum, Process} from '@ofModel/processes.model';
 import {ProcessesService} from '@ofServices/processes.service';
 import {AppService} from '@ofServices/app.service';
+import {AcknowledgeService} from '@ofServices/acknowledge.service';
+import {UserService} from '@ofServices/user.service';
+import {UserWithPerimeters} from '@ofModel/userWithPerimeters.model';
+import {EntitiesService} from '@ofServices/entities.service';
+import {Entity} from '@ofModel/entity.model';
 
 
 @Component({
@@ -38,15 +40,22 @@ export class CardListComponent implements AfterViewChecked, OnInit {
     modalRef: NgbModalRef;
     hideAckAllCardsFeature: boolean;
     ackAllCardsDemandTimestamp: number;
+    currentUserWithPerimeters: UserWithPerimeters;
+    listEntities: Entity[];
 
     domCardListElement;
 
     constructor(private modalService: NgbModal,
                 private configService: ConfigService,
-                private cardService: CardService,
                 private store: Store<AppState>,
                 private processesService: ProcessesService,
-                private _appService: AppService) { }
+                private acknowledgeService: AcknowledgeService,
+                private userService: UserService,
+                private entitiesService: EntitiesService,
+                private _appService: AppService) {
+        this.currentUserWithPerimeters = this.userService.getCurrentUserWithPerimeters();
+        this.listEntities = this.entitiesService.getEntities();
+    }
 
     ngOnInit(): void {
         this.domCardListElement = document.getElementById('opfab-card-list');
@@ -67,41 +76,23 @@ export class CardListComponent implements AfterViewChecked, OnInit {
 
     acknowledgeAllVisibleCardsInTheFeed() {
         this.lightCards.forEach(lightCard => {
+
+            const processDefinition = this.processesService.getProcess(lightCard.process);
+
             if (! lightCard.hasBeenAcknowledged && this.isCardPublishedBeforeAckDemand(lightCard)
-                && this.isAcknowledgmentAllowed(lightCard))
-                this.acknowledgeCard(lightCard);
+                && this.acknowledgeService.isAcknowledgmentAllowed(this.currentUserWithPerimeters, lightCard, processDefinition, this.listEntities)) {
+                try {
+                    this.acknowledgeService.acknowledgeCard(lightCard);
+                } catch (err) {
+                    console.error(err);
+                    this.displayMessage('response.error.ack', null, MessageLevel.ERROR);
+                }
+            }
         });
     }
 
     isCardPublishedBeforeAckDemand(lightCard: LightCard): boolean {
         return lightCard.publishDate < this.ackAllCardsDemandTimestamp;
-    }
-
-    isAcknowledgmentAllowed(lightCard: LightCard): boolean {
-        const processDefinition = this.processesService.getProcess(lightCard.process);
-        if (!! processDefinition) {
-            const lightCardState = Process.prototype.extractState.call(processDefinition, lightCard);
-
-            if (!! lightCardState)
-                return lightCardState.acknowledgmentAllowed !== AcknowledgmentAllowedEnum.NEVER;
-        }
-        return false;
-    }
-
-    acknowledgeCard(lightCard: LightCard) {
-        this.cardService.postUserAcknowledgement(lightCard.uid).subscribe(resp => {
-            if (resp.status === 201 || resp.status === 200) {
-                this.updateAcknowledgementOnLightCard(lightCard, true);
-            } else {
-                console.error('the remote acknowledgement endpoint returned an error status(%d)', resp.status);
-                this.displayMessage('response.error.ack', null, MessageLevel.ERROR);
-            }
-        });
-    }
-
-    updateAcknowledgementOnLightCard(lightCard: LightCard, hasBeenAcknowledged: boolean) {
-        const updatedLightCard = {...lightCard, hasBeenAcknowledged: hasBeenAcknowledged};
-        this.store.dispatch(new UpdateALightCard({card: updatedLightCard}));
     }
 
     private displayMessage(i18nKey: string, msg: string, severity: MessageLevel = MessageLevel.ERROR) {

--- a/ui/main/src/app/modules/feed/components/card-list/card-list.component.ts
+++ b/ui/main/src/app/modules/feed/components/card-list/card-list.component.ts
@@ -24,7 +24,6 @@ import {AcknowledgeService} from '@ofServices/acknowledge.service';
 import {UserService} from '@ofServices/user.service';
 import {UserWithPerimeters} from '@ofModel/userWithPerimeters.model';
 import {EntitiesService} from '@ofServices/entities.service';
-import {Entity} from '@ofModel/entity.model';
 
 
 @Component({
@@ -41,7 +40,6 @@ export class CardListComponent implements AfterViewChecked, OnInit {
     hideAckAllCardsFeature: boolean;
     ackAllCardsDemandTimestamp: number;
     currentUserWithPerimeters: UserWithPerimeters;
-    listEntities: Entity[];
 
     domCardListElement;
 
@@ -54,7 +52,6 @@ export class CardListComponent implements AfterViewChecked, OnInit {
                 private entitiesService: EntitiesService,
                 private _appService: AppService) {
         this.currentUserWithPerimeters = this.userService.getCurrentUserWithPerimeters();
-        this.listEntities = this.entitiesService.getEntities();
     }
 
     ngOnInit(): void {
@@ -80,7 +77,7 @@ export class CardListComponent implements AfterViewChecked, OnInit {
             const processDefinition = this.processesService.getProcess(lightCard.process);
 
             if (! lightCard.hasBeenAcknowledged && this.isCardPublishedBeforeAckDemand(lightCard)
-                && this.acknowledgeService.isAcknowledgmentAllowed(this.currentUserWithPerimeters, lightCard, processDefinition, this.listEntities)) {
+                && this.acknowledgeService.isAcknowledgmentAllowed(this.currentUserWithPerimeters, lightCard, processDefinition)) {
                 try {
                     this.acknowledgeService.acknowledgeCard(lightCard);
                 } catch (err) {

--- a/ui/main/src/app/services/acknowledge.service.spec.ts
+++ b/ui/main/src/app/services/acknowledge.service.spec.ts
@@ -1,0 +1,202 @@
+/* Copyright (c) 2021, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
+ */
+
+
+import {AcknowledgeService} from '@ofServices/acknowledge.service';
+import {TestBed} from '@angular/core/testing';
+import {AcknowledgmentAllowedEnum, Response, State} from '@ofModel/processes.model';
+import {Map as OfMap} from '@ofModel/map';
+import {getOneRandomCard, getOneRandomProcess} from '@tests/helpers';
+import {Card} from '@ofModel/card.model';
+import {UserWithPerimeters} from '@ofModel/userWithPerimeters.model';
+import {User} from '@ofModel/user.model';
+import {RightsEnum} from '@ofModel/perimeter.model';
+import {HttpClientTestingModule} from '@angular/common/http/testing';
+import {StoreModule} from '@ngrx/store';
+import {appReducer} from '@ofStore/index';
+import {ConfigService} from '@ofServices/config.service';
+import {Entity} from '@ofModel/entity.model';
+
+
+describe('AcknowledgeService testing ', () => {
+
+    let acknowledgeService: AcknowledgeService;
+    let card: Card, cardForEntityParent: Card;
+    let userMemberOfEntity1: User, userMemberOfEntity2: User;
+    let statesList;
+    let listEntities: Entity[] = [];
+    let entityAllControlRooms: Entity, entity1: Entity, entity2: Entity;
+
+    beforeEach(() => {
+        statesList = new OfMap();
+        listEntities = [];
+
+        TestBed.configureTestingModule({
+            providers: [ConfigService],
+            imports: [StoreModule.forRoot(appReducer),
+                      HttpClientTestingModule]
+        });
+        acknowledgeService = TestBed.inject(AcknowledgeService);
+
+        card = getOneRandomCard({process: 'testProcess', processVersion: '1', state: 'testState', entitiesAllowedToRespond: ['ENTITY1']});
+        cardForEntityParent = getOneRandomCard({process: 'testProcess', processVersion: '1', state: 'testState', entitiesAllowedToRespond: ['ALLCONTROLROOMS']});
+        userMemberOfEntity1 = new User('userTest', 'firstName', 'lastName', ['group1'], ['ENTITY1']);
+        userMemberOfEntity2 = new User('userTest', 'firstName', 'lastName', ['group1'], ['ENTITY2']);
+
+        entityAllControlRooms = new Entity('ALLCONTROLROOMS', 'All Control Rooms', 'All Control Rooms', false, []);
+        entity1 = new Entity('ENTITY1', 'Control Room 1', 'Control Room 1', true, ['ALLCONTROLROOMS']);
+        entity2 = new Entity('ENTITY2', 'Control Room 2', 'Control Room 2', true, []);
+        listEntities.push(entity1);
+        listEntities.push(entity2);
+        listEntities.push(entityAllControlRooms);
+    });
+
+    it('acknowledgmentAllowed of the state is Never, isAcknowledgmentAllowed() must return false', () => {
+
+        statesList['testState'] = new State(null, null, null, AcknowledgmentAllowedEnum.NEVER);
+        const processDefinition = getOneRandomProcess({id: 'testProcess', version: '1', states: statesList});
+        const userWithPerimeters = new UserWithPerimeters(userMemberOfEntity1,
+            [{process: 'testProcess', state: 'testState', rights: RightsEnum.Receive}]);
+
+        const res = acknowledgeService.isAcknowledgmentAllowed(userWithPerimeters, card, processDefinition, listEntities);
+        expect(res).toBeFalse();
+    });
+
+    it('acknowledgmentAllowed of the state is Always, isAcknowledgmentAllowed() must return true', () => {
+
+        statesList['testState'] = new State(null, null, null, AcknowledgmentAllowedEnum.ALWAYS);
+        const processDefinition = getOneRandomProcess({id: 'testProcess', version: '1', states: statesList});
+        const userWithPerimeters = new UserWithPerimeters(userMemberOfEntity1,
+            [{process: 'testProcess', state: 'testState', rights: RightsEnum.Receive}]);
+
+        const res = acknowledgeService.isAcknowledgmentAllowed(userWithPerimeters, card, processDefinition, listEntities);
+        expect(res).toBeTrue();
+    });
+
+    it('acknowledgmentAllowed of the state is OnlyWhenResponseDisabledForUser, ' +
+        'user cannot respond (user is a member of entity allowed to respond but user rights for the state of the response is Receive), ' +
+        'isAcknowledgmentAllowed() must return true', () => {
+
+        statesList['testState'] = new State(null, null,
+                                            new Response(null, 'responseState'),
+                                            AcknowledgmentAllowedEnum.ONLY_WHEN_RESPONSE_DISABLED_FOR_USER);
+        const processDefinition = getOneRandomProcess({id: 'testProcess', version: '1', states: statesList});
+        const userWithPerimeters = new UserWithPerimeters(userMemberOfEntity1,
+            [{process: 'testProcess', state: 'responseState', rights: RightsEnum.Receive}]);
+
+        const res = acknowledgeService.isAcknowledgmentAllowed(userWithPerimeters, card, processDefinition, listEntities);
+        expect(res).toBeTrue();
+    });
+
+    it('acknowledgmentAllowed of the state is OnlyWhenResponseDisabledForUser, ' +
+        'user can respond (user is a member of entity allowed to respond and user rights for the state of the response is Write), ' +
+        'isAcknowledgmentAllowed() must return false', () => {
+
+        statesList['testState'] = new State(null, null,
+            new Response(null, 'responseState'),
+            AcknowledgmentAllowedEnum.ONLY_WHEN_RESPONSE_DISABLED_FOR_USER);
+        const processDefinition = getOneRandomProcess({id: 'testProcess', version: '1', states: statesList});
+        const userWithPerimeters = new UserWithPerimeters(userMemberOfEntity1,
+            [{process: 'testProcess', state: 'responseState', rights: RightsEnum.Write}]);
+
+        const res = acknowledgeService.isAcknowledgmentAllowed(userWithPerimeters, card, processDefinition, listEntities);
+        expect(res).toBeFalse();
+    });
+
+    it('acknowledgmentAllowed of the state is OnlyWhenResponseDisabledForUser, ' +
+        'user can respond (user is a member of entity allowed to respond and user rights for the state of the response is ReceiveAndWrite), ' +
+        'isAcknowledgmentAllowed() must return false', () => {
+
+        statesList['testState'] = new State(null, null,
+            new Response(null, 'responseState'),
+            AcknowledgmentAllowedEnum.ONLY_WHEN_RESPONSE_DISABLED_FOR_USER);
+        const processDefinition = getOneRandomProcess({id: 'testProcess', version: '1', states: statesList});
+        const userWithPerimeters = new UserWithPerimeters(userMemberOfEntity1,
+            [{process: 'testProcess', state: 'responseState', rights: RightsEnum.ReceiveAndWrite}]);
+
+        const res = acknowledgeService.isAcknowledgmentAllowed(userWithPerimeters, card, processDefinition, listEntities);
+        expect(res).toBeFalse();
+    });
+
+    it('acknowledgmentAllowed of the state is OnlyWhenResponseDisabledForUser, ' +
+        'user cannot respond (user is not a member of entity allowed to respond and user rights for the state of the response is Receive), ' +
+        'isAcknowledgmentAllowed() must return true', () => {
+
+        statesList['testState'] = new State(null, null,
+            new Response(null, 'responseState'),
+            AcknowledgmentAllowedEnum.ONLY_WHEN_RESPONSE_DISABLED_FOR_USER);
+        const processDefinition = getOneRandomProcess({id: 'testProcess', version: '1', states: statesList});
+        const userWithPerimeters = new UserWithPerimeters(userMemberOfEntity2,
+            [{process: 'testProcess', state: 'responseState', rights: RightsEnum.Receive}]);
+
+        const res = acknowledgeService.isAcknowledgmentAllowed(userWithPerimeters, card, processDefinition, listEntities);
+        expect(res).toBeTrue();
+    });
+
+    it('acknowledgmentAllowed of the state is OnlyWhenResponseDisabledForUser, ' +
+        'user cannot respond (user is not a member of entity allowed to respond and user rights for the state of the response is Write), ' +
+        'isAcknowledgmentAllowed() must return true', () => {
+
+        statesList['testState'] = new State(null, null,
+            new Response(null, 'responseState'),
+            AcknowledgmentAllowedEnum.ONLY_WHEN_RESPONSE_DISABLED_FOR_USER);
+        const processDefinition = getOneRandomProcess({id: 'testProcess', version: '1', states: statesList});
+        const userWithPerimeters = new UserWithPerimeters(userMemberOfEntity2,
+            [{process: 'testProcess', state: 'responseState', rights: RightsEnum.Write}]);
+
+        const res = acknowledgeService.isAcknowledgmentAllowed(userWithPerimeters, card, processDefinition, listEntities);
+        expect(res).toBeTrue();
+    });
+
+    it('acknowledgmentAllowed of the state is OnlyWhenResponseDisabledForUser, ' +
+        'user cannot respond (user is not a member of entity allowed to respond and user rights for the state of the response is ReceiveAndWrite), ' +
+        'isAcknowledgmentAllowed() must return true', () => {
+
+        statesList['testState'] = new State(null, null,
+            new Response(null, 'responseState'),
+            AcknowledgmentAllowedEnum.ONLY_WHEN_RESPONSE_DISABLED_FOR_USER);
+        const processDefinition = getOneRandomProcess({id: 'testProcess', version: '1', states: statesList});
+        const userWithPerimeters = new UserWithPerimeters(userMemberOfEntity2,
+            [{process: 'testProcess', state: 'responseState', rights: RightsEnum.ReceiveAndWrite}]);
+
+        const res = acknowledgeService.isAcknowledgmentAllowed(userWithPerimeters, card, processDefinition, listEntities);
+        expect(res).toBeTrue();
+    });
+
+    it('acknowledgmentAllowed of the state is OnlyWhenResponseDisabledForUser, ' +
+        'user can respond (user is a member of entity allowed to respond (ALLCONTROLROOMS) and user rights for the state of the response is Write), ' +
+        'isAcknowledgmentAllowed() must return false', () => {
+
+        statesList['testState'] = new State(null, null,
+            new Response(null, 'responseState'),
+            AcknowledgmentAllowedEnum.ONLY_WHEN_RESPONSE_DISABLED_FOR_USER);
+        const processDefinition = getOneRandomProcess({id: 'testProcess', version: '1', states: statesList});
+        const userWithPerimeters = new UserWithPerimeters(userMemberOfEntity1,
+            [{process: 'testProcess', state: 'responseState', rights: RightsEnum.Write}]);
+
+        const res = acknowledgeService.isAcknowledgmentAllowed(userWithPerimeters, cardForEntityParent, processDefinition, listEntities);
+        expect(res).toBeFalse();
+    });
+
+    it('acknowledgmentAllowed of the state is OnlyWhenResponseDisabledForUser, ' +
+        'user cannot respond (user is a member of entity allowed to respond (ALLCONTROLROOMS) but user rights for the state of the response is Receive), ' +
+        'isAcknowledgmentAllowed() must return true', () => {
+
+        statesList['testState'] = new State(null, null,
+            new Response(null, 'responseState'),
+            AcknowledgmentAllowedEnum.ONLY_WHEN_RESPONSE_DISABLED_FOR_USER);
+        const processDefinition = getOneRandomProcess({id: 'testProcess', version: '1', states: statesList});
+        const userWithPerimeters = new UserWithPerimeters(userMemberOfEntity1,
+            [{process: 'testProcess', state: 'responseState', rights: RightsEnum.Receive}]);
+
+        const res = acknowledgeService.isAcknowledgmentAllowed(userWithPerimeters, cardForEntityParent, processDefinition, listEntities);
+        expect(res).toBeTrue();
+    });
+
+});

--- a/ui/main/src/app/services/acknowledge.service.spec.ts
+++ b/ui/main/src/app/services/acknowledge.service.spec.ts
@@ -21,7 +21,8 @@ import {HttpClientTestingModule} from '@angular/common/http/testing';
 import {StoreModule} from '@ngrx/store';
 import {appReducer} from '@ofStore/index';
 import {ConfigService} from '@ofServices/config.service';
-import {Entity} from '@ofModel/entity.model';
+import {EntitiesService} from '@ofServices/entities.service';
+import {EntitiesServiceMock} from '@tests/mocks/entities.service.mock';
 
 
 describe('AcknowledgeService testing ', () => {
@@ -30,15 +31,12 @@ describe('AcknowledgeService testing ', () => {
     let card: Card, cardForEntityParent: Card;
     let userMemberOfEntity1: User, userMemberOfEntity2: User;
     let statesList;
-    let listEntities: Entity[] = [];
-    let entityAllControlRooms: Entity, entity1: Entity, entity2: Entity;
 
     beforeEach(() => {
         statesList = new OfMap();
-        listEntities = [];
 
         TestBed.configureTestingModule({
-            providers: [ConfigService],
+            providers: [ConfigService, {provide: EntitiesService, useClass: EntitiesServiceMock}],
             imports: [StoreModule.forRoot(appReducer),
                       HttpClientTestingModule]
         });
@@ -48,13 +46,6 @@ describe('AcknowledgeService testing ', () => {
         cardForEntityParent = getOneRandomCard({process: 'testProcess', processVersion: '1', state: 'testState', entitiesAllowedToRespond: ['ALLCONTROLROOMS']});
         userMemberOfEntity1 = new User('userTest', 'firstName', 'lastName', ['group1'], ['ENTITY1']);
         userMemberOfEntity2 = new User('userTest', 'firstName', 'lastName', ['group1'], ['ENTITY2']);
-
-        entityAllControlRooms = new Entity('ALLCONTROLROOMS', 'All Control Rooms', 'All Control Rooms', false, []);
-        entity1 = new Entity('ENTITY1', 'Control Room 1', 'Control Room 1', true, ['ALLCONTROLROOMS']);
-        entity2 = new Entity('ENTITY2', 'Control Room 2', 'Control Room 2', true, []);
-        listEntities.push(entity1);
-        listEntities.push(entity2);
-        listEntities.push(entityAllControlRooms);
     });
 
     it('acknowledgmentAllowed of the state is Never, isAcknowledgmentAllowed() must return false', () => {
@@ -64,7 +55,7 @@ describe('AcknowledgeService testing ', () => {
         const userWithPerimeters = new UserWithPerimeters(userMemberOfEntity1,
             [{process: 'testProcess', state: 'testState', rights: RightsEnum.Receive}]);
 
-        const res = acknowledgeService.isAcknowledgmentAllowed(userWithPerimeters, card, processDefinition, listEntities);
+        const res = acknowledgeService.isAcknowledgmentAllowed(userWithPerimeters, card, processDefinition);
         expect(res).toBeFalse();
     });
 
@@ -75,7 +66,7 @@ describe('AcknowledgeService testing ', () => {
         const userWithPerimeters = new UserWithPerimeters(userMemberOfEntity1,
             [{process: 'testProcess', state: 'testState', rights: RightsEnum.Receive}]);
 
-        const res = acknowledgeService.isAcknowledgmentAllowed(userWithPerimeters, card, processDefinition, listEntities);
+        const res = acknowledgeService.isAcknowledgmentAllowed(userWithPerimeters, card, processDefinition);
         expect(res).toBeTrue();
     });
 
@@ -90,7 +81,7 @@ describe('AcknowledgeService testing ', () => {
         const userWithPerimeters = new UserWithPerimeters(userMemberOfEntity1,
             [{process: 'testProcess', state: 'responseState', rights: RightsEnum.Receive}]);
 
-        const res = acknowledgeService.isAcknowledgmentAllowed(userWithPerimeters, card, processDefinition, listEntities);
+        const res = acknowledgeService.isAcknowledgmentAllowed(userWithPerimeters, card, processDefinition);
         expect(res).toBeTrue();
     });
 
@@ -105,7 +96,7 @@ describe('AcknowledgeService testing ', () => {
         const userWithPerimeters = new UserWithPerimeters(userMemberOfEntity1,
             [{process: 'testProcess', state: 'responseState', rights: RightsEnum.Write}]);
 
-        const res = acknowledgeService.isAcknowledgmentAllowed(userWithPerimeters, card, processDefinition, listEntities);
+        const res = acknowledgeService.isAcknowledgmentAllowed(userWithPerimeters, card, processDefinition);
         expect(res).toBeFalse();
     });
 
@@ -120,7 +111,7 @@ describe('AcknowledgeService testing ', () => {
         const userWithPerimeters = new UserWithPerimeters(userMemberOfEntity1,
             [{process: 'testProcess', state: 'responseState', rights: RightsEnum.ReceiveAndWrite}]);
 
-        const res = acknowledgeService.isAcknowledgmentAllowed(userWithPerimeters, card, processDefinition, listEntities);
+        const res = acknowledgeService.isAcknowledgmentAllowed(userWithPerimeters, card, processDefinition);
         expect(res).toBeFalse();
     });
 
@@ -135,7 +126,7 @@ describe('AcknowledgeService testing ', () => {
         const userWithPerimeters = new UserWithPerimeters(userMemberOfEntity2,
             [{process: 'testProcess', state: 'responseState', rights: RightsEnum.Receive}]);
 
-        const res = acknowledgeService.isAcknowledgmentAllowed(userWithPerimeters, card, processDefinition, listEntities);
+        const res = acknowledgeService.isAcknowledgmentAllowed(userWithPerimeters, card, processDefinition);
         expect(res).toBeTrue();
     });
 
@@ -150,7 +141,7 @@ describe('AcknowledgeService testing ', () => {
         const userWithPerimeters = new UserWithPerimeters(userMemberOfEntity2,
             [{process: 'testProcess', state: 'responseState', rights: RightsEnum.Write}]);
 
-        const res = acknowledgeService.isAcknowledgmentAllowed(userWithPerimeters, card, processDefinition, listEntities);
+        const res = acknowledgeService.isAcknowledgmentAllowed(userWithPerimeters, card, processDefinition);
         expect(res).toBeTrue();
     });
 
@@ -165,7 +156,7 @@ describe('AcknowledgeService testing ', () => {
         const userWithPerimeters = new UserWithPerimeters(userMemberOfEntity2,
             [{process: 'testProcess', state: 'responseState', rights: RightsEnum.ReceiveAndWrite}]);
 
-        const res = acknowledgeService.isAcknowledgmentAllowed(userWithPerimeters, card, processDefinition, listEntities);
+        const res = acknowledgeService.isAcknowledgmentAllowed(userWithPerimeters, card, processDefinition);
         expect(res).toBeTrue();
     });
 
@@ -180,7 +171,7 @@ describe('AcknowledgeService testing ', () => {
         const userWithPerimeters = new UserWithPerimeters(userMemberOfEntity1,
             [{process: 'testProcess', state: 'responseState', rights: RightsEnum.Write}]);
 
-        const res = acknowledgeService.isAcknowledgmentAllowed(userWithPerimeters, cardForEntityParent, processDefinition, listEntities);
+        const res = acknowledgeService.isAcknowledgmentAllowed(userWithPerimeters, cardForEntityParent, processDefinition);
         expect(res).toBeFalse();
     });
 
@@ -195,7 +186,7 @@ describe('AcknowledgeService testing ', () => {
         const userWithPerimeters = new UserWithPerimeters(userMemberOfEntity1,
             [{process: 'testProcess', state: 'responseState', rights: RightsEnum.Receive}]);
 
-        const res = acknowledgeService.isAcknowledgmentAllowed(userWithPerimeters, cardForEntityParent, processDefinition, listEntities);
+        const res = acknowledgeService.isAcknowledgmentAllowed(userWithPerimeters, cardForEntityParent, processDefinition);
         expect(res).toBeTrue();
     });
 

--- a/ui/main/src/app/services/acknowledge.service.ts
+++ b/ui/main/src/app/services/acknowledge.service.ts
@@ -1,0 +1,72 @@
+/* Copyright (c) 2018-2021, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
+ */
+
+
+import {Injectable} from '@angular/core';
+import {AcknowledgmentAllowedEnum, Process} from '@ofModel/processes.model';
+import {Card} from '@ofModel/card.model';
+import {UserWithPerimeters} from '@ofModel/userWithPerimeters.model';
+import {Entity} from '@ofModel/entity.model';
+import {LightCard} from '@ofModel/light-card.model';
+import {UpdateALightCard} from '@ofActions/light-card.actions';
+import {Store} from '@ngrx/store';
+import {AppState} from '@ofStore/index';
+import {Observable} from 'rxjs';
+import {HttpClient, HttpResponse} from '@angular/common/http';
+import {environment} from '@env/environment';
+import {ActionService} from '@ofServices/action.service';
+
+@Injectable({
+    providedIn: 'root'
+})
+export class AcknowledgeService {
+
+    readonly userAckUrl: string;
+
+    constructor(private actionService: ActionService,
+                private store: Store<AppState>,
+                private httpClient: HttpClient) {
+        this.userAckUrl = `${environment.urls.cardspub}/cards/userAcknowledgement`;
+    }
+
+    postUserAcknowledgement(cardUid: string): Observable<HttpResponse<void>> {
+        return this.httpClient.post<void>(`${this.userAckUrl}/${cardUid}`, null, {observe: 'response'});
+    }
+
+    deleteUserAcknowledgement(cardUid: string): Observable<HttpResponse<void>> {
+        return this.httpClient.delete<void>(`${this.userAckUrl}/${cardUid}`, {observe: 'response'});
+    }
+
+    acknowledgeCard(lightCard: LightCard) {
+        this.postUserAcknowledgement(lightCard.uid).subscribe(resp => {
+            if (resp.status === 201 || resp.status === 200) {
+                this.updateAcknowledgementOnLightCard(lightCard, true);
+            } else {
+                throw new Error('the remote acknowledgement endpoint returned an error status(' + resp.status + ')');
+            }
+        });
+    }
+
+    updateAcknowledgementOnLightCard(lightCard: LightCard, hasBeenAcknowledged: boolean) {
+        const updatedLightCard = {...lightCard, hasBeenAcknowledged: hasBeenAcknowledged};
+        this.store.dispatch(new UpdateALightCard({card: updatedLightCard}));
+    }
+
+    isAcknowledgmentAllowed(user: UserWithPerimeters, card: Card|LightCard, processDefinition: Process, listEntities: Entity[]): boolean {
+        const state = Process.prototype.extractState.call(processDefinition, card);
+
+        if (!! state) {
+            if (state.acknowledgmentAllowed === AcknowledgmentAllowedEnum.NEVER)
+                return false;
+            if (state.acknowledgmentAllowed === AcknowledgmentAllowedEnum.ALWAYS)
+                return true;
+        }
+        return ! this.actionService.isUserEnabledToRespond(user, card, processDefinition, listEntities);
+    }
+}

--- a/ui/main/src/app/services/acknowledge.service.ts
+++ b/ui/main/src/app/services/acknowledge.service.ts
@@ -12,7 +12,6 @@ import {Injectable} from '@angular/core';
 import {AcknowledgmentAllowedEnum, Process} from '@ofModel/processes.model';
 import {Card} from '@ofModel/card.model';
 import {UserWithPerimeters} from '@ofModel/userWithPerimeters.model';
-import {Entity} from '@ofModel/entity.model';
 import {LightCard} from '@ofModel/light-card.model';
 import {UpdateALightCard} from '@ofActions/light-card.actions';
 import {Store} from '@ngrx/store';
@@ -58,7 +57,7 @@ export class AcknowledgeService {
         this.store.dispatch(new UpdateALightCard({card: updatedLightCard}));
     }
 
-    isAcknowledgmentAllowed(user: UserWithPerimeters, card: Card|LightCard, processDefinition: Process, listEntities: Entity[]): boolean {
+    isAcknowledgmentAllowed(user: UserWithPerimeters, card: Card|LightCard, processDefinition: Process): boolean {
         const state = Process.prototype.extractState.call(processDefinition, card);
 
         if (!! state) {
@@ -67,6 +66,6 @@ export class AcknowledgeService {
             if (state.acknowledgmentAllowed === AcknowledgmentAllowedEnum.ALWAYS)
                 return true;
         }
-        return ! this.actionService.isUserEnabledToRespond(user, card, processDefinition, listEntities);
+        return ! this.actionService.isUserEnabledToRespond(user, card, processDefinition);
     }
 }

--- a/ui/main/src/app/services/action.service.ts
+++ b/ui/main/src/app/services/action.service.ts
@@ -11,7 +11,6 @@ import { Injectable } from '@angular/core';
 import {userRight, UserWithPerimeters} from '@ofModel/userWithPerimeters.model';
 import {Card} from '@ofModel/card.model';
 import {Process} from '@ofModel/processes.model';
-import {Entity} from '@ofModel/entity.model';
 import {RightsEnum} from '@ofModel/perimeter.model';
 import {ConfigService} from '@ofServices/config.service';
 import {EntitiesService} from '@ofServices/entities.service';
@@ -26,17 +25,17 @@ export class ActionService {
   constructor(private configService: ConfigService,
               private entitiesService: EntitiesService) { }
 
-  public isUserEnabledToRespond(user: UserWithPerimeters, card: Card, processDefinition: Process, listEntities: Entity[]): boolean {
+  public isUserEnabledToRespond(user: UserWithPerimeters, card: Card, processDefinition: Process): boolean {
     const checkPerimeterForResponseCard = this.configService.getConfigValue('checkPerimeterForResponseCard');
 
     if (checkPerimeterForResponseCard === false)
-      return this.isUserInEntityAllowedToRespond(user, card, listEntities);
+      return this.isUserInEntityAllowedToRespond(user, card);
     else
-      return this.isUserInEntityAllowedToRespond(user, card, listEntities)
+      return this.isUserInEntityAllowedToRespond(user, card)
           && this.doesTheUserHavePermissionToRespond(user, card, processDefinition);
   }
 
-  private isUserInEntityAllowedToRespond(user: UserWithPerimeters, card: Card, listEntities: Entity[]): boolean {
+  private isUserInEntityAllowedToRespond(user: UserWithPerimeters, card: Card): boolean {
     let userEntitiesAllowedToRespond = [];
     let entitiesAllowedToRespondAndEntitiesRequiredToRespond = [];
 
@@ -49,10 +48,10 @@ export class ActionService {
 
     if (entitiesAllowedToRespondAndEntitiesRequiredToRespond) {
 
-      const entitiesAllowedToRespond = listEntities.filter(entity =>
+      const entitiesAllowedToRespond = this.entitiesService.getEntities().filter(entity =>
           entitiesAllowedToRespondAndEntitiesRequiredToRespond.includes(entity.id));
 
-      const allowed = this.entitiesService.resolveEntitiesAllowedToSendCards(entitiesAllowedToRespond, listEntities)
+      const allowed = this.entitiesService.resolveEntitiesAllowedToSendCards(entitiesAllowedToRespond)
           .map(entity => entity.id).filter(x =>  x !== card.publisher);
 
       console.log(new Date().toISOString(), ' Detail card - entities allowed to respond = ', allowed);

--- a/ui/main/src/app/services/action.service.ts
+++ b/ui/main/src/app/services/action.service.ts
@@ -1,0 +1,86 @@
+/* Copyright (c) 2018-2021, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
+ */
+
+import { Injectable } from '@angular/core';
+import {userRight, UserWithPerimeters} from '@ofModel/userWithPerimeters.model';
+import {Card} from '@ofModel/card.model';
+import {Process} from '@ofModel/processes.model';
+import {Entity} from '@ofModel/entity.model';
+import {RightsEnum} from '@ofModel/perimeter.model';
+import {ConfigService} from '@ofServices/config.service';
+import {EntitiesService} from '@ofServices/entities.service';
+
+/** This class contains functions allowing to know if the user has the right to answer to the card or not */
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ActionService {
+
+  constructor(private configService: ConfigService,
+              private entitiesService: EntitiesService) { }
+
+  public isUserEnabledToRespond(user: UserWithPerimeters, card: Card, processDefinition: Process, listEntities: Entity[]): boolean {
+    const checkPerimeterForResponseCard = this.configService.getConfigValue('checkPerimeterForResponseCard');
+
+    if (checkPerimeterForResponseCard === false)
+      return this.isUserInEntityAllowedToRespond(user, card, listEntities);
+    else
+      return this.isUserInEntityAllowedToRespond(user, card, listEntities)
+          && this.doesTheUserHavePermissionToRespond(user, card, processDefinition);
+  }
+
+  private isUserInEntityAllowedToRespond(user: UserWithPerimeters, card: Card, listEntities: Entity[]): boolean {
+    let userEntitiesAllowedToRespond = [];
+    let entitiesAllowedToRespondAndEntitiesRequiredToRespond = [];
+
+    if (card.entitiesAllowedToRespond)
+      entitiesAllowedToRespondAndEntitiesRequiredToRespond = entitiesAllowedToRespondAndEntitiesRequiredToRespond
+          .concat(card.entitiesAllowedToRespond);
+    if (card.entitiesRequiredToRespond)
+      entitiesAllowedToRespondAndEntitiesRequiredToRespond = entitiesAllowedToRespondAndEntitiesRequiredToRespond
+          .concat(card.entitiesRequiredToRespond);
+
+    if (entitiesAllowedToRespondAndEntitiesRequiredToRespond) {
+
+      const entitiesAllowedToRespond = listEntities.filter(entity =>
+          entitiesAllowedToRespondAndEntitiesRequiredToRespond.includes(entity.id));
+
+      const allowed = this.entitiesService.resolveEntitiesAllowedToSendCards(entitiesAllowedToRespond, listEntities)
+          .map(entity => entity.id).filter(x =>  x !== card.publisher);
+
+      console.log(new Date().toISOString(), ' Detail card - entities allowed to respond = ', allowed);
+
+      userEntitiesAllowedToRespond = allowed.filter(x => user.userData.entities.includes(x));
+      console.log(new Date().toISOString(), ' Detail card - users entities allowed to respond = ', userEntitiesAllowedToRespond);
+      if (userEntitiesAllowedToRespond.length > 1)
+        console.log(new Date().toISOString(), 'Warning : user can respond on behalf of more than one entity, so response is disabled');
+    }
+    return userEntitiesAllowedToRespond.length === 1;
+  }
+
+  private doesTheUserHavePermissionToRespond(user: UserWithPerimeters, card: Card, processDefinition: Process): boolean {
+    let permission = false;
+    user.computedPerimeters.forEach(perim => {
+      const stateOfTheCard = Process.prototype.extractState.call(processDefinition, card);
+
+      if ((!! stateOfTheCard) && (perim.process === card.process) && (perim.state === stateOfTheCard.response.state)
+          && (this.compareRightAction(perim.rights, RightsEnum.Write)
+              || this.compareRightAction(perim.rights, RightsEnum.ReceiveAndWrite))) {
+        permission = true;
+        return true;
+      }
+    });
+    return permission;
+  }
+
+  private compareRightAction(userRights: RightsEnum, rightsAction: RightsEnum): boolean {
+    return (userRight(userRights) - userRight(rightsAction)) === 0;
+  }
+}

--- a/ui/main/src/app/services/card.service.ts
+++ b/ui/main/src/app/services/card.service.ts
@@ -44,7 +44,6 @@ export class CardService {
     readonly cardsUrl: string;
     readonly archivesUrl: string;
     readonly cardsPubUrl: string;
-    readonly userAckUrl: string;
     readonly userCardReadUrl: string;
     readonly userCardUrl: string;
     private lastHeardBeatDate: number;
@@ -65,7 +64,6 @@ export class CardService {
         this.cardsUrl = `${environment.urls.cards}/cards`;
         this.archivesUrl = `${environment.urls.cards}/archives`;
         this.cardsPubUrl = `${environment.urls.cardspub}/cards`;
-        this.userAckUrl = `${environment.urls.cardspub}/cards/userAcknowledgement`;
         this.userCardReadUrl = `${environment.urls.cardspub}/cards/userCardRead`;
         this.userCardUrl = `${environment.urls.cardspub}/cards/userCard`;
     }
@@ -231,14 +229,6 @@ export class CardService {
     postCard(card: CardForPublishing): any {
         const headers = this.authService.getSecurityHeader();
         return this.httpClient.post<CardForPublishing>(`${this.cardsPubUrl}/userCard`, card, {headers});
-    }
-
-    postUserAcknowledgement(cardUid: string): Observable<HttpResponse<void>> {
-        return this.httpClient.post<void>(`${this.userAckUrl}/${cardUid}`, null, {observe: 'response'});
-    }
-
-    deleteUserAcknowledgement(cardUid: string): Observable<HttpResponse<void>> {
-        return this.httpClient.delete<void>(`${this.userAckUrl}/${cardUid}`, {observe: 'response'});
     }
 
     deleteCard(card: Card): Observable<HttpResponse<void>> {

--- a/ui/main/src/app/services/entities.service.ts
+++ b/ui/main/src/app/services/entities.service.ts
@@ -124,18 +124,15 @@ export class EntitiesService extends CachedCrudService implements OnDestroy {
   /** Given a list of entities that might contain parent entities, this method returns the list of entities
    *  that can actually send cards
    * */
-  public resolveEntitiesAllowedToSendCards(selected: Entity[], listEntities?: Entity[]): Entity[] {
+  public resolveEntitiesAllowedToSendCards(selected: Entity[]): Entity[] {
     const allowed = new Set<Entity>();
     selected.forEach(entity => {
         if (entity.entityAllowedToSendCard) {
             allowed.add(entity);
         } else {
             let children: Entity[];
-            if (listEntities)
-                children = listEntities.filter(child => child.parents.includes(entity.id));
-            else
-                children = this._entities.filter(child => child.parents.includes(entity.id));
-          const childrenAllowed = this.resolveEntitiesAllowedToSendCards(children);
+            children = this._entities.filter(child => child.parents.includes(entity.id));
+            const childrenAllowed = this.resolveEntitiesAllowedToSendCards(children);
             childrenAllowed.forEach(c => allowed.add(c));
         }
     });

--- a/ui/main/src/app/services/entities.service.ts
+++ b/ui/main/src/app/services/entities.service.ts
@@ -124,17 +124,21 @@ export class EntitiesService extends CachedCrudService implements OnDestroy {
   /** Given a list of entities that might contain parent entities, this method returns the list of entities
    *  that can actually send cards
    * */
-  public resolveEntitiesAllowedToSendCards(selected: Entity[]) : Entity[] {
-    let allowed = new Set<Entity>();
+  public resolveEntitiesAllowedToSendCards(selected: Entity[], listEntities?: Entity[]): Entity[] {
+    const allowed = new Set<Entity>();
     selected.forEach(entity => {
         if (entity.entityAllowedToSendCard) {
             allowed.add(entity);
         } else {
-          const childs = this._entities.filter(child => child.parents.includes(entity.id));
-          const childsAllowed = this.resolveEntitiesAllowedToSendCards(childs);
-          childsAllowed.forEach(c => allowed.add(c));
+            let children: Entity[];
+            if (listEntities)
+                children = listEntities.filter(child => child.parents.includes(entity.id));
+            else
+                children = this._entities.filter(child => child.parents.includes(entity.id));
+          const childrenAllowed = this.resolveEntitiesAllowedToSendCards(children);
+            childrenAllowed.forEach(c => allowed.add(c));
         }
-    })
+    });
 
     return Array.from(allowed);
   }

--- a/ui/main/src/app/services/reminder/reminder.service.ts
+++ b/ui/main/src/app/services/reminder/reminder.service.ts
@@ -18,13 +18,17 @@ import { AppState } from '@ofStore/index';
 import { fetchLightCard, selectLastCards } from '@ofStore/selectors/feed.selectors';
 import { take } from 'rxjs/operators';
 import { ReminderList } from './reminderList';
+import { AcknowledgeService } from '@ofServices/acknowledge.service';
 
 @Injectable()
 export class ReminderService {
 
     private reminderList: ReminderList;
 
-    constructor(private store: Store<AppState>, private processService: ProcessesService, private cardService: CardService) {
+    constructor(private store: Store<AppState>,
+                private processService: ProcessesService,
+                private cardService: CardService,
+                private acknowledgeService: AcknowledgeService) {
     }
 
 
@@ -57,7 +61,7 @@ export class ReminderService {
                 if (!!lightCard) {
 
                     this.reminderList.setCardHasBeenRemind(lightCard);
-                    this.cardService.deleteUserAcknowledgement(lightCard.uid).subscribe(resp => {
+                    this.acknowledgeService.deleteUserAcknowledgement(lightCard.uid).subscribe(resp => {
                         if (!(resp.status === 200 || resp.status === 204))
                             console.error(new Date().toISOString(),
                                 'Reminder : the remote acknowledgement endpoint returned an error status(%d)', resp.status);

--- a/ui/main/src/tests/helpers.ts
+++ b/ui/main/src/tests/helpers.ts
@@ -197,7 +197,13 @@ export function getOneRandomCard(cardTemplate?:any): Card {
         generateRandomPositiveIntegerWithinRangeWithOneAsMinimum(4654, 5666),
         getRandomI18nData(),
         getRandomI18nData(),
-        cardTemplate.data ? cardTemplate.data : {data: "data"}
+        cardTemplate.data ? cardTemplate.data : {data: "data"},
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        cardTemplate.entitiesAllowedToRespond ? cardTemplate.entitiesAllowedToRespond : null,
+        cardTemplate.entitiesRequiredToRespond ? cardTemplate.entitiesRequiredToRespond : null
     );
     return oneCard;
 }

--- a/ui/main/src/tests/mocks/entities.service.mock.ts
+++ b/ui/main/src/tests/mocks/entities.service.mock.ts
@@ -1,0 +1,46 @@
+/* Copyright (c) 2018-2021, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
+ */
+
+import {Entity} from '@ofModel/entity.model';
+
+export class EntitiesServiceMock {
+
+    private readonly _entities: Entity[];
+
+    constructor() {
+        this._entities = new Array<Entity>();
+        let entityAllControlRooms: Entity, entity1: Entity, entity2: Entity;
+
+        entityAllControlRooms = new Entity('ALLCONTROLROOMS', 'All Control Rooms', 'All Control Rooms', false, []);
+        entity1 = new Entity('ENTITY1', 'Control Room 1', 'Control Room 1', true, ['ALLCONTROLROOMS']);
+        entity2 = new Entity('ENTITY2', 'Control Room 2', 'Control Room 2', true, []);
+        this._entities.push(entity1);
+        this._entities.push(entity2);
+        this._entities.push(entityAllControlRooms);
+    }
+
+    public resolveEntitiesAllowedToSendCards(selected: Entity[]): Entity[] {
+        const allowed = new Set<Entity>();
+        selected.forEach(entity => {
+            if (entity.entityAllowedToSendCard) {
+                allowed.add(entity);
+            } else {
+                let children: Entity[];
+                children = this._entities.filter(child => child.parents.includes(entity.id));
+                const childrenAllowed = this.resolveEntitiesAllowedToSendCards(children);
+                childrenAllowed.forEach(c => allowed.add(c));
+            }
+        });
+        return Array.from(allowed);
+    }
+
+    public getEntities(): Entity[] {
+        return this._entities;
+    }
+}


### PR DESCRIPTION
In the acknowledge.service.ts file, I only left functions directly related to the ack (even when they are not strictly speaking requests).
And I created a new file, action.service.ts, which contains functions allowing to know if the user has the right to answer or not.
And I propose to make another ticket to do a refacto consisting of using this new action service, in the Detail component (OC-1659).

Release notes : 

In Tasks section : 

[OC-1604](https://opfab.atlassian.net/browse/OC-1604) : Acknowledge all cards : manage states with acknowledgmentAllowed set to "OnlyWhenResponseDisabledForUser"