### PR TITLE
[OC-1647] Update Renovate config to handle Karate and Cypress

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,5 +6,10 @@
   "prCreation": "not-pending",
   "branchPrefix": "OC-1590_",
   "branchConcurrentLimit": 10,
-  "prConcurrentLimit":5
+  "prConcurrentLimit":5,
+  "ignorePaths": [
+    "**/node_modules/**",
+    "**/bower_components/**",
+    "**/vendor/**"
+  ]
 }


### PR DESCRIPTION
The default config excluded any dependencies under "test" so Karate and Cypress were not kept up to date by Renovate.
No need to mention it in release notes.