### PR TITLE
[OC-1634] When changing perimeter attach to a group it is not propagate to the card-publication service

### DIFF
--- a/services/core/users/src/main/java/org/opfab/users/controllers/GroupsController.java
+++ b/services/core/users/src/main/java/org/opfab/users/controllers/GroupsController.java
@@ -88,6 +88,11 @@ public class GroupsController implements GroupsApi {
         if(groupRepository.findById(group.getId()).orElse(null) == null){
             response.addHeader("Location", request.getContextPath() + "/groups/" + group.getId());
             response.setStatus(201);
+        } else {
+            List<UserData> users = userRepository.findByGroupSetContaining(group.getId());
+            users.forEach(foundUser -> {
+                publisher.publishEvent(new UpdatedUserEvent(this, busServiceMatcher.getServiceId(), foundUser.getLogin()));
+            });
         }
         return groupRepository.save((GroupData)group);
     }


### PR DESCRIPTION
Release notes

In Bugs section:
[OC-1634] When changing perimeter attach to a group it is not propagate to the card-publication service

[OC-1634]: https://opfab.atlassian.net/browse/OC-1634