### PR TITLE
[OC-1654] After an update of a question card, the entities that have already answered shall be orange in card header

### DIFF
--- a/ui/main/src/app/modules/cards/components/detail/detail.component.ts
+++ b/ui/main/src/app/modules/cards/components/detail/detail.component.ts
@@ -590,7 +590,7 @@ export class DetailComponent implements OnChanges, OnInit, OnDestroy, AfterViewC
     }
 
     checkEntityAnswered(entity: string): boolean {
-        return this.childCards.some(childCard => childCard.publisher === entity);
+        return this.childCards.some(childCard => childCard.publisher === entity && childCard.initialParentCardUid === this.card.uid);
     }
 
     private initializeHrefsOfCssLink() {


### PR DESCRIPTION
Release notes

In Tasks section:
[OC-1654] After an update of a question card, the entities that have already answered shall be orange in card header
   Note: the entities will be marked in green only  when they answer to the updated version of card

[OC-1654]: https://opfab.atlassian.net/browse/OC-1654