### PR TITLE
[OC-1639] Use user perimeter to populate services/process/state list in archives/logging/monitoring/feedconfiguration

### DIFF
--- a/config/dev/web-ui.json
+++ b/config/dev/web-ui.json
@@ -3,6 +3,7 @@
   "environmentName": "DEV ENV",
   "environmentColor": "green",
   "checkPerimeterForResponseCard": true,
+  "checkPerimeterForSearchFields": false,
   "archive": {
     "filters": {
       "page": {

--- a/config/docker/web-ui.json
+++ b/config/docker/web-ui.json
@@ -2,6 +2,7 @@
   "environmentName": "TEST ENV",
   "environmentColor": "blue",
   "checkPerimeterForResponseCard": true,
+  "checkPerimeterForSearchFields": false,
   "archive": {
     "filters": {
       "page": {

--- a/src/docs/asciidoc/deployment/configuration/web-ui_configuration.adoc
+++ b/src/docs/asciidoc/deployment/configuration/web-ui_configuration.adoc
@@ -138,7 +138,7 @@ There will be two new routes with the release of the `[OC-936]`:
 - `logging`;
 - `monitoring`.
 |checkPerimeterForResponseCard|true|no|If false, OperatorFabric will not check that a user has write rights on a process/state to respond to a card.
-|checkPerimeterForSearchFields|false|no|If true, to see a service, process or state in the archives/logging/monitoring/feedconfiguration screens of OperatorFabric, you must have a "Receive" right enabled in the corresponding process/state.
+|checkPerimeterForSearchFields|false|no|If true, to see a service, process or state in the archives/logging/monitoring/feedconfiguration screens of OperatorFabric, you must have a "Receive" or "ReceiveAndWrite" right enabled in the corresponding process/state.
 
 
 |===
@@ -152,6 +152,5 @@ There will be two new routes with the release of the `[OC-936]`:
 |settings.default-tags||no|Default user list of filtered in tags
 
 |===
-
 
 

--- a/src/docs/asciidoc/deployment/configuration/web-ui_configuration.adoc
+++ b/src/docs/asciidoc/deployment/configuration/web-ui_configuration.adoc
@@ -138,6 +138,8 @@ There will be two new routes with the release of the `[OC-936]`:
 - `logging`;
 - `monitoring`.
 |checkPerimeterForResponseCard|true|no|If false, OperatorFabric will not check that a user has write rights on a process/state to respond to a card.
+|checkPerimeterForSearchFields|false|no|If true, to see a service, process or state in the archives/logging/monitoring/feedconfiguration screens of OperatorFabric, you must have a "Receive" right enabled in the corresponding process/state.
+
 
 |===
 

--- a/ui/main/src/app/modules/feedconfiguration/feedconfiguration.component.html
+++ b/ui/main/src/app/modules/feedconfiguration/feedconfiguration.component.html
@@ -17,10 +17,10 @@
             <h5 class="font-weight-bold">{{processGroup.groupLabel}}</h5>
             <div class="row">
                 <div class="col-md" *ngFor="let processIdAndLabel of processGroup.processes; ">
-                    <div *ngIf="processesStatesLabels.get(processIdAndLabel.processId)">
-                        <p class="font-weight-bold">{{processesStatesLabels.get(processIdAndLabel.processId).processLabel}}</p>
+                    <div *ngIf="processesStatesLabels.get(processIdAndLabel.processId) as processData">
+                        <p class="font-weight-bold">{{processData.processLabel}}</p>
                         <div style="margin-left: 20px;" >
-                            <div class="row" formArrayName="processesStates" *ngFor="let state of processesStatesLabels.get(processIdAndLabel.processId).states; ">
+                            <div class="row" formArrayName="processesStates" *ngFor="let state of processData.states; ">
                                 <label class="opfab-checkbox">{{state.stateLabel}}
                                     <input type="checkbox"[formControlName]=state.stateControlIndex [id]=state.stateControlIndex >
                                     <span class="opfab-checkbox-checkmark"></span>

--- a/ui/main/src/app/modules/feedconfiguration/feedconfiguration.component.ts
+++ b/ui/main/src/app/modules/feedconfiguration/feedconfiguration.component.ts
@@ -163,7 +163,7 @@ export class FeedconfigurationComponent implements OnInit {
     /** cleaning of the two arrays : processGroupsAndLabels and processesWithoutGroup
      * processGroupsAndLabels : we don't display process which doesn't have any state with Receive right
      *                          and we don't display process group which doesn't have any process
-     * processesWithoutGroup : we don't display process which doesn't have any state with Receive right*/
+     * processesWithoutGroup : we don't display process which doesn't have any state with Receive or ReceiveAndWrite right*/
     private removeProcessesWithoutStatesWithReceiveRights() {
         this.processGroupsAndLabels.forEach((processGroupData, index) => {
             processGroupData.processes = processGroupData.processes.filter(processData => !! this.processesStatesLabels.get(processData.processId));

--- a/ui/main/src/app/modules/feedconfiguration/feedconfiguration.component.ts
+++ b/ui/main/src/app/modules/feedconfiguration/feedconfiguration.component.ts
@@ -22,6 +22,7 @@ import {CardService} from '@ofServices/card.service';
 import {EmptyLightCards} from '@ofActions/light-card.actions';
 import {TranslateService} from '@ngx-translate/core';
 import {Utilities} from '../../common/utilities';
+import {ConfigService} from '@ofServices/config.service';
 
 
 @Component({
@@ -34,6 +35,7 @@ export class FeedconfigurationComponent implements OnInit {
     feedConfigurationForm: FormGroup;
 
     processesDefinition: Process[];
+    checkPerimeterForSearchFields: boolean;
     processGroupsAndLabels: { groupId: string,
                               groupLabel: string,
                               processes:
@@ -48,7 +50,8 @@ export class FeedconfigurationComponent implements OnInit {
     currentUserWithPerimeters: UserWithPerimeters;
     processesStatesLabels: Map<string, { processLabel: string,
                                          states:
-                                             { stateLabel: string,
+                                             { stateId: string,
+                                               stateLabel: string,
                                                stateControlIndex: number
                                              } []
                                        } >;
@@ -68,14 +71,10 @@ export class FeedconfigurationComponent implements OnInit {
                 private modalService: NgbModal,
                 private settingsService: SettingsService,
                 private cardService: CardService,
-                private translateService: TranslateService
+                private translateService: TranslateService,
+                private configService: ConfigService
     ) {
-        this.processesStatesLabels = new Map<string, {processLabel: string,
-            states:
-                { stateLabel: string,
-                    stateControlIndex: number
-                }[]
-        }> ();
+        this.processesStatesLabels = new Map();
         this.preparedListOfProcessesStates = [];
         this.processesWithoutGroup = [];
         this.processesDefinition = this.processesService.getAllProcesses();
@@ -88,7 +87,7 @@ export class FeedconfigurationComponent implements OnInit {
 
     private findInProcessGroups(processIdToFind: string): boolean {
         for (const processGroup of this.processGroupsAndLabels.values()) {
-            if (processGroup.processes.find(process => process.processId == processIdToFind))
+            if (processGroup.processes.find(process => process.processId === processIdToFind))
                 return true;
         }
         return false;
@@ -132,31 +131,46 @@ export class FeedconfigurationComponent implements OnInit {
 
             for (const process of this.processesDefinition) {
 
-                const statesArray: { stateLabel: string, stateControlIndex: number }[]
-                    = new Array<{stateLabel: string, stateControlIndex: number}>();
+                const states: { stateId: string, stateLabel: string, stateControlIndex: number }[] = [];
 
-                let processLabel = (!!process.name) ? Utilities.getI18nPrefixFromProcess(process) + process.name :
-                    Utilities.getI18nPrefixFromProcess(process) + process.id;
+                let processLabel = this.computeI18n(process, process.name, process.id);
                 this.translateService.get(processLabel).subscribe(translate => { processLabel = translate; });
 
-                for (const key in process.states) {
-                    const value = process.states[key];
-                    let stateLabel = (!!value.name) ? Utilities.getI18nPrefixFromProcess(process) + value.name :
-                        Utilities.getI18nPrefixFromProcess(process) + key;
+                for (const stateId of Object.keys(process.states)) {
+                    const state = process.states[stateId];
 
-                    this.translateService.get(stateLabel).subscribe(translate => { stateLabel = translate; });
+                    if ((!this.checkPerimeterForSearchFields) || this.userService.isReceiveRightsForProcessAndState(process.id, stateId)) {
+                        let stateLabel = this.computeI18n(process, state.name, stateId);
+                        this.translateService.get(stateLabel).subscribe(translate => { stateLabel = translate; });
 
-                    statesArray.push({stateLabel: stateLabel, stateControlIndex: stateControlIndex});
-                    this.preparedListOfProcessesStates.push({
-                        processId: process.id,
-                        stateId: key});
-                    stateControlIndex++;
+                        states.push({stateId, stateLabel, stateControlIndex});
+                        this.preparedListOfProcessesStates.push({processId: process.id, stateId});
+                        stateControlIndex++;
+                    }
                 }
-                statesArray.sort((obj1, obj2) => this.compareObj(obj1.stateLabel, obj2.stateLabel));
-                this.processesStatesLabels.set(process.id, {processLabel: processLabel,
-                    states: statesArray});
+                if (states.length) {
+                    states.sort((obj1, obj2) => this.compareObj(obj1.stateLabel, obj2.stateLabel));
+                    this.processesStatesLabels.set(process.id, {processLabel, states});
+                }
             }
         }
+    }
+
+    computeI18n(process: Process, dataToFind: string, defaultValue: string): string {
+        return Utilities.getI18nPrefixFromProcess(process) + ((!! dataToFind) ? dataToFind : defaultValue);
+    }
+
+    /** cleaning of the two arrays : processGroupsAndLabels and processesWithoutGroup
+     * processGroupsAndLabels : we don't display process which doesn't have any state with Receive right
+     *                          and we don't display process group which doesn't have any process
+     * processesWithoutGroup : we don't display process which doesn't have any state with Receive right*/
+    private removeProcessesWithoutStatesWithReceiveRights() {
+        this.processGroupsAndLabels.forEach((processGroupData, index) => {
+            processGroupData.processes = processGroupData.processes.filter(processData => !! this.processesStatesLabels.get(processData.processId));
+            if (processGroupData.processes.length === 0)
+                this.processGroupsAndLabels.splice(index, 1);
+        });
+        this.processesWithoutGroup = this.processesWithoutGroup.filter(processData => !! this.processesStatesLabels.get(processData.idProcess));
     }
 
     private initForm() {
@@ -166,6 +180,7 @@ export class FeedconfigurationComponent implements OnInit {
     }
 
     ngOnInit() {
+        this.checkPerimeterForSearchFields = this.configService.getConfigValue('checkPerimeterForSearchFields', false);
         this.userService.currentUserWithPerimeters().subscribe(result => {
             this.currentUserWithPerimeters = result;
 
@@ -179,6 +194,8 @@ export class FeedconfigurationComponent implements OnInit {
             this.computePreparedListOfProcessesStatesAndProcessesStatesLabels();
             this.makeProcessesWithoutGroup();
             this.addCheckboxesInFormArray();
+            if (this.checkPerimeterForSearchFields)
+                this.removeProcessesWithoutStatesWithReceiveRights();
         });
     }
 

--- a/ui/main/src/app/modules/monitoring/components/monitoring-filters/monitoring-filters.component.html
+++ b/ui/main/src/app/modules/monitoring/components/monitoring-filters/monitoring-filters.component.html
@@ -28,7 +28,13 @@
                                  [dropdownSettings]="processDropdownSettings" [selectedItems]="[]" i18nRootLabelKey="monitoring.filters.">
                 </of-multi-filter>
             </div>
-            <div *ngIf="! displayProcessGroupsFilter()" style="margin-top: 28px;margin-right: 40px;position:relative; min-width:300px;max-width:400px;">
+            <div *ngIf="! displayProcessGroupsFilter() && isThereProcessGroup()" style="margin-top: 28px;margin-right: 40px;position:relative; min-width:300px;max-width:400px;">
+                <of-multi-filter filterPath="process" id="process"
+                                 [parentForm]="monitoringForm" [values]="processesDropdownListPerProcessGroups.get(processGroupDropdownList[0].id)"
+                                 [dropdownSettings]="processDropdownSettings" [selectedItems]="[]" i18nRootLabelKey="monitoring.filters.">
+                </of-multi-filter>
+            </div>
+            <div *ngIf="! displayProcessGroupsFilter() && ! isThereProcessGroup()" style="margin-top: 28px;margin-right: 40px;position:relative; min-width:300px;max-width:400px;">
                 <of-multi-filter filterPath="process" id="process"
                                  [parentForm]="monitoringForm" [values]="processDropdownList"
                                  [dropdownSettings]="processDropdownSettings" [selectedItems]="[]" i18nRootLabelKey="monitoring.filters.">

--- a/ui/main/src/app/modules/share/archives-logging-filters/archives-logging-filters.component.html
+++ b/ui/main/src/app/modules/share/archives-logging-filters/archives-logging-filters.component.html
@@ -30,13 +30,17 @@
 <!--Second column-->
 <div *ngIf="displayProcessGroupFilter() || tags" style="margin-right:40px">
     <div style="min-width:300px;max-width:400px;margin-top:28px;margin-bottom: 54px;">
-        <of-multi-filter [hidden]="displayProcessGroupFilter()" filterPath="process" id="process" [parentForm]="this.parentForm"
+        <of-multi-filter *ngIf="! isThereProcessGroup()" filterPath="process" id="process" [parentForm]="this.parentForm"
                          [values]="processDropdownList" [dropdownSettings]="processDropdownSettings" [selectedItems]="[]"
                          i18nRootLabelKey="filters.">
         </of-multi-filter>
-        <of-multi-filter [hidden]="! displayProcessGroupFilter()" filterPath="process" id="process" [parentForm]="this.parentForm"
+        <of-multi-filter *ngIf="displayProcessGroupFilter()" filterPath="process" id="process" [parentForm]="this.parentForm"
                          [values]="processDropdownListWhenSelectedProcessGroup" [dropdownSettings]="processDropdownSettings" [selectedItems]="[]"
                          i18nRootLabelKey="filters.">
+        </of-multi-filter>
+        <of-multi-filter *ngIf="!displayProcessGroupFilter() && isThereProcessGroup()" filterPath="process" id="process" [parentForm]="this.parentForm"
+                         [values]="processesDropdownListPerProcessGroups.get(processGroupDropdownList[0].id)"
+                         [dropdownSettings]="processDropdownSettings" [selectedItems]="[]" i18nRootLabelKey="filters.">
         </of-multi-filter>
     </div>
     <div style="min-width:300px;max-width:400px;">
@@ -50,9 +54,13 @@
 <!--Only one column in this case-->
 <div *ngIf="! displayProcessGroupFilter() && ! tags" style="margin-right:40px">
     <div style="min-width:300px;max-width:400px;margin-top:28px;margin-bottom: 54px;">
-        <of-multi-filter filterPath="process" id="process" [parentForm]="this.parentForm"
+        <of-multi-filter *ngIf="! isThereProcessGroup()" filterPath="process" id="process" [parentForm]="this.parentForm"
                          [values]="processDropdownList" [dropdownSettings]="processDropdownSettings" [selectedItems]="[]"
                          i18nRootLabelKey="filters.">
+        </of-multi-filter>
+        <of-multi-filter *ngIf="isThereProcessGroup()" filterPath="process" id="process" [parentForm]="this.parentForm"
+                         [values]="processesDropdownListPerProcessGroups.get(processGroupDropdownList[0].id)"
+                         [dropdownSettings]="processDropdownSettings" [selectedItems]="[]" i18nRootLabelKey="filters.">
         </of-multi-filter>
     </div>
     <div style="min-width:300px;max-width:400px;">

--- a/ui/main/src/app/services/processes.service.ts
+++ b/ui/main/src/app/services/processes.service.ts
@@ -269,22 +269,22 @@ export class ProcessesService {
         };
     }
 
-    public findProcessGroupForProcess(processId : string) : string {
-        for (let group of this.processGroups) {
-            if (group.processes.find(process => process == processId))
+    public findProcessGroupForProcess(processId: string): string {
+        for (const group of this.processGroups) {
+            if (group.processes.find(process => process === processId))
                 return group.id;
         }
         return '';
     }
 
     public getProcessesPerProcessGroups(): Map<any, any> {
-        let processesPerProcessGroups = new Map();
+        const processesPerProcessGroups = new Map();
 
         this.getAllProcesses().forEach(process => {
 
             const processGroupId = this.findProcessGroupForProcess(process.id);
-            if (processGroupId != '') {
-                let processes = (!! processesPerProcessGroups.get(processGroupId) ? processesPerProcessGroups.get(processGroupId) : []);
+            if (processGroupId !== '') {
+                const processes = (!! processesPerProcessGroups.get(processGroupId) ? processesPerProcessGroups.get(processGroupId) : []);
                 processes.push({id: process.id, itemName: process.name, i18nPrefix: `${process.id}.${process.version}`});
                 processesPerProcessGroups.set(processGroupId, processes);
             }
@@ -293,26 +293,26 @@ export class ProcessesService {
     }
 
     public getProcessesWithoutProcessGroup(): any[] {
-        let processesWithoutProcessGroup = [];
+        const processesWithoutProcessGroup = [];
 
         this.getAllProcesses().forEach(process => {
             const processGroupId = this.findProcessGroupForProcess(process.id);
-            if (processGroupId == '')
+            if (processGroupId === '')
                 processesWithoutProcessGroup.push({ id: process.id, itemName: process.name, i18nPrefix: `${process.id}.${process.version}` });
         });
         return processesWithoutProcessGroup;
     }
 
-    public findProcessGroupLabelForProcess(processId : string) : string {
+    public findProcessGroupLabelForProcess(processId: string): string {
         const processGroupId = this.findProcessGroupForProcess(processId);
-        return (!! processGroupId && processGroupId != '') ? processGroupId : "processGroup.defaultLabel";
+        return (!! processGroupId && processGroupId !== '') ? processGroupId : 'processGroup.defaultLabel';
     }
 
     private loadTypeOfStatesPerProcessAndState() {
         this.typeOfStatesPerProcessAndState = new Map();
 
-        for (let process of this.processes) {
-            for (let state in process.states)
+        for (const process of this.processes) {
+            for (const state in process.states)
                 this.typeOfStatesPerProcessAndState.set(process.id + '.' + state, process.states[state].type);
         }
     }


### PR DESCRIPTION
Release notes : 

In Features section : 

[OC-1639](https://opfab.atlassian.net/browse/OC-1639) : Use user perimeter to populate services/process/state list in archives/logging/monitoring/feedconfiguration

Tests performed : 

For notification configuration screen : 
- missing variable : no change for the screen : OK
- variable set to false : no change for the screen : OK
- variable set to true : 
         - only the states are present for which a Receive right is granted : OK
         - if I remove the userCardExamples3 perimeter from the Dispatcher group (to which operator1 belongs) then the process is not displayed at all : OK (if no more state present for a process then do not display the process)
         - if I delete the gridCooperation and question perimeters from the Dispatcher group then the process group is not displayed : OK (if no more process present for a process group then do not display the process group)


Same tests for archives/logging/monitoring screen. With and without process groups. 

