### PR TITLE
[OC-1681] Updating TSC voting members and authors

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -7,10 +7,12 @@ AlexGuironnetRTE
 bendaoudmba
 davidbinderRTE
 freddidierRTE
+geppyz
 HanaeSafiRTE
 jeandemanded
 JeroenGommans
 JulienBapt
+lucian-balea
 quinarygio
 rlg-pro
 rte-amal

--- a/src/docs/asciidoc/community/index.adoc
+++ b/src/docs/asciidoc/community/index.adoc
@@ -107,10 +107,10 @@ OperatorFabric TSC voting members are:
 * link:https://github.com/0x62646f727465[Boris Dolley]
 * link:https://github.com/AlexGuironnetRTE[Alexandra Guironnet]
 * link:https://github.com/vlo-rte[Valérie Longa]
-* link:https://github.com/HanaeSafiRTE[Hanae Safi]
+* Floris van der Meulen
 * link:https://github.com/gtrimbach-RTE[Guillaume Trimbach]
 
-Boris Dolley will chair the TSC, with Hanae Safi as his deputy.
+Boris Dolley will chair the TSC, with Alexandra Guironnet as his deputy.
 
 === Contributors
 


### PR DESCRIPTION
Changes to the TSC voting members have been validated by an online vote: https://lists.lfenergy.org/g/opfab-tsc/message/26

Nothing to mention on the release notes.