### PR TITLE
[OC-1684] Bug in usercard preview when displaying a lot of recipients

### DIFF
--- a/ui/main/src/app/modules/usercard/usercard.component.html
+++ b/ui/main/src/app/modules/usercard/usercard.component.html
@@ -107,9 +107,9 @@
             <div class="opfab-section-header">
                 <span translate>userCard.recipients</span>
             </div>
-            <div style="display: inline-flex;">
-                <div *ngFor="let entityId of card.entityRecipients">
-                    <span  style="text-align: center;">&nbsp; {{getEntityName(entityId)}} &nbsp; </span>
+            <div style="display: flex;flex-wrap: wrap;">
+                <div *ngFor="let entityId of card.entityRecipients" style="padding-right: 10px">
+                    <span>&nbsp; {{getEntityName(entityId)}} &nbsp; </span>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Release notes : 

In bugs section : 

[OC-1684](https://opfab.atlassian.net/browse/OC-1684) : Bug in usercard preview when displaying a lot of recipients


To have a lot of entities, I set these entities in users-dev.yml : 

entities:
   - id: ENTITY1
     name: Control Room 1
     description: Control Room 1
     parents : ["ALLCONTROLROOMS"]
   - id: ENTITY2
     name: Control Room 2
     description: Control Room 2
     parents : ["ALLCONTROLROOMS"]
   - id: ENTITY3
     name: Control Room 3
     description: Control Room 3
     parents : ["ALLCONTROLROOMS"]
   - id: ALLCONTROLROOMS
     name: All Control Rooms 
     description: All Control Rooms
     entityAllowedToSendCard: false
   - id: ENTITY4
     name: IT Supervision Center 
     description: IT Supervision Center
   - id: ENTITY5
     name: Control Room 5
     description: Control Room 5
     parents: ["ALLCONTROLROOMS"]
   - id: ENTITY6
     name: Control Room 6
     description: Control Room 6
     parents: ["ALLCONTROLROOMS"]
   - id: ENTITY7
     name: Control Room 7
     description: Control Room 7
     parents: ["ALLCONTROLROOMS"]
   - id: ENTITY8
     name: Centre Exploitation Toulouse
     description: Centre Exploitation Toulouse
     parents: ["ALLCONTROLROOMS"]
   - id: ENTITY9
     name: Centre Exploitation ST. Quentin En Yvelines
     description: Centre Exploitation ST. Quentin En Yvelines
     parents: ["ALLCONTROLROOMS"]
   - id: ENTITY10
     name: Centre Exploitation Lille
     description: Centre Exploitation Lille
     parents: ["ALLCONTROLROOMS"]
   - id: ENTITY11
     name: Centre Exploitation Lyon
     description: Control Room 11
     parents: ["ALLCONTROLROOMS"]
   - id: ENTITY12
     name: Centre Exploitation Marseille
     description: Control Room 12
     parents: ["ALLCONTROLROOMS"]
   - id: ENTITY13
     name: Centre Exploitation Nancy
     description: Control Room 13
     parents: ["ALLCONTROLROOMS"]
   - id: ENTITY14
     name: Centre Exploitation Nantes
     description: Control Room 14
     parents: ["ALLCONTROLROOMS"]
   - id: ENTITY15
     name: Centre Exploitation Nantes - Est
     description: Control Room 15
     parents: ["ALLCONTROLROOMS"]
   - id: ENTITY16
     name: Centre Exploitation Nantes - Planif
     description: Centre Exploitation Nantes - Planif
     parents: ["ALLCONTROLROOMS"]
   - id: ENTITY17
     name: Centre Exploitation Nantes - Sud
     description: Control Room 17
     parents: ["ALLCONTROLROOMS"]
   - id: ENTITY18
     name: Centre Exploitation Lille 18
     description: Centre Exploitation Lille 18
     parents: ["ALLCONTROLROOMS"]
   - id: ENTITY19
     name: Centre Exploitation Lyon
     description: Control Room 19
     parents: ["ALLCONTROLROOMS"]
   - id: ENTITY20
     name: Centre Exploitation Marseille
     description: Control Room 12
     parents: ["ALLCONTROLROOMS"]
   - id: ENTITY21
     name: Centre Exploitation Nancy
     description: Control Room 13
     parents: ["ALLCONTROLROOMS"]
   - id: ENTITY22
     name: Centre Exploitation Nantes
     description: Control Room 14
     parents: ["ALLCONTROLROOMS"]
   - id: ENTITY23
     name: Centre Exploitation Nantes - Est
     description: Control Room 15
     parents: ["ALLCONTROLROOMS"]
   - id: ENTITY24
     name: Centre Exploitation Nantes - Ouest
     description: Centre Exploitation Nantes - Planif
     parents: ["ALLCONTROLROOMS"]
   - id: ENTITY25
     name: Centre Exploitation Nantes - Sud
     description: Control Room 17
     parents: ["ALLCONTROLROOMS"]

