### PR TITLE
[OC-1715] Acknowledging a card shouldn't trigger sound

### DIFF
--- a/config/docker/web-ui-cypress.json
+++ b/config/docker/web-ui-cypress.json
@@ -30,6 +30,7 @@
         "display": "BUSINESS"
       },
       "hideAckFilter": false,
+      "hideAckAllCardsFeature": false,
       "secondsBeforeLttdForClockDisplay": 3700,
       "hideReadSort": false,
       "hideSeveritySort": false

--- a/services/core/cards-publication/src/main/modeling/swagger.yaml
+++ b/services/core/cards-publication/src/main/modeling/swagger.yaml
@@ -428,7 +428,7 @@ definitions:
           $ref: '#/definitions/TimeSpan'
       hasBeenAcknowledged:
         type: boolean
-        description: Is true if the card was acknoledged by current user
+        description: Is true if the card was acknowledged by current user
       hasBeenRead:
         type: boolean
         description: Is true if the card was read by current user  

--- a/src/test/api/karate/cards/cardsUserAcks.feature
+++ b/src/test/api/karate/cards/cardsUserAcks.feature
@@ -45,7 +45,7 @@ Feature: CardsUserAcknowledgement
     And def uid = response.card.uid
 
 
-#make an acknoledgement to the card with operator1
+#make an acknowledgement to the card with operator1
     Given url opfabUrl + 'cardspub/cards/userAcknowledgement/' + uid
     And header Authorization = 'Bearer ' + authToken
     And request ''
@@ -69,7 +69,7 @@ Feature: CardsUserAcknowledgement
     And match response.card.uid == uid
 
 
-#make a second acknoledgement to the card with operator2
+#make a second acknowledgement to the card with operator2
     Given url opfabUrl + 'cardspub/cards/userAcknowledgement/' + uid
     And header Authorization = 'Bearer ' + authToken2
     And request ''

--- a/src/test/api/karate/cards/userAcknowledgmentUpdateCheck.feature
+++ b/src/test/api/karate/cards/userAcknowledgmentUpdateCheck.feature
@@ -41,7 +41,7 @@ Feature: CardsUserAcknowledgementUpdateCheck
     And match response.card.hasBeenAcknowledged == false
     And def uid = response.card.uid
 
-#make an acknoledgement to the card with operator1
+#make an acknowledgement to the card with operator1
     Given url opfabUrl + 'cardspub/cards/userAcknowledgement/' + uid
     And header Authorization = 'Bearer ' + authToken
     And request ''

--- a/ui/main/src/app/modules/cards/components/detail/detail.component.ts
+++ b/ui/main/src/app/modules/cards/components/detail/detail.component.ts
@@ -390,8 +390,11 @@ export class DetailComponent implements OnChanges, OnInit, OnDestroy, AfterViewC
     updateAcknowledgementOnLightCard(hasBeenAcknowledged: boolean) {
         this.store.select(fetchLightCard(this.card.id)).pipe(take(1))
             .subscribe((lightCard: LightCard) => {
-                const updatedLighCard = {...lightCard, hasBeenAcknowledged: hasBeenAcknowledged};
-                this.store.dispatch(new UpdateALightCard({card: updatedLighCard}));
+                // If the card has been acknowledged, set it as read as well otherwise leave it as is.
+                // This is to prevent firing two updates, one for the ack and one for the read, which messed with sounds
+                const hasBeenRead = hasBeenAcknowledged ? true : lightCard.hasBeenRead;
+                const updatedLightCard = {...lightCard, hasBeenAcknowledged: hasBeenAcknowledged, hasBeenRead: hasBeenRead};
+                this.store.dispatch(new UpdateALightCard({card: updatedLightCard}));
             });
     }
 

--- a/ui/main/src/app/services/acknowledge.service.ts
+++ b/ui/main/src/app/services/acknowledge.service.ts
@@ -53,7 +53,10 @@ export class AcknowledgeService {
     }
 
     updateAcknowledgementOnLightCard(lightCard: LightCard, hasBeenAcknowledged: boolean) {
-        const updatedLightCard = {...lightCard, hasBeenAcknowledged: hasBeenAcknowledged};
+        // If the card has been acknowledged, set it as read as well otherwise leave it as is.
+        // This is to prevent firing two updates, one for the ack and one for the read, which messed with sounds
+        const hasBeenRead = hasBeenAcknowledged ? true : lightCard.hasBeenRead;
+        const updatedLightCard = {...lightCard, hasBeenAcknowledged: hasBeenAcknowledged, hasBeenRead: hasBeenRead};
         this.store.dispatch(new UpdateALightCard({card: updatedLightCard}));
     }
 


### PR DESCRIPTION
The issue is not a regression from this version (reproduced on version 2.4.0.RELEASE, but likely older than that).
It only happens on first acknowledgments, not unack or subsequent acks.
It happens with the acknowledge all feature as well.

The issue was due to a piece of code meant to trigger sound when reminders came up, which was targeted at update light card actions with hasBeenRead set to false.

The problem is that when a card is first acknowledged, a first update was sent with:
hasBeenAcknowledged: true
hasBeenRead: null 

(then the card was set to read by a second update triggered by the automatic closing of the card details).

The proposed solution is to set hasBeenRead to true in the lightcard update action for acknowledgement.

Tested:
- Acknowledging a single card doesn't trigger sound (but acknowledges the card as intended).
- Acknowledging all cards doesn't trigger any sound (but acknowledges the cards as intended).
- User card example with reminders still triggers sound when it is time for the reminder (even if it has been acknowledged before).


In release notes, under bugs section:

* OC-1715 : Acknowledging a card shouldn't trigger sound

