### PR TITLE
[OC-1695] Add authorized ip address settings in user administration screen

### DIFF
--- a/ui/main/src/app/model/user.model.ts
+++ b/ui/main/src/app/model/user.model.ts
@@ -16,6 +16,7 @@ export class User {
     readonly firstName: string,
     readonly lastName: string,
     readonly groups?: Array<string>,
-    readonly entities?: Array<string>
+    readonly entities?: Array<string>,
+    readonly authorizedIPAddresses?: Array<string>
 ) {}
 }

--- a/ui/main/src/app/modules/admin/components/editmodal/users/edit-user-modal.component.html
+++ b/ui/main/src/app/modules/admin/components/editmodal/users/edit-user-modal.component.html
@@ -56,6 +56,10 @@
                              i18nRootLabelKey="admin.input.user.">
             </of-multi-filter>
           </div>
+          <div class="opfab-input row">
+            <label for="authorizedIPAddresses" translate>admin.input.user.authorizedIPAddresses</label>
+            <input formControlName="authorizedIPAddresses" name="authorizedIPAddresses" id="authorizedIPAddresses" type="text">
+          </div>
         </div>
       </div>
     </form>

--- a/ui/main/src/app/modules/admin/components/editmodal/users/edit-user-modal.component.ts
+++ b/ui/main/src/app/modules/admin/components/editmodal/users/edit-user-modal.component.ts
@@ -53,7 +53,8 @@ export class EditUserModalComponent implements OnInit {
       firstName: new FormControl('', []),
       lastName: new FormControl('', []),
       groups: new FormControl([]),
-      entities: new FormControl([])
+      entities: new FormControl([]),
+      authorizedIPAddresses: new FormControl([])
     });
 
   }
@@ -65,6 +66,9 @@ export class EditUserModalComponent implements OnInit {
       const {login, firstName, lastName} = this.row;
       this.userForm.patchValue({login, firstName, lastName}, { onlySelf: false });
 
+      if (!!this.row.authorizedIPAddresses) {
+        this.userForm.patchValue({'authorizedIPAddresses' : this.row.authorizedIPAddresses.join(',')});
+      }
       // Otherwise, we use the selectedItems property of the of-multiselect component
       this.selectedGroups = this.row.groups;
       this.selectedEntities = this.row.entities;
@@ -98,6 +102,8 @@ export class EditUserModalComponent implements OnInit {
     this.cleanForm();
     this.groups.setValue(this.groups.value.map(group => group.id));
     this.entities.setValue(this.entities.value.map(entity => entity.id));
+    const ipList = this.authorizedIPAddresses.value.trim().length > 0 ? this.authorizedIPAddresses.value.split(',') : [];
+    this.authorizedIPAddresses.setValue(ipList.map(str => str.trim()));
     this.crudService.update(this.userForm.value).subscribe(() => {
       this.activeModal.close('Update button clicked on user modal');
       // We call the activeModal "close" method and not "dismiss" to indicate that the modal was closed because the
@@ -138,6 +144,11 @@ export class EditUserModalComponent implements OnInit {
   get entities() {
     return this.userForm.get('entities') as FormControl;
   }
+
+  get authorizedIPAddresses() {
+    return this.userForm.get('authorizedIPAddresses') as FormControl;
+  }
+
 
   dismissModal(reason: string): void {
     this.activeModal.dismiss(reason);

--- a/ui/main/src/assets/i18n/en.json
+++ b/ui/main/src/assets/i18n/en.json
@@ -321,6 +321,7 @@
         "firstName": "First name",
         "groups": "Groups",
         "entities": "Entities",
+        "authorizedIPAddresses": "Authorized IP addresses",
         "confirmDelete": "Do you really want to delete user",
         "add": "Add new user"
       },

--- a/ui/main/src/assets/i18n/fr.json
+++ b/ui/main/src/assets/i18n/fr.json
@@ -320,6 +320,7 @@
         "firstName": "Prénom",
         "groups": "Groupes",
         "entities": "Entités",
+        "authorizedIPAddresses": "Adresses IP autorisées",
         "confirmDelete": "Voulez-vous vraiment supprimer l'utilisateur",
         "add":"Ajouter un nouvel utilisateur"
       },


### PR DESCRIPTION
The ip addresses setting is handled as text input in modal form.  It is supposed to be a comma separated list of ip addresses and it is spitted into a string array before calling the api.

Release notes:

In Task section:
[OC-1695] Add authorized ip address settings in user administration screen

[OC-1695]: https://opfab.atlassian.net/browse/OC-1695