### PR TITLE
[OC-1728]  Acknowledging all cards shouldn't change their read status

### DIFF
--- a/ui/main/src/app/modules/cards/components/detail/detail.component.ts
+++ b/ui/main/src/app/modules/cards/components/detail/detail.component.ts
@@ -41,7 +41,7 @@ import {AppService, PageType} from '@ofServices/app.service';
 import {User} from '@ofModel/user.model';
 import {Map} from '@ofModel/map';
 import {userRight} from '@ofModel/userWithPerimeters.model';
-import {ClearLightCardSelection, UpdateALightCard} from '@ofStore/actions/light-card.actions';
+import {ClearLightCardSelection, UpdateALightCard, UpdateTrigger} from '@ofStore/actions/light-card.actions';
 import {UserService} from '@ofServices/user.service';
 import {EntitiesService} from '@ofServices/entities.service';
 import {NgbModal, NgbModalOptions, NgbModalRef} from '@ng-bootstrap/ng-bootstrap';
@@ -390,11 +390,8 @@ export class DetailComponent implements OnChanges, OnInit, OnDestroy, AfterViewC
     updateAcknowledgementOnLightCard(hasBeenAcknowledged: boolean) {
         this.store.select(fetchLightCard(this.card.id)).pipe(take(1))
             .subscribe((lightCard: LightCard) => {
-                // If the card has been acknowledged, set it as read as well otherwise leave it as is.
-                // This is to prevent firing two updates, one for the ack and one for the read, which messed with sounds
-                const hasBeenRead = hasBeenAcknowledged ? true : lightCard.hasBeenRead;
-                const updatedLightCard = {...lightCard, hasBeenAcknowledged: hasBeenAcknowledged, hasBeenRead: hasBeenRead};
-                this.store.dispatch(new UpdateALightCard({card: updatedLightCard}));
+                const updatedLighCard = {...lightCard, hasBeenAcknowledged: hasBeenAcknowledged};
+                this.store.dispatch(new UpdateALightCard({lightCard: updatedLighCard, updateTrigger: UpdateTrigger.ACKNOWLEDGEMENT}));
             });
     }
 
@@ -422,7 +419,7 @@ export class DetailComponent implements OnChanges, OnInit, OnDestroy, AfterViewC
             this.store.select(fetchLightCard(this.lastCardSetToReadButNotYetOnFeed.id)).pipe(take(1))
                 .subscribe((lightCard: LightCard) => {
                     const updatedLightCard = { ...lightCard, hasBeenRead: true };
-                    this.store.dispatch(new UpdateALightCard({ card: updatedLightCard }));
+                    this.store.dispatch(new UpdateALightCard({ lightCard: updatedLightCard, updateTrigger: UpdateTrigger.READ }));
                 });
             this.lastCardSetToReadButNotYetOnFeed = null;
         }

--- a/ui/main/src/app/services/acknowledge.service.ts
+++ b/ui/main/src/app/services/acknowledge.service.ts
@@ -13,7 +13,7 @@ import {AcknowledgmentAllowedEnum, Process} from '@ofModel/processes.model';
 import {Card} from '@ofModel/card.model';
 import {UserWithPerimeters} from '@ofModel/userWithPerimeters.model';
 import {LightCard} from '@ofModel/light-card.model';
-import {UpdateALightCard} from '@ofActions/light-card.actions';
+import {UpdateALightCard, UpdateTrigger} from '@ofActions/light-card.actions';
 import {Store} from '@ngrx/store';
 import {AppState} from '@ofStore/index';
 import {Observable} from 'rxjs';
@@ -53,11 +53,8 @@ export class AcknowledgeService {
     }
 
     updateAcknowledgementOnLightCard(lightCard: LightCard, hasBeenAcknowledged: boolean) {
-        // If the card has been acknowledged, set it as read as well otherwise leave it as is.
-        // This is to prevent firing two updates, one for the ack and one for the read, which messed with sounds
-        const hasBeenRead = hasBeenAcknowledged ? true : lightCard.hasBeenRead;
-        const updatedLightCard = {...lightCard, hasBeenAcknowledged: hasBeenAcknowledged, hasBeenRead: hasBeenRead};
-        this.store.dispatch(new UpdateALightCard({card: updatedLightCard}));
+        const updatedLightCard = {...lightCard, hasBeenAcknowledged: hasBeenAcknowledged};
+        this.store.dispatch(new UpdateALightCard({lightCard: updatedLightCard, updateTrigger: UpdateTrigger.ACKNOWLEDGEMENT}));
     }
 
     isAcknowledgmentAllowed(user: UserWithPerimeters, card: Card|LightCard, processDefinition: Process): boolean {

--- a/ui/main/src/app/services/reminder/reminder.service.ts
+++ b/ui/main/src/app/services/reminder/reminder.service.ts
@@ -8,17 +8,17 @@
  */
 
 
-import { Injectable } from '@angular/core';
-import { select, Store } from '@ngrx/store';
-import { LightCard } from '@ofModel/light-card.model';
-import { CardService } from '@ofServices/card.service';
-import { ProcessesService } from '@ofServices/processes.service';
-import { UpdateALightCard } from '@ofStore/actions/light-card.actions';
-import { AppState } from '@ofStore/index';
-import { fetchLightCard, selectLastCardLoaded } from '@ofStore/selectors/feed.selectors';
-import { take } from 'rxjs/operators';
-import { ReminderList } from './reminderList';
-import { AcknowledgeService } from '@ofServices/acknowledge.service';
+import {Injectable} from '@angular/core';
+import {select, Store} from '@ngrx/store';
+import {LightCard} from '@ofModel/light-card.model';
+import {CardService} from '@ofServices/card.service';
+import {ProcessesService} from '@ofServices/processes.service';
+import {UpdateALightCard, UpdateTrigger} from '@ofStore/actions/light-card.actions';
+import {AppState} from '@ofStore/index';
+import {fetchLightCard, selectLastCardLoaded} from '@ofStore/selectors/feed.selectors';
+import {take} from 'rxjs/operators';
+import {ReminderList} from './reminderList';
+import {AcknowledgeService} from '@ofServices/acknowledge.service';
 
 @Injectable()
 export class ReminderService {
@@ -74,7 +74,7 @@ export class ReminderService {
                     }
                     );
                     const updatedLightCard = { ...lightCard, hasBeenAcknowledged: false, hasBeenRead: false };
-                    this.store.dispatch(new UpdateALightCard({ card: updatedLightCard }));
+                    this.store.dispatch(new UpdateALightCard({ lightCard: updatedLightCard, updateTrigger: UpdateTrigger.REMINDER }));
                 } else { // the card has been deleted in this case
                     this.reminderList.removeAReminder(cardId);
                 }

--- a/ui/main/src/app/services/sound-notification.service.spec.ts
+++ b/ui/main/src/app/services/sound-notification.service.spec.ts
@@ -8,7 +8,7 @@
  */
 
 
-import { TestBed } from '@angular/core/testing';
+import {TestBed} from '@angular/core/testing';
 
 import { SoundNotificationService } from './sound-notification.service';
 import {StoreModule} from "@ngrx/store";
@@ -234,7 +234,7 @@ describe('SoundNotificationService', () => {
 
   /* For these tests, settings configuration property to true for all severities */
 
-  it('should not play sound if updated card is not visible', () => {
+  it('should not play sound if updated card is not visible, even if it is reminder', () => {
 
     configAllSeveritiesOn();
 
@@ -246,7 +246,7 @@ describe('SoundNotificationService', () => {
 
   });
 
-  it('should play sound if updated card is visible, even if it is not freshly published (', () => {
+  it('should play sound if updated card is reminder and is visible, even if it is not freshly published (', () => {
 
     configAllSeveritiesOn()
 

--- a/ui/main/src/app/services/sound-notification.service.spec.ts
+++ b/ui/main/src/app/services/sound-notification.service.spec.ts
@@ -1,4 +1,4 @@
-/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+/* Copyright (c) 2018-2021, RTE (http://www.rte-france.com)
  * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -15,6 +15,7 @@ import {StoreModule} from "@ngrx/store";
 import {appReducer,} from "@ofStore/index";
 import {getOneRandomLightCard} from "@tests/helpers";
 import {Severity} from "@ofModel/light-card.model";
+import {UpdateTrigger} from "@ofActions/light-card.actions";
 
 describe('SoundNotificationService', () => {
 
@@ -65,7 +66,9 @@ describe('SoundNotificationService', () => {
     expect(service).toBeTruthy();
   });
 
-  it('should play appropriate sound only if card is visible and freshly published and its severity is on', () => {
+  // ---- Tests for loaded cards ----
+
+  it('should play appropriate sound only if loaded card is visible and freshly published and its severity is on', () => {
 
     //Handles 1 Action and 1 Information, should play 1 Action sound
 
@@ -76,14 +79,14 @@ describe('SoundNotificationService', () => {
     const informationCard = getOneRandomLightCard({severity:Severity.INFORMATION, publishDate:today}); //This one shouldn't be notified
 
     expect(playSound).toHaveBeenCalledTimes(0);
-    service.handleCards(actionCard,[actionCard.id,informationCard.id]);
-    service.handleCards(informationCard,[actionCard.id,informationCard.id]);
+    service.handleLoadedCard(actionCard,[actionCard.id,informationCard.id]);
+    service.handleLoadedCard(informationCard,[actionCard.id,informationCard.id]);
     expect(playSound).toHaveBeenCalledTimes(1);
     expect(playSound).toHaveBeenCalledWith(service.actionSound);
 
   });
 
-  it('should play appropriate sound for all severities if card is visible and freshly published and all severities are on', () => {
+  it('should play appropriate sound for all severities if loaded card is visible and freshly published and all severities are on', () => {
 
     //Handles 1 card of each severity, should play all four sounds
 
@@ -96,10 +99,10 @@ describe('SoundNotificationService', () => {
     const informationCard = getOneRandomLightCard({severity:Severity.INFORMATION, publishDate:today});
 
     expect(playSound).toHaveBeenCalledTimes(0);
-    service.handleCards(alarmCard,[alarmCard.id, actionCard.id, compliantCard.id, informationCard.id]);
-    service.handleCards(actionCard,[alarmCard.id, actionCard.id, compliantCard.id, informationCard.id]);
-    service.handleCards(compliantCard,[alarmCard.id, actionCard.id, compliantCard.id, informationCard.id]);
-    service.handleCards(informationCard,[alarmCard.id, actionCard.id, compliantCard.id, informationCard.id]);
+    service.handleLoadedCard(alarmCard,[alarmCard.id, actionCard.id, compliantCard.id, informationCard.id]);
+    service.handleLoadedCard(actionCard,[alarmCard.id, actionCard.id, compliantCard.id, informationCard.id]);
+    service.handleLoadedCard(compliantCard,[alarmCard.id, actionCard.id, compliantCard.id, informationCard.id]);
+    service.handleLoadedCard(informationCard,[alarmCard.id, actionCard.id, compliantCard.id, informationCard.id]);
  
     expect(playSound).toHaveBeenCalledTimes(4);
     expect(playSound).toHaveBeenCalledWith(service.alarmSound);
@@ -109,55 +112,162 @@ describe('SoundNotificationService', () => {
 
   });
 
-  it('should not play sound if all severities are off even if card is visible and freshly published', () => {
+  it('should not play sound if all severities are off even if loaded card is visible and freshly published', () => {
 
     configAllSeveritiesOff();
 
     const today = new Date().getTime();
     const card = getOneRandomLightCard({publishDate:today});
 
-    service.handleCards(card,[card.id]);
+    service.handleLoadedCard(card,[card.id]);
     expect(playSound).not.toHaveBeenCalled();
 
   });
 
-  it('should not play sound if no configuration is made even if card is visible and freshly published', () => {
+  it('should not play sound if no configuration is made even if loaded card is visible and freshly published', () => {
 
     noConfig();
 
     const today = new Date().getTime();
     const card = getOneRandomLightCard({ publishDate: today});
 
-    service.handleCards(card,[card.id]);
+    service.handleLoadedCard(card,[card.id]);
     expect(playSound).not.toHaveBeenCalled();
 
   });
 
   /* For these tests, settings configuration property to true for all severities */
 
-  it('should not play sound if card is not visible (even if freshly published)', () => {
+  it('should not play sound if loaded card is not visible (even if freshly published)', () => {
 
     configAllSeveritiesOn();
 
     const today = new Date().getTime();
     const card = getOneRandomLightCard({ publishDate: today});
 
-    service.handleCards(card,[]);
+    service.handleLoadedCard(card,[]);
     expect(playSound).not.toHaveBeenCalled();
 
   });
 
-  it('should not play sound if card is not freshly published (even if visible)', () => {
+  it('should not play sound if loaded card is not freshly published (even if visible)', () => {
 
     configAllSeveritiesOn()
 
     const past = new Date().getTime() - service.recentThreshold * 10; //PublishDate that is way past the recent threshold
     const card = getOneRandomLightCard({ publishDate: past});
 
-    service.handleCards(card,[card.id]);
+    service.handleLoadedCard(card,[card.id]);
     expect(playSound).not.toHaveBeenCalled();
 
   });
 
+  // ---- Tests for updated cards ----
+
+  it('should play appropriate sound only if updated card is a reminder, is visible and its severity is on', () => {
+
+    //Handles 1 Action and 1 Information, should play 1 Action sound
+
+    configOnlyActionOn();
+
+    const today = new Date().getTime();
+    const actionCard = getOneRandomLightCard({severity:Severity.ACTION, publishDate:today});
+    const informationCard = getOneRandomLightCard({severity:Severity.INFORMATION, publishDate:today}); //This one shouldn't be notified
+
+    expect(playSound).toHaveBeenCalledTimes(0);
+    service.handleUpdatedCard(actionCard,UpdateTrigger.REMINDER, [actionCard.id,informationCard.id]);
+    service.handleUpdatedCard(informationCard,UpdateTrigger.REMINDER,[actionCard.id,informationCard.id]);
+    expect(playSound).toHaveBeenCalledTimes(1);
+    expect(playSound).toHaveBeenCalledWith(service.actionSound);
+
+  });
+
+  it('should play appropriate sound for all severities if updated card is a reminder, is visible and all severities are on', () => {
+
+    //Handles 1 card of each severity, should play all four sounds
+
+    configAllSeveritiesOn();
+
+    const today = new Date().getTime();
+    const alarmCard = getOneRandomLightCard({severity:Severity.ALARM, publishDate:today});
+    const actionCard = getOneRandomLightCard({severity:Severity.ACTION, publishDate:today});
+    const compliantCard = getOneRandomLightCard({severity:Severity.COMPLIANT, publishDate:today});
+    const informationCard = getOneRandomLightCard({severity:Severity.INFORMATION, publishDate:today});
+
+    expect(playSound).toHaveBeenCalledTimes(0);
+    service.handleUpdatedCard(alarmCard,UpdateTrigger.REMINDER,[alarmCard.id, actionCard.id, compliantCard.id, informationCard.id]);
+    service.handleUpdatedCard(actionCard,UpdateTrigger.REMINDER,[alarmCard.id, actionCard.id, compliantCard.id, informationCard.id]);
+    service.handleUpdatedCard(compliantCard,UpdateTrigger.REMINDER,[alarmCard.id, actionCard.id, compliantCard.id, informationCard.id]);
+    service.handleUpdatedCard(informationCard,UpdateTrigger.REMINDER,[alarmCard.id, actionCard.id, compliantCard.id, informationCard.id]);
+
+    expect(playSound).toHaveBeenCalledTimes(4);
+    expect(playSound).toHaveBeenCalledWith(service.alarmSound);
+    expect(playSound).toHaveBeenCalledWith(service.actionSound);
+    expect(playSound).toHaveBeenCalledWith(service.compliantSound);
+    expect(playSound).toHaveBeenCalledWith(service.informationSound);
+
+  });
+
+  it('should not play sound if all severities are off even if updated card is a reminder and is visible', () => {
+
+    configAllSeveritiesOff();
+
+    const today = new Date().getTime();
+    const card = getOneRandomLightCard({publishDate:today});
+
+    service.handleUpdatedCard(card,UpdateTrigger.REMINDER,[card.id]);
+    expect(playSound).not.toHaveBeenCalled();
+
+  });
+
+  it('should not play sound if no configuration is made even if updated card is a reminder and is visible', () => {
+
+    noConfig();
+
+    const today = new Date().getTime();
+    const card = getOneRandomLightCard({ publishDate: today});
+
+    service.handleUpdatedCard(card,UpdateTrigger.REMINDER,[card.id]);
+    expect(playSound).not.toHaveBeenCalled();
+
+  });
+
+  /* For these tests, settings configuration property to true for all severities */
+
+  it('should not play sound if updated card is not visible', () => {
+
+    configAllSeveritiesOn();
+
+    const today = new Date().getTime();
+    const card = getOneRandomLightCard({ publishDate: today});
+
+    service.handleUpdatedCard(card,UpdateTrigger.REMINDER,[]);
+    expect(playSound).not.toHaveBeenCalled();
+
+  });
+
+  it('should play sound if updated card is visible, even if it is not freshly published (', () => {
+
+    configAllSeveritiesOn()
+
+    const past = new Date().getTime() - service.recentThreshold * 10; //PublishDate that is way past the recent threshold
+    const card = getOneRandomLightCard({ publishDate: past});
+
+    service.handleUpdatedCard(card,UpdateTrigger.REMINDER,[card.id]);
+    expect(playSound).toHaveBeenCalled();
+
+  });
+
+  it('should not play sound if updated card is not a reminder, even if it is visible (', () => {
+
+    configAllSeveritiesOn()
+
+    const past = new Date().getTime() - service.recentThreshold * 10; //PublishDate that is way past the recent threshold
+    const card = getOneRandomLightCard({ publishDate: past});
+
+    service.handleUpdatedCard(card,UpdateTrigger.ACKNOWLEDGEMENT,[card.id]);
+    expect(playSound).not.toHaveBeenCalled();
+
+  });
 
 });

--- a/ui/main/src/app/services/sound-notification.service.ts
+++ b/ui/main/src/app/services/sound-notification.service.ts
@@ -14,7 +14,7 @@ import {LightCard, Severity} from "@ofModel/light-card.model";
 import {Store} from "@ngrx/store";
 import {AppState} from "@ofStore/index";
 import {buildSettingsOrConfigSelector} from "@ofSelectors/settings.x.config.selectors";
-import {LoadLightParentCard, UpdateALightCard, UpdateTrigger} from "@ofActions/light-card.actions";
+import {UpdateTrigger} from "@ofActions/light-card.actions";
 
 @Injectable()
 export class SoundNotificationService {

--- a/ui/main/src/app/services/sound-notification.service.ts
+++ b/ui/main/src/app/services/sound-notification.service.ts
@@ -1,4 +1,4 @@
-/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+/* Copyright (c) 2018-2021, RTE (http://www.rte-france.com)
  * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -8,13 +8,13 @@
  */
 
 
-
 import {Injectable} from '@angular/core';
 import {PlatformLocation} from "@angular/common";
 import {LightCard, Severity} from "@ofModel/light-card.model";
 import {Store} from "@ngrx/store";
 import {AppState} from "@ofStore/index";
 import {buildSettingsOrConfigSelector} from "@ofSelectors/settings.x.config.selectors";
+import {LoadLightParentCard, UpdateALightCard, UpdateTrigger} from "@ofActions/light-card.actions";
 
 @Injectable()
 export class SoundNotificationService {
@@ -59,11 +59,20 @@ export class SoundNotificationService {
 
   }
 
-  handleCards(card: LightCard, currentlyVisibleIds: string[]) {
-              // Check whether card has just been published and whether it is currently visible in the feed
-          if (((new Date().getTime() - card.publishDate) <= this.recentThreshold) && (currentlyVisibleIds.includes(card.id))) {
-            this.playSoundForCard(card);
-          }
+  handleUpdatedCard(card: LightCard , updateTrigger: UpdateTrigger, currentlyVisibleIds: string[]) {
+    if(this.checkCardIsVisibleInFeed(card,currentlyVisibleIds) && updateTrigger === UpdateTrigger.REMINDER) this.playSoundForCard(card);
+  }
+
+  handleLoadedCard(card: LightCard , currentlyVisibleIds: string[]) {
+    if(this.checkCardIsVisibleInFeed(card,currentlyVisibleIds) && this.checkCardIsRecent(card)) this.playSoundForCard(card);
+  }
+
+  private checkCardIsVisibleInFeed (card: LightCard, currentlyVisibleIds: string[]) : boolean {
+    return currentlyVisibleIds.includes(card.id);
+  }
+
+  private checkCardIsRecent (card: LightCard) : boolean {
+    return ((new Date().getTime() - card.publishDate) <= this.recentThreshold);
   }
 
   playSoundForCard(card: LightCard) {
@@ -100,7 +109,7 @@ export class SoundNotificationService {
   playSound(sound: HTMLAudioElement) {
     sound.play().catch(error => {
       console.log(new Date().toISOString(),
-              `Notification sound wasn't played because the user hasn't interacted with the app yet (autoplay policy).`);
+          `Notification sound wasn't played because the user hasn't interacted with the app yet (autoplay policy).`);
       /* This is to handle the exception thrown due to the autoplay policy on Chrome. See https://goo.gl/xX8pDD */
     });
   }

--- a/ui/main/src/app/store/actions/light-card.actions.ts
+++ b/ui/main/src/app/store/actions/light-card.actions.ts
@@ -72,8 +72,10 @@ export class RemoveLightCard implements Action {
 
 export class UpdateALightCard implements Action {
     readonly type = LightCardActionTypes.UpdateALightCard;
-    constructor(public payload: { card: LightCard }) {
+    constructor(public payload: { lightCard: LightCard, updateTrigger: UpdateTrigger}) {
     }
+    //The updateTrigger property is used to indicate what triggered the update of the card, so some effects can be
+    //adapted accordingly (sound notifications for example).
 }
 
 export class LightCardAlreadyUpdated implements Action {
@@ -91,3 +93,9 @@ export type LightCardActions =
     | UpdateALightCard
     | LightCardAlreadyUpdated
     | RemoveLightCard;
+
+export enum UpdateTrigger {
+    READ = 'READ',
+    ACKNOWLEDGEMENT = 'ACKNOWLEDGEMENT',
+    REMINDER = 'REMINDER'
+}

--- a/ui/main/src/app/store/effects/card-operation.effects.ts
+++ b/ui/main/src/app/store/effects/card-operation.effects.ts
@@ -30,8 +30,6 @@ import {SoundNotificationService} from '@ofServices/sound-notification.service';
 import {selectLightCardsState, selectSortedFilterLightCardIds} from '@ofSelectors/feed.selectors';
 import {LightCard} from '@ofModel/light-card.model';
 import {UserService} from '@ofServices/user.service';
-import {CardsSubscriptionActionTypes} from "@ofActions/cards-subscription.actions";
-
 
 @Injectable()
 export class CardOperationEffects {

--- a/ui/main/src/app/store/reducers/light-card.reducer.ts
+++ b/ui/main/src/app/store/reducers/light-card.reducer.ts
@@ -116,7 +116,7 @@ export function reducer(
             };
         }
         case LightCardActionTypes.UpdateALightCard: {
-            return LightCardAdapter.upsertOne(action.payload.card, state);
+            return LightCardAdapter.upsertOne(action.payload.lightCard, state);
         }
 
         case FeedActionTypes.ApplySeveralFilters: {


### PR DESCRIPTION
I reverted the fix I made in OC-1715 so updates triggered by acknowledgement (either single card using the button or all card with the ack all feature) no longer set the card to hasBeenRead = true.
In the case of the single card ack, the ack button triggers a closing of the details which in turns triggers an update of the card with hasBeenRead = true, and which is also propagated to the back.
In the case of the ack all features however, no changes are made to the hasBeenRead property of the card, so the user can tell which card he/she has actually read.

Tests (on 4200 chrome, with cypress-flavoured docker):
- Incoming cards (with send6cards) trigger sounds
- Ack all or single card ack don't trigger sounds
- Ack all sets all cards to acknowledged but read cards stay read and unread stay unread
- Reminders do trigger sounds (even if the original card had been read and/or acknowledged)
- No sounds are triggered for cards that are not visible in the feed (for example because of filter on severity or ack). This stands for all types of cards : new cards, new responses, reminders, etc. 

In release notes, under bug section: 

* OC-1728 : Acknowledging all cards shouldn't change their read status
