### PR TITLE
OC-1701 Set indexes in mongoDB

### DIFF
--- a/services/core/cards-consultation/src/main/java/org/opfab/cards/consultation/model/ArchivedCardConsultationData.java
+++ b/services/core/cards-consultation/src/main/java/org/opfab/cards/consultation/model/ArchivedCardConsultationData.java
@@ -71,8 +71,6 @@ public class ArchivedCardConsultationData implements Card {
     private List<String> tags;
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private Object data;
-    @Indexed
-    private int shardKey;
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     @Singular
     private List<String> userRecipients;

--- a/services/core/cards-consultation/src/main/java/org/opfab/cards/consultation/model/ArchivedCardConsultationData.java
+++ b/services/core/cards-consultation/src/main/java/org/opfab/cards/consultation/model/ArchivedCardConsultationData.java
@@ -18,7 +18,6 @@ import org.opfab.cards.model.SeverityEnum;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.annotation.Transient;
-import org.springframework.data.mongodb.core.index.Indexed;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 import java.time.Instant;
@@ -58,9 +57,8 @@ public class ArchivedCardConsultationData implements Card {
     @CreatedDate
     private Instant publishDate;
     private Instant lttd;
-    @Indexed
+
     private Instant startDate;
-    @Indexed
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private Instant endDate;
     @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -78,13 +76,10 @@ public class ArchivedCardConsultationData implements Card {
     @Singular
     private List<String> groupRecipients;
     @Singular
-    @Indexed
     private List<String> entityRecipients;
     @Singular("entityAllowedToRespond")
-    @Indexed
     private List<String> entitiesAllowedToRespond;
     @Singular("entityRequiredToRespond")
-    @Indexed
     private List<String> entitiesRequiredToRespond;
     @Singular
     private List<String> externalRecipients;

--- a/services/core/cards-consultation/src/main/java/org/opfab/cards/consultation/model/CardConsultationData.java
+++ b/services/core/cards-consultation/src/main/java/org/opfab/cards/consultation/model/CardConsultationData.java
@@ -18,7 +18,6 @@ import org.opfab.cards.model.SeverityEnum;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.annotation.Transient;
-import org.springframework.data.mongodb.core.index.Indexed;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 import java.time.Instant;
@@ -58,9 +57,7 @@ public class CardConsultationData implements Card {
     @CreatedDate
     private Instant publishDate;
     private Instant lttd;
-    @Indexed
     private Instant startDate;
-    @Indexed
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private Instant endDate;
     @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -79,13 +76,10 @@ public class CardConsultationData implements Card {
     @Singular
     private List<String> groupRecipients;
     @Singular
-    @Indexed
     private List<String> entityRecipients;
     @Singular("entityAllowedToRespond")
-    @Indexed
     private List<String> entitiesAllowedToRespond;
     @Singular("entityRequiredToRespond")
-    @Indexed
     private List<String> entitiesRequiredToRespond;
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     @Singular

--- a/services/core/cards-consultation/src/main/java/org/opfab/cards/consultation/model/CardConsultationData.java
+++ b/services/core/cards-consultation/src/main/java/org/opfab/cards/consultation/model/CardConsultationData.java
@@ -72,8 +72,6 @@ public class CardConsultationData implements Card {
     
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private Object data;
-    @Indexed
-    private int shardKey;
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     @Singular
     private List<String> userRecipients;

--- a/services/core/cards-consultation/src/test/java/org/opfab/cards/consultation/TestUtilities.java
+++ b/services/core/cards-consultation/src/test/java/org/opfab/cards/consultation/TestUtilities.java
@@ -131,7 +131,6 @@ public class TestUtilities {
         card.setUid(UUID.randomUUID().toString());
         card.setPublishDate(publishDate);
         card.setId(card.getProcess() + "." + card.getProcessInstanceId());
-        card.setShardKey(Math.toIntExact(card.getStartDate().toEpochMilli() % 24 * 1000));
     }
 
 
@@ -180,7 +179,6 @@ public class TestUtilities {
     public static void prepareArchivedCard(ArchivedCardConsultationData archivedCard, Instant publishDate) {
         archivedCard.setId(UUID.randomUUID().toString());
         archivedCard.setPublishDate(publishDate);
-        archivedCard.setShardKey(Math.toIntExact(archivedCard.getStartDate().toEpochMilli() % 24 * 1000));
     }
 
     public static boolean checkIfCardActiveInRange(LightCard card, Instant rangeStart, Instant rangeEnd) {

--- a/services/core/cards-consultation/src/test/java/org/opfab/cards/consultation/controllers/CardOperationsControllerShould.java
+++ b/services/core/cards-consultation/src/test/java/org/opfab/cards/consultation/controllers/CardOperationsControllerShould.java
@@ -38,6 +38,7 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -200,45 +201,40 @@ public class CardOperationsControllerShould {
                         .rangeEnd(nowPlusThree)
                         .notification(false).build()
         ));
-        StepVerifier.FirstStep<CardOperation> verifier = StepVerifier.create(publisher.map(s -> TestUtilities.readCardOperation(mapper, s)).doOnNext(TestUtilities::logCardOperation));
-        verifier
-                .assertNext(op->{
+        HashMap<String,CardOperation> results = new HashMap<String,CardOperation>();
+        StepVerifier.FirstStep<CardOperation> verifier = StepVerifier
+                        .create(publisher.map(s -> TestUtilities.readCardOperation(mapper, s))
+                                        .doOnNext(TestUtilities::logCardOperation));
+        for (int i = 0; i < 7; i++)
+                verifier.assertNext(op -> {
                         assertThat(op.getCard()).isNotNull();
-                        assertThat(op.getCard().getId()).isEqualTo("PROCESS.PROCESS2");
-                        assertThat(op.getPublishDate()).isEqualTo(nowMinusThree);
-                })
-                .assertNext(op->{
-                        assertThat(op.getCard()).isNotNull();
-                        assertThat(op.getCard().getId()).isEqualTo("PROCESS.PROCESS3");
-                        assertThat(op.getPublishDate()).isEqualTo(nowPlusOne);
-                })
-                .assertNext(op->{
-                        assertThat(op.getCard()).isNotNull();
-                        assertThat(op.getCard().getId()).isEqualTo("PROCESS.PROCESS4");
-                        assertThat(op.getPublishDate()).isEqualTo(nowMinusThree);
-                })
-                .assertNext(op->{
-                        assertThat(op.getCard()).isNotNull();
-                        assertThat(op.getCard().getId()).isEqualTo("PROCESS.PROCESS5");
-                        assertThat(op.getPublishDate()).isEqualTo(nowMinusThree);
-                })
-                .assertNext(op->{
-                        assertThat(op.getCard()).isNotNull();
-                        assertThat(op.getCard().getId()).isEqualTo("PROCESS.PROCESS6");
-                        assertThat(op.getPublishDate()).isEqualTo(nowMinusThree);
-                })
-                .assertNext(op->{
-                        assertThat(op.getCard()).isNotNull();
-                        assertThat(op.getCard().getId()).isEqualTo("PROCESS.PROCESS8");
-                        assertThat(op.getPublishDate()).isEqualTo(nowMinusThree);
-                })
-                .assertNext(op->{
-                        assertThat(op.getCard()).isNotNull();
-                        assertThat(op.getCard().getId()).isEqualTo("PROCESS.PROCESS10");
-                        assertThat(op.getPublishDate()).isEqualTo(nowPlusOne);
-                })
-                .expectComplete()
-                .verify();
+                        results.put(op.getCard().getProcessInstanceId(), op);
+                });
+        verifier.expectComplete().verify();
+
+        CardOperation card2 = (CardOperation) results.get("PROCESS2");
+        CardOperation card3 = (CardOperation) results.get("PROCESS3");
+        CardOperation card4 = (CardOperation) results.get("PROCESS4");
+        CardOperation card5 = (CardOperation) results.get("PROCESS5");
+        CardOperation card6 = (CardOperation) results.get("PROCESS6");
+        CardOperation card8 = (CardOperation) results.get("PROCESS8");
+        CardOperation card10 = (CardOperation) results.get("PROCESS10");
+
+        assertThat(card2.getCard().getId()).isEqualTo("PROCESS.PROCESS2");
+        assertThat(card2.getPublishDate()).isEqualTo(nowMinusThree);
+        assertThat(card3.getCard().getId()).isEqualTo("PROCESS.PROCESS3");
+        assertThat(card3.getPublishDate()).isEqualTo(nowPlusOne);
+        assertThat(card4.getCard().getId()).isEqualTo("PROCESS.PROCESS4");
+        assertThat(card4.getPublishDate()).isEqualTo(nowMinusThree);
+        assertThat(card5.getCard().getId()).isEqualTo("PROCESS.PROCESS5");
+        assertThat(card5.getPublishDate()).isEqualTo(nowMinusThree);
+        assertThat(card6.getCard().getId()).isEqualTo("PROCESS.PROCESS6");
+        assertThat(card6.getPublishDate()).isEqualTo(nowMinusThree);
+        assertThat(card8.getCard().getId()).isEqualTo("PROCESS.PROCESS8");
+        assertThat(card8.getPublishDate()).isEqualTo(nowMinusThree);
+        assertThat(card10.getCard().getId()).isEqualTo("PROCESS.PROCESS10");
+        assertThat(card10.getPublishDate()).isEqualTo(nowPlusOne);
+
     }
 
     @Test

--- a/services/core/cards-consultation/src/test/java/org/opfab/cards/consultation/repositories/CardRepositoryShould.java
+++ b/services/core/cards-consultation/src/test/java/org/opfab/cards/consultation/repositories/CardRepositoryShould.java
@@ -34,6 +34,7 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.function.Predicate;
 
@@ -226,19 +227,24 @@ public class CardRepositoryShould {
         persistCard(createSimpleCard("2", now, nowMinusOne, null, LOGIN, null,null));
         persistCard(createSimpleCard("3", now, nowPlusOne, null, LOGIN,null,null));
 
+        HashMap<String,CardOperation> results = new HashMap<String,CardOperation>();
         StepVerifier.create(repository.getCardOperations(null, now,nowPlusTwo, adminUser)
                 .doOnNext(TestUtilities::logCardOperation))
                 .assertNext(op -> {
                     assertThat(op.getCard()).isNotNull();
-                    assertCard(op,"PROCESS.PROCESS1", "PUBLISHER", "0");
+                    results.put(op.getCard().getProcessInstanceId(), op);
                 })
                 .assertNext(op -> {
                     assertThat(op.getCard()).isNotNull();
-                    assertCard(op,"PROCESS.PROCESS3", "PUBLISHER", "0");
+                    results.put(op.getCard().getProcessInstanceId(), op);
                 })
                 .expectComplete()
                 .verify();
-       
+       CardOperation card1 = (CardOperation) results.get("PROCESS1");
+       CardOperation card2 = (CardOperation) results.get("PROCESS3");
+       assertCard(card1, "PROCESS.PROCESS1", "PUBLISHER", "0");
+       assertCard(card2, "PROCESS.PROCESS3", "PUBLISHER", "0");
+
     }
     
     @Test

--- a/services/core/cards-publication/src/main/java/org/opfab/cards/publication/model/ArchivedCardPublicationData.java
+++ b/services/core/cards-publication/src/main/java/org/opfab/cards/publication/model/ArchivedCardPublicationData.java
@@ -45,14 +45,19 @@ public class ArchivedCardPublicationData implements Card {
     private Boolean keepChildCards = false;
     private String publisher;
     private String processVersion;
+
+    @Indexed
     private String process;
     
     private String processInstanceId;
+    
+    @Indexed
     private String state;
     private I18n title;
     private I18n summary;
 
     @CreatedDate
+    @Indexed
     private Instant publishDate;
     private Instant lttd;
 
@@ -62,18 +67,27 @@ public class ArchivedCardPublicationData implements Card {
     @Indexed
     private Instant endDate;
     private SeverityEnum severity;
+    @Indexed
     private List<String> tags;
     private Object data;
 
+    @Indexed
     private List<String> userRecipients;
+    
+    @Indexed
     private List<String> groupRecipients;
+    
     @Transient
     private List<? extends TimeSpan> timeSpans;
+    
     @Indexed
     private List<String> entityRecipients;
+    
     private List<String> externalRecipients;
+    
     @Singular("entityAllowedToRespond")
     private List<String> entitiesAllowedToRespond;
+    
     @Singular("entitiyRequiredToRespond")
     private List<String> entitiesRequiredToRespond;
 

--- a/services/core/cards-publication/src/main/java/org/opfab/cards/publication/model/ArchivedCardPublicationData.java
+++ b/services/core/cards-publication/src/main/java/org/opfab/cards/publication/model/ArchivedCardPublicationData.java
@@ -64,8 +64,7 @@ public class ArchivedCardPublicationData implements Card {
     private SeverityEnum severity;
     private List<String> tags;
     private Object data;
-    @Indexed
-    private int shardKey;
+
     private List<String> userRecipients;
     private List<String> groupRecipients;
     @Transient
@@ -105,7 +104,6 @@ public class ArchivedCardPublicationData implements Card {
         this.processInstanceId = card.getProcessInstanceId();
         this.state = card.getState();
         this.startDate = card.getStartDate();
-        this.shardKey = card.getShardKey();
         this.endDate = card.getEndDate();
         this.lttd = card.getLttd();
         this.title = card.getTitle();

--- a/services/core/cards-publication/src/main/java/org/opfab/cards/publication/model/CardPublicationData.java
+++ b/services/core/cards-publication/src/main/java/org/opfab/cards/publication/model/CardPublicationData.java
@@ -18,7 +18,6 @@ import org.opfab.cards.model.SeverityEnum;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.annotation.Transient;
-import org.springframework.data.mongodb.core.index.CompoundIndex;
 import org.springframework.data.mongodb.core.index.Indexed;
 import org.springframework.data.mongodb.core.mapping.Document;
 
@@ -41,7 +40,7 @@ import java.util.UUID;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-@CompoundIndex(name = "process_state", def = "{'process' : 1, 'state' : 1}")
+
 public class CardPublicationData implements Card {
 
     @Builder.Default
@@ -91,21 +90,20 @@ public class CardPublicationData implements Card {
     private Object data;
     @Singular
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    @Indexed
     private List<String> userRecipients;
     @Singular
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    @Indexed
     private List<String> groupRecipients;
     @Singular("entityAllowedToRespond")
-    @Indexed
     private List<String> entitiesAllowedToRespond;
     @Singular("entityRequiredToRespond")
-    @Indexed
     private List<String> entitiesRequiredToRespond;
     @Singular
     @Indexed
     private List<String> entityRecipients;
     @Singular
-    @Indexed
     private List<String> externalRecipients;
     @JsonIgnore
     private List<String> usersAcks;

--- a/services/core/cards-publication/src/main/java/org/opfab/cards/publication/model/CardPublicationData.java
+++ b/services/core/cards-publication/src/main/java/org/opfab/cards/publication/model/CardPublicationData.java
@@ -89,8 +89,6 @@ public class CardPublicationData implements Card {
     private List<? extends TimeSpan> timeSpans;
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private Object data;
-    @Indexed
-    private int shardKey;
     @Singular
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     private List<String> userRecipients;
@@ -133,7 +131,6 @@ public class CardPublicationData implements Card {
         this.id = process + "." + processInstanceId;
         if (null == this.uid)
         	this.uid = UUID.randomUUID().toString();
-        this.setShardKey(Math.toIntExact(this.getStartDate().toEpochMilli() % 24 * 1000));
         this.processStateKey = process + "." + state;
     }
 

--- a/services/core/cards-publication/src/test/java/org/opfab/cards/publication/services/CardProcessServiceShould.java
+++ b/services/core/cards-publication/src/test/java/org/opfab/cards/publication/services/CardProcessServiceShould.java
@@ -516,7 +516,6 @@ class CardProcessServiceShould {
                 .dateRange(today, tomorrow).stringLengthRange(5, 50).collectionSizeRange(1, 10)
                 .excludeField(named("data"))
                 .excludeField(named("parameters"))
-                .excludeField(named("shardKey"))
                 .scanClasspathForConcreteTypes(true).overrideDefaultInitialization(false)
                 .ignoreRandomizationErrors(true);
 

--- a/tools/spring/spring-mongo-utilities/src/main/java/org/opfab/springtools/configuration/mongo/MongoConfiguration.java
+++ b/tools/spring/spring-mongo-utilities/src/main/java/org/opfab/springtools/configuration/mongo/MongoConfiguration.java
@@ -201,4 +201,9 @@ public class MongoConfiguration extends AbstractReactiveMongoConfiguration {
 
         return converter;
     }
+
+    @Override
+    protected boolean autoIndexCreation() {
+        return true;
+    }
 }


### PR DESCRIPTION
Indexes are set in two collections : cards and archivedCards

They are set on fields:
- used in requests made by the ui to search cards : startDate, endDate,...
- used to search for cards visibles for the current user (entityRecipients, userRecipients, groupRecipients and processStateKey)

They are defined in two classes using @Index annotation: CardPublicationData and ArchivesCardPublicationData

The automatic creation of the indexes has to be set to true (see tools/spring/spring-mongo-utilities/src/main/java/org/opfab/springtools/configuration/mongo/MongoConfiguration.java)
This was not the case in previous versions of mongoDB Java drive

In release note : 

Tasks : 

OC-1701 : Set indexes in mongoDB