### PR TITLE
[OC-1736] BUG when child card received before parent card

### DIFF
--- a/src/test/cypress/cypress/integration/ResponseCard.spec.js
+++ b/src/test/cypress/cypress/integration/ResponseCard.spec.js
@@ -52,7 +52,10 @@ describe ('Response card tests',function () {
          
         // See in the feed the fact that user has respond (icon)
         cy.get('#opfab-feed-lightcard-hasChildCardFromCurrentUserEntity');
-    })
+    });
+
+
+
 
     it('Check card response for operator 2 ', function () {
 
@@ -112,4 +115,39 @@ describe ('Response card tests',function () {
         cy.get('#opfab-card-details-btn-response').should('not.exist');
         
     })
+
+    it ('Check response for  operator 1  is still present after update of card with keepChildCard=true re-logging',function () {
+        cy.sendCard('defaultProcess/questionWithKeepChildCards.json');
+
+        cy.loginOpFab('operator1','test');
+        // See in the feed the fact that user has respond (icon)
+        cy.get('#opfab-feed-lightcard-hasChildCardFromCurrentUserEntity');
+
+         // Click on the card
+         cy.get('of-light-card').eq(0).click();
+
+         // Check the correct rendering of card 
+         cy.get('#question-choice2');
+ 
+         // Check the old response from ENTITY1 has been integrated in the template 
+         cy.get('#response_from_ENTITY1');
+    });
+
+    it ('Check response for  operator 1  is not present after update of card with keepChildCard= false re-logging',function () {
+        cy.sendCard('defaultProcess/question.json');
+
+        cy.loginOpFab('operator1','test');
+       
+        // Click on the card
+        cy.get('of-light-card').eq(0).click(); 
+
+        // Should not have an icon of response
+        cy.get('#opfab-feed-lightcard-hasChildCardFromCurrentUserEntity').should('not.exist');;
+
+         // Check the correct rendering of card 
+         cy.get('#question-choice2');
+ 
+         // Check the old response from ENTITY1 has not been integrated in the template 
+         cy.get('#response_from_ENTITY1').should('not.exist');
+    });
 })

--- a/src/test/resources/cards/defaultProcess/questionWithKeepChildCards.json
+++ b/src/test/resources/cards/defaultProcess/questionWithKeepChildCards.json
@@ -1,0 +1,21 @@
+ {
+		"publisher" : "processAction",
+		"processVersion" : "1",
+		"process"  :"defaultProcess",
+		"processInstanceId" : "process4",
+		"state": "questionState",
+		"userRecipients": ["operator1", "operator2","operator3","operator4"],
+		"entitiesAllowedToRespond": ["ENTITY1","ENTITY2","ENTITY3"],
+		"entitiesRequiredToRespond": ["ENTITY1","ENTITY2"],
+		"severity" : "ACTION",
+		"startDate" : ${current_date_in_milliseconds_from_epoch},
+		"endDate" : ${current_date_in_milliseconds_from_epoch_plus_8hours},
+		"summary" : {"key" : "message.summary"},
+		"title" : {"key" : "question.title"},
+		"data" : {"message":" Action Card"},
+		"lttd" :  ${current_date_in_milliseconds_from_epoch_plus_3minutes},
+		"timeSpans" : [
+			{"start" :  ${current_date_in_milliseconds_from_epoch_plus_4hours}}
+			],
+        "keepChildCards" : true
+	}

--- a/ui/main/src/app/store/actions/light-card.actions.ts
+++ b/ui/main/src/app/store/actions/light-card.actions.ts
@@ -21,7 +21,8 @@ export enum LightCardActionTypes {
     AddLightCardFailure = '[LCard] Add Light Card Fail',
     RemoveLightCard = '[LCard] Remove a card',
     UpdateALightCard = '[LCard] Update a Light Card',
-    LightCardAlreadyUpdated = '[LCard] Light Card already Updated'
+    LightCardAlreadyUpdated = '[LCard] Light Card already Updated',
+    NoopAction = '[LCard] Nothing to do'
 }
 
 
@@ -82,6 +83,10 @@ export class LightCardAlreadyUpdated implements Action {
     readonly type = LightCardActionTypes.LightCardAlreadyUpdated;
 }
 
+export class NoopAction implements Action {
+    readonly type = LightCardActionTypes.NoopAction;
+}
+
 export type LightCardActions =
     LoadLightCard
     | LoadLightChildCard
@@ -92,7 +97,8 @@ export type LightCardActions =
     | EmptyLightCards
     | UpdateALightCard
     | LightCardAlreadyUpdated
-    | RemoveLightCard;
+    | RemoveLightCard
+    | NoopAction;
 
 export enum UpdateTrigger {
     READ = 'READ',


### PR DESCRIPTION
BUG : When loading application, it can happen that a child card is received
from back before his parent card. In this case when the child card is
a response from an entity of the current user, the blue response arrow
is not seen in feed as it should.

Release note : 

Bugs : 
OC-1736 Correct bug when child card is receive before parent card