### PR TITLE
[OC-1721] When getting entities from token, it shall take into accoun…

### DIFF
--- a/tools/spring/spring-oauth2-utilities/src/main/java/org/opfab/springtools/configuration/oauth/OAuth2GenericConfiguration.java
+++ b/tools/spring/spring-oauth2-utilities/src/main/java/org/opfab/springtools/configuration/oauth/OAuth2GenericConfiguration.java
@@ -33,8 +33,6 @@ import org.springframework.security.authentication.AbstractAuthenticationToken;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.oauth2.jwt.Jwt;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -114,8 +112,6 @@ public class OAuth2GenericConfiguration {
         // override the groups list from JWT mode, otherwise, default mode is OPERATOR_FABRIC
 		if (groupsProperties.getMode() == GroupsMode.JWT) user.setGroups(getGroupsList(jwt));
         
-        if (jwtProperties.gettingEntitiesFromToken) user.setEntities(getEntitiesFromToken(jwt));
-
 		List<GrantedAuthority> authorities = OAuth2JwtProcessingUtilities.computeAuthorities(user);
 		
 		log.debug("user [{}] has these roles '{}' through the {} mode and entities {}",principalId,authorities,groupsProperties.getMode(),user.getEntities());
@@ -131,14 +127,6 @@ public class OAuth2GenericConfiguration {
 	 */
 	public List<String> getGroupsList(Jwt jwt) {
 		return groupsUtils.createGroupsList(jwt);
-
-    }
-
-    private List<String> getEntitiesFromToken(Jwt jwt){
-        String entitiesId = jwt.getClaimAsString(jwtProperties.getEntitiesIdClaim());  
-        List<String> enititiesIdList = new ArrayList<>();
-		if (entitiesId!=null)  enititiesIdList.addAll(Arrays.asList(entitiesId.split(";")));	
-		return enititiesIdList;      
 
     }
 


### PR DESCRIPTION
No need to override entities list retrieved from user service with the ones taken from token because these are already taken into account by user service and enriched with entity groups defined in mongo.

Release notes:

In Bugs section:
[OC-1721] When getting entities from token, it shall take into account groups of entities configured in mongo

Signed-off-by: Giovanni Ferrari <giovanni.ferrari@soft.it>

[OC-1721]: https://opfab.atlassian.net/browse/OC-1721