### PR TITLE
[OC-1663] Removing Ribbon and updating Spring Boot to 2.4.6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
     id "maven-publish"
     id "signing"
     id "org.owasp.dependencycheck" version "6.2.0"
-    id 'org.springframework.boot' version '2.4.0-M1'
+    id 'org.springframework.boot' version '2.4.6'
     id 'org.sonarqube' version '3.2.0' apply false
 }
 
@@ -46,7 +46,7 @@ ext {
             securityOauthResource   : "org.springframework.security:spring-security-oauth2-resource-server:${versions['spring.security']}",
             securityOauthJose       : "org.springframework.security:spring-security-oauth2-jose:${versions['spring.security']}",
             securityTest            : "org.springframework.security:spring-security-test:${versions['spring.security']}",
-            webflux                 : "org.springframework:spring-webflux:${versions['spring']}",
+            webflux                 : "org.springframework:spring-webflux:${versions['spring.webflux']}",
             retry                   : "org.springframework.retry:spring-retry:${versions['spring.retry']}"
     ]
 
@@ -54,8 +54,7 @@ ext {
             dependencies          : "org.springframework.cloud:spring-cloud-dependencies:${versions['spring.cloud']}",
             starterBus            : "org.springframework.cloud:spring-cloud-starter-bus-amqp",
             starterStream         : "org.springframework.cloud:spring-cloud-starter-stream-rabbit",
-            starterFeign          : "org.springframework.cloud:spring-cloud-starter-openfeign",
-            ribbon                : "org.springframework.cloud:spring-cloud-starter-netflix-ribbon"
+            starterFeign          : "org.springframework.cloud:spring-cloud-starter-openfeign"
     ]
 
     testing = [
@@ -76,9 +75,11 @@ ext {
             compress       : "org.apache.commons:commons-compress:${versions['apache.commons.compress']}",
             feignMock      : "io.github.openfeign:feign-mock:${versions['feign']}",
             feignJackson   : "io.github.openfeign:feign-jackson:${versions['feign']}",
+            guava          : "com.google.guava:guava:30.1.1-jre",
             jacksonAnnotations   : "com.fasterxml.jackson.core:jackson-annotations:${versions['jacksonAnnotations']}",
             collections4   : "org.apache.commons:commons-collections4:${versions['apache.commons.collections4']}",
-            micrometer     : "io.micrometer:micrometer-registry-prometheus:${versions['micrometer']}"
+            micrometer     : "io.micrometer:micrometer-registry-prometheus:${versions['micrometer']}",
+            jsonSmart      : "net.minidev:json-smart:2.4.7"
     ]
 
     generator = [

--- a/config/dev/businessconfig-dev.yml
+++ b/config/dev/businessconfig-dev.yml
@@ -7,8 +7,3 @@ spring:
 operatorfabric.businessconfig:
   storage:
     path: "./services/core/businessconfig/build/docker-volume/businessconfig-storage"
-
-#here we put urls for all feign clients
-users:
-  ribbon:
-    listOfServers: http://localhost:2103

--- a/config/dev/cards-consultation-dev.yml
+++ b/config/dev/cards-consultation-dev.yml
@@ -4,7 +4,4 @@ spring:
   application:
     name: cards-consultation
 #logging.level.org.opfab: debug
-#here we put urls for all feign clients
-users:
-  ribbon:
-    listOfServers: http://localhost:2103
+

--- a/config/dev/cards-publication-dev.yml
+++ b/config/dev/cards-publication-dev.yml
@@ -29,11 +29,6 @@ opfab:
       registry:
         url: http://localhost:8081
 
-#here we put urls for all feign clients
-users:
-  ribbon:
-    listOfServers: http://localhost:2103
-
 externalRecipients-url: "{\
            processAction: \"http://localhost:8090/test\", \
            api_test_externalRecipient1: \"http://localhost:8090/test\", \

--- a/config/dev/common-dev.yml
+++ b/config/dev/common-dev.yml
@@ -30,6 +30,8 @@ operatorfabric:
     jwt:
       login-claim: preferred_username
       expire-claim: exp
+  servicesUrls:
+    users: "http://localhost:2103"
 
 ### activate the folLowing if you want the entities of the user to came from the token and not mongoDB   
 ### entitiesIdClaim is the name of the field in the token     

--- a/config/docker/businessconfig-docker.yml
+++ b/config/docker/businessconfig-docker.yml
@@ -6,7 +6,3 @@ operatorfabric.businessconfig:
   storage:
     path: "/businessconfig-storage"
 
-#here we put urls for all feign clients
-users:
-  ribbon:
-    listOfServers: users:8080

--- a/config/docker/cards-consultation-docker.yml
+++ b/config/docker/cards-consultation-docker.yml
@@ -1,8 +1,3 @@
 spring:
   application:
     name: cards-consultation
-
-#here we put urls for all feign clients
-users:
-  ribbon:
-    listOfServers: users:8080

--- a/config/docker/cards-publication-docker.yml
+++ b/config/docker/cards-publication-docker.yml
@@ -27,11 +27,7 @@ opfab:
       registry:
         url: http://localhost:8081
 
-#here we put urls for all feign clients
-users:
-  ribbon:
-    listOfServers: users:8080
-# WARNING - If you are not working on linux, you should replace the host ip address 172.17.0.1 
+# WARNING - If you are not working on linux, you should replace the host ip address 172.17.0.1
 # for mac see https://docs.docker.com/docker-for-mac/networking/#use-cases-and-workarounds
 # for windows see https://docs.docker.com/docker-for-windows/networking/#use-cases-and-workarounds
 externalRecipients-url: "{\

--- a/config/docker/common-docker.yml
+++ b/config/docker/common-docker.yml
@@ -30,3 +30,5 @@ operatorfabric:
       login-claim: preferred_username
       expire-claim: exp
   businessLogActivated: true
+  servicesUrls:
+    users: "users:8080"

--- a/services/core/businessconfig/build.gradle
+++ b/services/core/businessconfig/build.gradle
@@ -2,9 +2,9 @@ dependencies {
     swaggerCodegen generator.swagger, project(':tools:swagger-spring-generators')
     swaggerUI generator.swaggerUI
     compile project(':tools:generic:utilities'), project(':tools:spring:spring-utilities')
-    compile  cloud.starterBus, cloud.ribbon
+    compile  cloud.starterBus
     compile boot.starterAop
-    compile 'com.google.guava:guava:30.1.1-jre'
+    compile misc.guava
     compileOnly boot.annotationConfiguration
     annotationProcessor boot.annotationConfiguration
 

--- a/services/core/cards-consultation/build.gradle
+++ b/services/core/cards-consultation/build.gradle
@@ -2,7 +2,8 @@ dependencies {
     swaggerCodegen generator.swagger, project(':tools:swagger-spring-generators')
     swaggerUI generator.swaggerUI
     compile project(':tools:generic:utilities'), project(':tools:spring:spring-utilities')
-    compile  cloud.starterBus, cloud.ribbon
+    compile  cloud.starterBus
+    implementation misc.jsonSmart
     compile boot.starterAop
     compileOnly boot.annotationConfiguration
     annotationProcessor boot.annotationConfiguration

--- a/services/core/cards-publication/build.gradle
+++ b/services/core/cards-publication/build.gradle
@@ -6,7 +6,8 @@ dependencies {
     swaggerCodegen generator.swagger, project(':tools:swagger-spring-generators')
     swaggerUI generator.swaggerUI
     compile project(':tools:generic:utilities'), project(':tools:spring:spring-utilities')
-    compile  cloud.starterBus, cloud.ribbon
+    compile  cloud.starterBus
+    implementation misc.jsonSmart
     compile boot.starterAop
 
     compileOnly boot.annotationConfiguration

--- a/services/core/cards-publication/src/main/java/org/opfab/cards/publication/configuration/kafka/KafkaListenerContainerFactoryConfiguration.java
+++ b/services/core/cards-publication/src/main/java/org/opfab/cards/publication/configuration/kafka/KafkaListenerContainerFactoryConfiguration.java
@@ -23,6 +23,7 @@ import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
 import org.springframework.kafka.config.KafkaListenerContainerFactory;
 import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.listener.ConcurrentMessageListenerContainer;
+import org.springframework.kafka.listener.ConsumerProperties;
 
 import java.time.Duration;
 import java.util.List;
@@ -50,7 +51,7 @@ public class KafkaListenerContainerFactoryConfiguration {
         if (duration != null) {
             return duration.toMillis();
         }
-        return 1000L;
+        return ConsumerProperties.DEFAULT_POLL_TIMEOUT;
     }
 
     @Bean

--- a/services/core/cards-publication/src/main/java/org/opfab/cards/publication/services/CardProcessingService.java
+++ b/services/core/cards-publication/src/main/java/org/opfab/cards/publication/services/CardProcessingService.java
@@ -11,7 +11,6 @@
 package org.opfab.cards.publication.services;
 
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang.StringUtils;
 import org.opfab.aop.process.AopTraceType;
 import org.opfab.aop.process.mongo.models.UserActionTraceData;
 import org.opfab.cards.model.CardOperationTypeEnum;
@@ -186,7 +185,7 @@ public class CardProcessingService {
     }
 
     public Optional<CardPublicationData> deleteCard(CardPublicationData card) {
-        if (StringUtils.isEmpty(card.getId())) {
+        if (card.getId()==null||card.getId().isEmpty()) {
             card.prepare(card.getPublishDate());
         }
         return deleteCard0(card);

--- a/services/core/cards-publication/src/main/resources/application.yml
+++ b/services/core/cards-publication/src/main/resources/application.yml
@@ -1,0 +1,3 @@
+spring:
+  application:
+    name: cards-publication

--- a/services/core/cards-publication/src/test/java/org/opfab/cards/publication/configuration/kafka/KafkaListenerContainerFactoryConfigurationShould.java
+++ b/services/core/cards-publication/src/test/java/org/opfab/cards/publication/configuration/kafka/KafkaListenerContainerFactoryConfigurationShould.java
@@ -21,6 +21,7 @@ import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
 import org.springframework.kafka.config.KafkaListenerContainerFactory;
 import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.listener.ConcurrentMessageListenerContainer;
+import org.springframework.kafka.listener.ConsumerProperties;
 import org.springframework.test.context.ActiveProfiles;
 
 import java.time.Duration;
@@ -74,8 +75,9 @@ class KafkaListenerContainerFactoryConfigurationShould {
         assertNotNull(kafkaListenerContainerFactory);
 
         ConcurrentMessageListenerContainer container = kafkaListenerContainerFactory.createContainer("dummyTopic");
+
         assertThat (container.getConcurrency()).isGreaterThan(0);
-        assertThat(container.getContainerProperties().getPollTimeout()).isGreaterThan(0);
+        assertThat(container.getContainerProperties().getPollTimeout()).isEqualTo(ConsumerProperties.DEFAULT_POLL_TIMEOUT);
     }
 
     @Test

--- a/services/core/cards-publication/src/test/java/org/opfab/cards/publication/configuration/kafka/KafkaListenerContainerFactoryConfigurationShould.java
+++ b/services/core/cards-publication/src/test/java/org/opfab/cards/publication/configuration/kafka/KafkaListenerContainerFactoryConfigurationShould.java
@@ -67,6 +67,7 @@ class KafkaListenerContainerFactoryConfigurationShould {
     void kafkaListenerContainerFactoryWithDefaults() {
         KafkaProperties.Listener listenerMock = mock (KafkaProperties.Listener.class);
         when (listenerMock.getConcurrency()).thenReturn(null);
+        when (listenerMock.getPollTimeout()).thenReturn(null);
         when (kafkaProperties.getListener()).thenReturn(listenerMock);
         KafkaListenerContainerFactory<ConcurrentMessageListenerContainer<String, CardCommand>> kafkaListenerContainerFactory = cut.kafkaListenerContainerFactory();
 

--- a/services/core/users/build.gradle
+++ b/services/core/users/build.gradle
@@ -2,7 +2,8 @@ dependencies {
     swaggerCodegen generator.swagger, project(':tools:swagger-spring-generators')
     swaggerUI generator.swaggerUI
     compile project(':tools:generic:utilities'), project(':tools:spring:spring-utilities')
-    compile  cloud.starterBus, cloud.ribbon
+    compile  cloud.starterBus
+    implementation misc.jsonSmart
     compile boot.starterAop
     compile misc.collections4
 

--- a/services/core/users/src/main/java/org/opfab/users/controllers/EntitiesController.java
+++ b/services/core/users/src/main/java/org/opfab/users/controllers/EntitiesController.java
@@ -19,6 +19,7 @@ import org.opfab.users.model.EntityData;
 import org.opfab.users.model.UserData;
 import org.opfab.users.repositories.EntityRepository;
 import org.opfab.users.repositories.UserRepository;
+
 import org.opfab.users.utils.EntityCycleDetector;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.bus.ServiceMatcher;
@@ -54,7 +55,7 @@ public class EntitiesController implements EntitiesApi {
     /* These are Spring Cloud Bus beans used to fire an event (UpdatedUserEvent) every time a user is modified.
     *  Other services handle this event by clearing their user cache for the given user. See issue #64*/
     @Autowired
-    private ServiceMatcher busServiceMatcher;
+    private ServiceMatcher serviceMatcher;
     @Autowired
     private ApplicationEventPublisher publisher;
 
@@ -69,7 +70,7 @@ public class EntitiesController implements EntitiesApi {
 
         for (UserData userData : foundUsers) {
             userData.addEntity(id);
-            publisher.publishEvent(new UpdatedUserEvent(this, busServiceMatcher.getServiceId(), userData.getLogin()));
+            publisher.publishEvent(new UpdatedUserEvent(this, serviceMatcher.getBusId(), userData.getLogin()));
         }
         userRepository.saveAll(foundUsers);
         return null;
@@ -119,7 +120,7 @@ public class EntitiesController implements EntitiesApi {
 
         if(foundUser!=null) {
                 foundUser.deleteEntity(id);
-                publisher.publishEvent(new UpdatedUserEvent(this, busServiceMatcher.getServiceId(), foundUser.getLogin()));
+                publisher.publishEvent(new UpdatedUserEvent(this, serviceMatcher.getBusId(), foundUser.getLogin()));
             userRepository.save(foundUser);
         }
         return null;
@@ -175,7 +176,7 @@ public class EntitiesController implements EntitiesApi {
                             u.deleteEntity(id);
                             newUsersInEntity.remove(u.getLogin());
                             //Fire an UpdatedUserEvent for all users that are updated because they're removed from the entity
-                            publisher.publishEvent(new UpdatedUserEvent(this, busServiceMatcher.getServiceId(), u.getLogin()));
+                            publisher.publishEvent(new UpdatedUserEvent(this, serviceMatcher.getBusId(), u.getLogin()));
                         }).collect(Collectors.toList());
 
         userRepository.saveAll(toUpdate);
@@ -207,7 +208,7 @@ public class EntitiesController implements EntitiesApi {
         if (foundUsers != null) {
             for (UserData userData : foundUsers) {
                 userData.deleteEntity(idEntity);
-                publisher.publishEvent(new UpdatedUserEvent(this, busServiceMatcher.getServiceId(), userData.getLogin()));
+                publisher.publishEvent(new UpdatedUserEvent(this, serviceMatcher.getBusId(), userData.getLogin()));
             }
             userRepository.saveAll(foundUsers);
         }

--- a/services/core/users/src/main/java/org/opfab/users/controllers/GroupsController.java
+++ b/services/core/users/src/main/java/org/opfab/users/controllers/GroupsController.java
@@ -63,7 +63,7 @@ public class GroupsController implements GroupsApi {
     /* These are Spring Cloud Bus beans used to fire an event (UpdatedUserEvent) every time a user is modified.
     *  Other services handle this event by clearing their user cache for the given user. See issue #64*/
     @Autowired
-    private ServiceMatcher busServiceMatcher;
+    private ServiceMatcher serviceMatcher;
     @Autowired
     private ApplicationEventPublisher publisher;
 
@@ -78,7 +78,7 @@ public class GroupsController implements GroupsApi {
 
         for (UserData userData : foundUsers) {
             userData.addGroup(id);
-            publisher.publishEvent(new UpdatedUserEvent(this, busServiceMatcher.getServiceId(), userData.getLogin()));
+            publisher.publishEvent(new UpdatedUserEvent(this, serviceMatcher.getBusId(), userData.getLogin()));
         }
         userRepository.saveAll(foundUsers);
         return null;
@@ -92,7 +92,7 @@ public class GroupsController implements GroupsApi {
         } else {
             List<UserData> users = userRepository.findByGroupSetContaining(group.getId());
             users.forEach(foundUser -> {
-                publisher.publishEvent(new UpdatedUserEvent(this, busServiceMatcher.getServiceId(), foundUser.getLogin()));
+                publisher.publishEvent(new UpdatedUserEvent(this, serviceMatcher.getBusId(), foundUser.getLogin()));
             });
         }
         return groupRepository.save((GroupData)group);
@@ -125,7 +125,7 @@ public class GroupsController implements GroupsApi {
 
         if(foundUser!=null) {
                 foundUser.deleteGroup(id);
-                publisher.publishEvent(new UpdatedUserEvent(this, busServiceMatcher.getServiceId(), foundUser.getLogin()));
+                publisher.publishEvent(new UpdatedUserEvent(this, serviceMatcher.getBusId(), foundUser.getLogin()));
             userRepository.save(foundUser);
         }
         return null;
@@ -181,7 +181,7 @@ public class GroupsController implements GroupsApi {
                             u.deleteGroup(id);
                             newUsersInGroup.remove(u.getLogin());
                             //Fire an UpdatedUserEvent for all users that are updated because they're removed from the group
-                            publisher.publishEvent(new UpdatedUserEvent(this, busServiceMatcher.getServiceId(), u.getLogin()));
+                            publisher.publishEvent(new UpdatedUserEvent(this, serviceMatcher.getBusId(), u.getLogin()));
                         }).collect(Collectors.toList());
 
         userRepository.saveAll(toUpdate);
@@ -264,7 +264,7 @@ public class GroupsController implements GroupsApi {
         if (foundUsers != null) {
             for (UserData userData : foundUsers) {
                 userData.deleteGroup(idGroup);
-                publisher.publishEvent(new UpdatedUserEvent(this, busServiceMatcher.getServiceId(), userData.getLogin()));
+                publisher.publishEvent(new UpdatedUserEvent(this, serviceMatcher.getBusId(), userData.getLogin()));
             }
             userRepository.saveAll(foundUsers);
         }

--- a/services/core/users/src/main/java/org/opfab/users/services/UserServiceImp.java
+++ b/services/core/users/src/main/java/org/opfab/users/services/UserServiceImp.java
@@ -50,7 +50,7 @@ public class UserServiceImp implements UserService {
     /* These are Spring Cloud Bus beans used to fire an event (UpdatedUserEvent) every time a user is modified.
      *  Other services handle this event by clearing their user cache for the given user. See issue #64*/
     @Autowired
-    private ServiceMatcher busServiceMatcher;
+    private ServiceMatcher serviceMatcher;
     @Autowired
     private ApplicationEventPublisher publisher;
 
@@ -115,7 +115,7 @@ public class UserServiceImp implements UserService {
         List<UserData> foundUsers = userRepository.findByGroupSetContaining(groupId);
         if (foundUsers != null) {
             for (UserData userData : foundUsers)
-                publisher.publishEvent(new UpdatedUserEvent(this, busServiceMatcher.getServiceId(), userData.getLogin()));
+                publisher.publishEvent(new UpdatedUserEvent(this, serviceMatcher.getBusId(), userData.getLogin()));
         }
     }
 

--- a/services/core/users/src/test/java/org/opfab/users/application/UnitTestApplication.java
+++ b/services/core/users/src/test/java/org/opfab/users/application/UnitTestApplication.java
@@ -20,7 +20,6 @@ import org.opfab.users.configuration.json.JacksonConfig;
 import org.opfab.users.configuration.mongo.LocalMongoConfiguration;
 import org.opfab.users.configuration.users.UsersProperties;
 import org.opfab.users.controllers.*;
-import org.opfab.users.controllers.*;
 import org.opfab.users.repositories.UserRepository;
 import org.opfab.users.services.UserServiceImp;
 import org.springframework.boot.SpringApplication;

--- a/services/core/users/src/test/java/org/opfab/users/controllers/EntitiesControllerShould.java
+++ b/services/core/users/src/test/java/org/opfab/users/controllers/EntitiesControllerShould.java
@@ -13,6 +13,7 @@ package org.opfab.users.controllers;
 
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
 import org.opfab.users.application.UnitTestApplication;
 import org.opfab.users.application.configuration.WithMockOpFabUser;
 import org.opfab.users.model.EntityData;
@@ -62,7 +63,7 @@ class EntitiesControllerShould {
     private EntityRepository entityRepository;
 
     @MockBean
-    private ServiceMatcher busServiceMatcher;
+    private ServiceMatcher serviceMatcher;
 
     @MockBean
     private ApplicationEventPublisher publisher;
@@ -117,6 +118,8 @@ class EntitiesControllerShould {
            .build();
         entityRepository.insert(e1);
         entityRepository.insert(e2);
+
+        Mockito.when(serviceMatcher.getBusId()).thenReturn("DUMMY_BUS_ID");
     }
 
     @AfterEach

--- a/services/core/users/src/test/java/org/opfab/users/controllers/GroupsControllerShould.java
+++ b/services/core/users/src/test/java/org/opfab/users/controllers/GroupsControllerShould.java
@@ -14,13 +14,13 @@ package org.opfab.users.controllers;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
 import org.opfab.users.application.UnitTestApplication;
 import org.opfab.users.application.configuration.WithMockOpFabUser;
 import org.opfab.users.model.*;
 import org.opfab.users.repositories.GroupRepository;
 import org.opfab.users.repositories.PerimeterRepository;
 import org.opfab.users.repositories.UserRepository;
-import org.opfab.users.model.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -72,7 +72,7 @@ class GroupsControllerShould {
     private PerimeterRepository perimeterRepository;
 
     @MockBean
-    private ServiceMatcher busServiceMatcher;
+    private ServiceMatcher serviceMatcher;
 
     @MockBean
     private ApplicationEventPublisher publisher;
@@ -161,6 +161,8 @@ class GroupsControllerShould {
         perimeterRepository.insert(p1);
         perimeterRepository.insert(p2);
         perimeterRepository.insert(p3);
+
+        Mockito.when(serviceMatcher.getBusId()).thenReturn("DUMMY_BUS_ID");
     }
 
     @AfterEach

--- a/services/core/users/src/test/java/org/opfab/users/controllers/PerimetersControllerShould.java
+++ b/services/core/users/src/test/java/org/opfab/users/controllers/PerimetersControllerShould.java
@@ -13,13 +13,13 @@ package org.opfab.users.controllers;
 
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
 import org.opfab.users.application.UnitTestApplication;
 import org.opfab.users.application.configuration.WithMockOpFabUser;
 import org.opfab.users.model.*;
 import org.opfab.users.repositories.GroupRepository;
 import org.opfab.users.repositories.PerimeterRepository;
 import org.opfab.users.repositories.UserRepository;
-import org.opfab.users.model.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -66,7 +66,7 @@ class PerimetersControllerShould {
     private UserRepository userRepository;
 
     @MockBean
-    private ServiceMatcher busServiceMatcher;
+    private ServiceMatcher serviceMatcher;
 
     @MockBean
     private ApplicationEventPublisher publisher;
@@ -156,6 +156,8 @@ class PerimetersControllerShould {
         perimeterRepository.insert(p1);
         perimeterRepository.insert(p2);
         perimeterRepository.insert(p3);
+
+        Mockito.when(serviceMatcher.getBusId()).thenReturn("DUMMY_BUS_ID");
     }
 
     @AfterEach

--- a/services/core/users/src/test/java/org/opfab/users/controllers/UsersControllerShould.java
+++ b/services/core/users/src/test/java/org/opfab/users/controllers/UsersControllerShould.java
@@ -14,6 +14,7 @@ package org.opfab.users.controllers;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
 import org.opfab.users.application.UnitTestApplication;
 import org.opfab.users.application.configuration.WithMockOpFabUser;
 import org.opfab.users.model.*;
@@ -22,6 +23,7 @@ import org.opfab.users.repositories.PerimeterRepository;
 import org.opfab.users.repositories.UserRepository;
 import org.opfab.users.repositories.UserSettingsRepository;
 import org.opfab.users.model.*;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -76,7 +78,7 @@ class UsersControllerShould {
     private UserSettingsRepository userSettingsRepository;
 
     @MockBean
-    private ServiceMatcher busServiceMatcher;
+    private ServiceMatcher serviceMatcher;
 
     @MockBean
     private ApplicationEventPublisher publisher;
@@ -177,6 +179,8 @@ class UsersControllerShould {
         perimeterRepository.insert(p1);
         perimeterRepository.insert(p2);
         perimeterRepository.insert(p3);
+
+        Mockito.when(serviceMatcher.getBusId()).thenReturn("DUMMY_BUS_ID");
     }
 
     @AfterEach

--- a/src/docs/asciidoc/deployment/configuration/configuration.adoc
+++ b/src/docs/asciidoc/deployment/configuration/configuration.adoc
@@ -130,17 +130,6 @@ include::web-ui_configuration.adoc[leveloffset=+1]
 [[opfab_spec_conf]]
 include::security_configuration.adoc[leveloffset=+1]
 
-==== All services except Users
-
-All business services except the Users service need to have this property.
-
-|===
-|name|default|mandatory?|Description
-
-|feignclient.users.url||yes|Indicates where the Users service can we reached (to get information about the current user).
-
-|===
-
 == OperatorFabric Mongo configuration
 
 We only use URI configuration for mongo through the usage of the ```spring.data.mongodb.uris```,

--- a/src/docs/asciidoc/deployment/configuration/configuration.adoc
+++ b/src/docs/asciidoc/deployment/configuration/configuration.adoc
@@ -59,6 +59,7 @@ In this file you will find, among others, the parameters below :
 |name|default|mandatory?|Description
 
 |operatorfabric.businessLogActivated|false|no|Indicates whether or not operatorfabric should record business logs
+|operatorfabric.servicesUrls.users||yes|Indicates where the Users service can we reached (to get information about the current user).
 
 |===
 
@@ -71,14 +72,6 @@ Each business service has a specific yaml configuration file. It should a least 
 spring:
   application:
     name: businessconfig
-----
-
-It can contain references to other services as well, for example :
-[source, yaml]
-----
-users:
-  ribbon:
-    listOfServers: users:8080
 ----
 
 Examples of configuration of each business service can be found either under config/docker or config/dev depending on
@@ -136,6 +129,17 @@ include::web-ui_configuration.adoc[leveloffset=+1]
 
 [[opfab_spec_conf]]
 include::security_configuration.adoc[leveloffset=+1]
+
+==== All services except Users
+
+All business services except the Users service need to have this property.
+
+|===
+|name|default|mandatory?|Description
+
+|feignclient.users.url||yes|Indicates where the Users service can we reached (to get information about the current user).
+
+|===
 
 == OperatorFabric Mongo configuration
 

--- a/src/docs/asciidoc/resources/index.adoc
+++ b/src/docs/asciidoc/resources/index.adoc
@@ -23,3 +23,6 @@ include::migration_guide_to_2.3.adoc[leveloffset=+1]
 include::migration_guide_to_2.4.adoc[leveloffset=+1]
 
 include::migration_guide_to_2.5.adoc[leveloffset=+1]
+
+include::migration_guide_to_2.6.adoc[leveloffset=+1]
+

--- a/src/docs/asciidoc/resources/migration_guide_to_2.6.adoc
+++ b/src/docs/asciidoc/resources/migration_guide_to_2.6.adoc
@@ -18,9 +18,12 @@ update of the other Spring dependencies).
 Instead, the Feign client now relies on an external property to know where the Users service can be reached, and there
 is no load-balancing for now.
 
-The following property should then be set in the configuration of all business services (except users), or
-in the common configuration.
+This requires a change to service configuration: the `users.ribbon.listOfServers` property should be removed and
+replaced with `operatorfabric.servicesUrls.users`.
 
+It should be set in the configuration of all business services (except users), or in the common configuration.
+
+.Example
 [source,yaml]
 ----
 operatorfabric:
@@ -28,9 +31,13 @@ operatorfabric:
     users: "http://localhost:2103"
 ----
 
-According to the Feign documentation, the property should contain "an absolute URL or resolvable hostname (the protocol is optional)".
+According to the Feign documentation, the property should contain "an absolute URL or resolvable hostname (the protocol
+is optional)".
 
 IMPORTANT: This property is mandatory, if it is absent the application won't start.
+
+IMPORTANT: While the ribbon property could handle an array of several urls, this new property expects a single url as
+there is no load-balancing mechanism for now.
 
 
 

--- a/src/docs/asciidoc/resources/migration_guide_to_2.6.adoc
+++ b/src/docs/asciidoc/resources/migration_guide_to_2.6.adoc
@@ -1,0 +1,40 @@
+// Copyright (c) 2021 RTE (http://www.rte-france.com)
+// See AUTHORS.txt
+// This document is subject to the terms of the Creative Commons Attribution 4.0 International license.
+// If a copy of the license was not distributed with this
+// file, You can obtain one at https://creativecommons.org/licenses/by/4.0/.
+// SPDX-License-Identifier: CC-BY-4.0
+
+= Migration Guide from release 2.5.0 to release 2.6.0
+
+== Inter-service communication - Ribbon
+
+Ribbon was used by our Feign client that lets business services get information on the current user from the Users
+service.
+
+Ribbon is no longer maintained, so we chose to remove it from our dependencies (mostly because it was blocking any
+update of the other Spring dependencies).
+
+Instead, the Feign client now relies on an external property to know where the Users service can be reached, and there
+is no load-balancing for now.
+
+The following property should then be set in the configuration of all business services (except users), or
+in the common configuration.
+
+[source,yaml]
+----
+operatorfabric:
+  servicesUrls:
+    users: "http://localhost:2103"
+----
+
+According to the Feign documentation, the property should contain "an absolute URL or resolvable hostname (the protocol is optional)".
+
+IMPORTANT: This property is mandatory, if it is absent the application won't start.
+
+
+
+
+
+
+

--- a/tools/spring/spring-oauth2-utilities/src/main/java/org/opfab/springtools/configuration/oauth/UserServiceProxy.java
+++ b/tools/spring/spring-oauth2-utilities/src/main/java/org/opfab/springtools/configuration/oauth/UserServiceProxy.java
@@ -12,16 +12,15 @@
 package org.opfab.springtools.configuration.oauth;
 
 import org.opfab.users.model.CurrentUserWithPerimeters;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 
 /**
  * Feign proxy for User service
- *
- *
  */
-@FeignClient("users")
+@FeignClient(url="${operatorfabric.servicesUrls.users}", name = "users")
 public interface UserServiceProxy {
 
     @GetMapping(value = "/internal/CurrentUserWithPerimeters",

--- a/versions.properties
+++ b/versions.properties
@@ -1,7 +1,7 @@
 # spring libs
-spring.boot=2.4.0-M1
-spring.cloud=Hoxton.SR9
-spring=5.3.2
+spring.boot=2.4.6
+spring.cloud=2020.0.2
+spring.webflux=5.3.2
 spring.security=5.4.2
 spring.retry=1.3.0
 # logging libs


### PR DESCRIPTION
Quick recap of the changes in this PR:

- Upgrading Spring Boot beyond 2.4.0-M1 meant we needed to remove Ribbon as it is no longer supported
- Ribbon was also pulling other "utility" dependencies that we made use of in other parts of the code, so it caused errors when I removed it.
  - In the case of JsonSmart, I added it as a direct dependency as we were using it in several places
  - org.apache.commons.lang.StringUtils was used for a single "isEmpty" check on a string so I removed it
- Moved guava dependency definition to main build file like the others
- Updating Spring seems to have updated the Kafka version as well, and one of the test regarding configuration was no longer passing. I fixed it in the spirit of what was already done in the test, but maybe @JeroenGommans you could have a look ?
- The spring boot update meant spring cloud bus was updated as well with a breaking change to the ServiceMatcher class (became an interface) that was causing the unit tests to fail. Mocking the behaviour from the getBusId method solved that (as we're not really testing this in the unit tests, a dummy service id is ok I think).

Karate Tests and Cypress Tests are passing.

I didn't go to Spring Boot 2.5.0 in the end because even though it brought no new issues with the build, there seems to be a breaking change with the associated version of the spring boot gradle plugin that caused the jars not to work with docker, so I left some fun for another time ;-)

In release notes: 
OC-1663 : Removing Ribbon and updating Spring Boot to 2.4.6
Please see the migration guide regarding the configuration of a new mandatory deployment property.
//TODO Add link

It's a breaking change in a way because it's a new property and it's mandatory, but I don't know if it's worth making a migration guide just for this change?

Signed-off-by: Alexandra Guironnet <alexandra.guironnet@rte-france.com>