### PR TITLE
[OC-1748] Card detail screen deleted when the card is deleted : Addin…

### DIFF
--- a/src/test/cypress/cypress/integration/FeedTests.spec.js
+++ b/src/test/cypress/cypress/integration/FeedTests.spec.js
@@ -95,7 +95,10 @@ describe ('FeedScreen tests',function () {
         // TODO Test with sort set to unread first
 
 
-
+        // If we delete all the cards, the feed should be empty and the detail view should also be empty
+        cy.deleteTestCards();
+        cy.get('of-light-card').should('have.length',0);
+        cy.get('of-card-details').should('not.exist');
 
     })
 })


### PR DESCRIPTION
I propose to add nothing in the release notes.

[OC-1748](https://opfab.atlassian.net/browse/OC-1748) : Card detail screen deleted when the card is deleted : Adding a cypress test
