### PR TITLE
[OC-1756] Typo error in french template of "Exemple de nouvelles cartes 3"

### DIFF
--- a/src/test/resources/bundles/userCardExamples3/template/fr/task.handlebars
+++ b/src/test/resources/bundles/userCardExamples3/template/fr/task.handlebars
@@ -8,7 +8,7 @@
 <!-- This file is part of the OperatorFabric project.                      -->
 
 
-<h2> You avez la tâche suivante à réaliser :  </h2>
+<h2> Vous avez la tâche suivante à réaliser :  </h2>
 <br/>
 <br/>
 <center>


### PR DESCRIPTION
I propose to add nothing in release notes.

[OC-1756](https://opfab.atlassian.net/browse/OC-1756) : Typo error in french template of "Exemple de nouvelles cartes 3"