### PR TITLE
[OC-1769] Fixing issues with documentation noticed during release

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ import com.github.jk1.license.render.*
 plugins {
     id "com.github.jk1.dependency-license-report" version "1.16"
     id "com.github.node-gradle.node" version "3.1.0"
-    id "org.asciidoctor.convert" version "2.4.0"
+    id "org.asciidoctor.convert" version "1.5.10" //Upgrading to 2.4.0 changed the behaviour of {gradle-rootdir}, breaking all cross-document links
     id "maven-publish"
     id "signing"
     id "org.owasp.dependencycheck" version "6.2.0"

--- a/src/docs/asciidoc/deployment/configuration/security_configuration.adoc
+++ b/src/docs/asciidoc/deployment/configuration/security_configuration.adoc
@@ -267,7 +267,7 @@ Setting automated user creation==. Creation user requires a user id. Given name 
 |operatorfabric.security.jwt.family-name-claim|family-name|no| Jwt claim is used to set the user's family name
 |===
 
-==== Automated User creation with NONE flow
+=== Automated User creation with NONE flow
 
 Currently users with not be automatically created when using the `NONE` flow. 
 An administrator can add the users that are allowed to login to Operator Fabric.

--- a/src/docs/asciidoc/dev_env/gradle.adoc
+++ b/src/docs/asciidoc/dev_env/gradle.adoc
@@ -74,6 +74,11 @@ signing.gnupg.keyName=ID_OF_THE_GPG_KEY_TO_USE
 signing.secretKeyRingFile=LOCATION_OF_THE_KEYRING_HOLDING_THE_GPG_KEY
 ----
 
+NOTE: See https://makandracards.com/makandra-orga/notes/37763-gpg-extract-private-key-and-import-on-different-machine[this link]
+about importing a GPG key to your machine and getting its id.
+
+IMPORTANT: The gradle signing plugins uses gpg2 rather than gpg, so you should https://makandracards.com/makandra-orga/37763-gpg-extract-private-key-and-import-on-different-machine#note-section-enigmail--gnupg-v2[import the key to the gpg2 keyring].
+
 For the publication to the staging repository (OSSRH) to work, you need to set the credentials in your gradle.properties file:
 
 ----


### PR DESCRIPTION
Nothing to mention in release notes.
I went back on the gradle asciidoctor plugin update that caused the issue with links, as there is no hurry to upgrade. I created OC-1770 to handle the change in behaviour in newer versions and do the update when we have the time.


Signed-off-by: Alexandra Guironnet <alexandra.guironnet@rte-france.com>