### PR TITLE
[OC-1691] Add publisherName in child card for custom export in monitoring

### DIFF
--- a/src/test/resources/monitoringConfig/monitoringConfig.json
+++ b/src/test/resources/monitoringConfig/monitoringConfig.json
@@ -42,7 +42,7 @@
       {
         "jsonField" : "childCards",
         "fields" : [
-          { "columnName": "Response from", "jsonField": "publisher" },
+          { "columnName": "Response from", "jsonField": "publisherName" },
           { "columnName": "Response date","jsonField": "publishDate"},
           { "columnName": "Response ","jsonField": "data.response"}
         ]

--- a/ui/main/src/app/modules/monitoring/components/monitoring-table/monitoring-table.component.ts
+++ b/ui/main/src/app/modules/monitoring/components/monitoring-table/monitoring-table.component.ts
@@ -26,6 +26,7 @@ import {MonitoringConfig} from '@ofModel/monitoringConfig.model';
 import {JsonToArray} from 'app/common/jsontoarray/json-to-array';
 import {CardService} from '@ofServices/card.service';
 import {Process} from '@ofModel/processes.model';
+import {EntitiesService} from '@ofServices/entities.service';
 
 @Component({
     selector: 'of-monitoring-table',
@@ -50,6 +51,7 @@ export class MonitoringTableComponent implements OnDestroy {
                 , private modalService: NgbModal
                 , private processesService: ProcessesService
                 , private cardService : CardService
+                , private entitiesService: EntitiesService
     ) {
         this.monitoringConfig = processesService.getMonitoringConfig();
     }
@@ -143,6 +145,8 @@ export class MonitoringTableComponent implements OnDestroy {
 
         card.childCards.forEach(childCard => {
             childCard.publishDate = this.displayTime(childCard.publishDate);
+            if (childCard.publisherType==="ENTITY") childCard.publisherName= this.entitiesService.getEntityName(childCard.publisher);
+            else childCard.publisherName = childCard.publisher;
         });
         return card;
     }


### PR DESCRIPTION


To test use : 

Load config via  loadMonitoringConfig.sh monitoringConfig.json   in src/test/resources/monitoringConfig
Send card and respond to card 
make the monitoring export , you should see the entity name of the response in the excel file 


Release note : 

Features : 
 OC-1691: Add publisherName in child card for custom export in monitoring
