### PR TITLE
[OC-1768] Make possible the no displaying of a State in the Monitoring screen

### DIFF
--- a/src/test/resources/bundles/defaultProcess_V1/config.json
+++ b/src/test/resources/bundles/defaultProcess_V1/config.json
@@ -21,7 +21,7 @@
         "style"
       ],
       "acknowledgmentAllowed": "Always",
-      "type" : "INPROGRESS"
+      "type" : "FINISHED"
     },
     "chartState": {
       "name": "chartDetail.title",

--- a/src/test/resources/bundles/defaultProcess_V1/config.json
+++ b/src/test/resources/bundles/defaultProcess_V1/config.json
@@ -31,8 +31,7 @@
       "styles": [
         "style"
       ],
-      "acknowledgmentAllowed": "Always",
-      "type" : "FINISHED"
+      "acknowledgmentAllowed": "Always"
     },
     "chartLineState": {
       "name": "chartLine.title",

--- a/ui/main/src/app/modules/monitoring/monitoring.component.ts
+++ b/ui/main/src/app/modules/monitoring/monitoring.component.ts
@@ -73,22 +73,25 @@ export class MonitoringComponent implements OnInit, OnDestroy {
                                  * and thus currentProcess.extractState(…) throws an error
                                  */
                                 const state = Process.prototype.extractState.call(currentProcess, card);
+
                                 if (!!state && !!state.type) {
                                     typeOfState = state.type;
                                 }
-                                return (
-                                    {
-                                        creationDateTime: moment(card.publishDate),
-                                        beginningOfBusinessPeriod: moment(card.startDate),
-                                        endOfBusinessPeriod: ((!!card.endDate) ? moment(card.endDate) : null),
-                                        title: this.prefixI18nKey(card, 'title'),
-                                        summary: this.prefixI18nKey(card, 'summary'),
-                                        processName: this.prefixForTranslation(card, currentProcess.name),
-                                        cardId: card.id,
-                                        severity: card.severity.toLocaleLowerCase(),
-                                        processId: procId,
-                                        typeOfState: typeOfState
-                                    } as LineOfMonitoringResult);
+                                if (!!state.type) {
+                                    return (
+                                        {
+                                            creationDateTime: moment(card.publishDate),
+                                            beginningOfBusinessPeriod: moment(card.startDate),
+                                            endOfBusinessPeriod: ((!!card.endDate) ? moment(card.endDate) : null),
+                                            title: this.prefixI18nKey(card, 'title'),
+                                            summary: this.prefixI18nKey(card, 'summary'),
+                                            processName: this.prefixForTranslation(card, currentProcess.name),
+                                            cardId: card.id,
+                                            severity: card.severity.toLocaleLowerCase(),
+                                            processId: procId,
+                                            typeOfState: typeOfState
+                                        } as LineOfMonitoringResult);
+                                }
                             }
                         }
                     ).filter(elem => !!elem);


### PR DESCRIPTION


Release notes:

In Features section:
[OC-1768] : Make possible the no displaying of a State in the Monitoring screen
NOTE: Cards with a process state without 'type' property are not displayed in monitoring screen 

Signed-off-by: Giovanni Ferrari <giovanni.ferrari@soft.it>

[OC-1768]: https://opfab.atlassian.net/browse/OC-1768