### PR TITLE
[OC-1783] Removing Compodoc dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,10 +49,6 @@ jobs:
         - docker login --username ${DOCKER_CLOUD_USER} --password ${DOCKER_CLOUD_PWD}
         - docker-compose -f src/main/docker/test-environment/docker-compose.yml up -d
         - ./gradlew --build-cache copyDependencies test jacocoTestReport dockerTag${OF_VERSION}
-        # [OC-865] Dropping dependency messing with typescript version as a workaround until sonar bug is fixed
-        # See https://github.com/SonarSource/SonarJS/issues/1928 and https://community.sonarsource.com/t/error-about-unsupported-ts-version-while-project-is-using-supported-version/15776
-        - rm -r ui/main/node_modules/@compodoc/ngd-core
-        - rm -r ui/main/node_modules/ts-simple-ast
         - sonar-scanner
         - docker-compose -f src/main/docker/test-environment/docker-compose.yml down
         # Launch karate tests

--- a/ui/main/package.json
+++ b/ui/main/package.json
@@ -9,7 +9,6 @@
     "headless": "ng test --browsers ChromeHeadless --watch=false --code-coverage",
     "lint": "ng lint",
     "e2e": "ng e2e",
-    "compodoc": "npx compodoc -p src/tsconfig.app.json",
     "audit": "npm audit --json | $(npm bin)/npm-audit-html --output reports/report.html"
   },
   "private": true,
@@ -68,7 +67,6 @@
     "@angular/compiler-cli": "11.2.12",
     "@angular/language-service": "11.2.12",
     "@babel/compat-data": "7.14.4",
-    "@compodoc/compodoc": "1.1.11",
     "@fortawesome/fontawesome-free": "5.15.3",
     "@ngrx/schematics": "11.1.1",
     "@ngrx/store-devtools": "11.1.1",


### PR DESCRIPTION
Should solve at least 3 security issues (test to see if bot closes them or if it's broken).

No need to mention it in release notes as I don't think anyone was using it.

Signed-off-by: Alexandra Guironnet <alexandra.guironnet@rte-france.com>