### PR TITLE
[1806] Date filters : make impossible to enter a start date later than end date

### DIFF
--- a/ui/main/src/app/modules/archives/archives.component.html
+++ b/ui/main/src/app/modules/archives/archives.component.html
@@ -18,22 +18,22 @@
           <div class="opfab-publish-date">
             <div>
               <of-datetime-filter filterPath="publishDateFrom" formControlName="publishDateFrom"
-                labelKey="archive.filters."></of-datetime-filter>
+                labelKey="archive.filters." [maxDate]="publishMaxDate" (change)="onDateTimeChange($event)"></of-datetime-filter>
             </div>
             <div>
               <of-datetime-filter filterPath="publishDateTo" formControlName="publishDateTo"
-                labelKey="archive.filters."></of-datetime-filter>
+                labelKey="archive.filters." [minDate]="publishMinDate" (change)="onDateTimeChange($event)"></of-datetime-filter>
             </div>
           </div>
 
           <div class="opfab-vertical-bar"></div>
           <div style="margin-left:40px;width:230px;min-width: 230px;">
             <div>
-              <of-datetime-filter filterPath="activeFrom" formControlName="activeFrom" labelKey="archive.filters.">
+              <of-datetime-filter filterPath="activeFrom" formControlName="activeFrom" labelKey="archive.filters." [maxDate]="activeMaxDate" (change)="onDateTimeChange($event)">
               </of-datetime-filter>
             </div>
             <div>
-              <of-datetime-filter filterPath="activeTo" formControlName="activeTo" labelKey="archive.filters.">
+              <of-datetime-filter filterPath="activeTo" formControlName="activeTo" labelKey="archive.filters." [minDate]="activeMinDate" (change)="onDateTimeChange($event)">
               </of-datetime-filter>
             </div>
           </div>

--- a/ui/main/src/app/modules/archives/archives.component.ts
+++ b/ui/main/src/app/modules/archives/archives.component.ts
@@ -13,8 +13,8 @@ import {Subject} from 'rxjs';
 import {AppState} from '@ofStore/index';
 import {ProcessesService} from '@ofServices/processes.service';
 import {Store} from '@ngrx/store';
-import {takeUntil} from 'rxjs/operators';
-import {FormControl, FormGroup} from '@angular/forms';
+import {debounceTime, takeUntil} from 'rxjs/operators';
+import {AbstractControl, FormControl, FormGroup} from '@angular/forms';
 import {ConfigService} from '@ofServices/config.service';
 import {TimeService} from '@ofServices/time.service';
 import {NgbModal, NgbModalOptions, NgbModalRef} from '@ng-bootstrap/ng-bootstrap';
@@ -26,6 +26,9 @@ import {TranslateService} from '@ngx-translate/core';
 import {Card} from '@ofModel/card.model';
 import {ArchivesLoggingFiltersComponent} from '../share/archives-logging-filters/archives-logging-filters.component';
 import { EntitiesService } from '@ofServices/entities.service';
+import {MessageLevel} from '@ofModel/message.model';
+import {AlertMessage} from '@ofStore/actions/alert.actions';
+import {DateTimeNgb} from '@ofModel/datetime-ngb.model';
 
 
 @Component({
@@ -54,6 +57,13 @@ export class ArchivesComponent implements OnDestroy, OnInit {
     selectedCard: Card;
     fromEntityOrRepresentativeSelectedCard = null;
     listOfProcesses = [];
+
+    publishMinDate : {year: number, month: number, day: number} = null;
+    publishMaxDate : {year: number, month: number, day: number} = null;
+    activeMinDate : {year: number, month: number, day: number} = null;
+    activeMaxDate : {year: number, month: number, day: number} = null;
+
+    dateTimeFilterChange = new Subject();
 
     constructor(private store: Store<AppState>,
                 private processesService: ProcessesService,
@@ -91,6 +101,27 @@ export class ArchivesComponent implements OnDestroy, OnInit {
     ngOnInit() {
         this.size = this.configService.getConfigValue('archive.filters.page.size', 10);
         this.results = [];
+        this.dateTimeFilterChange.pipe(
+            takeUntil(this.unsubscribe$),
+            debounceTime(1000),
+        ).subscribe(() => this.setDateFilterBounds());
+    }
+
+    setDateFilterBounds(): void {
+
+        if (this.archiveForm.value.publishDateFrom?.date) {
+            this.publishMinDate = {year: this.archiveForm.value.publishDateFrom.date.year, month: this.archiveForm.value.publishDateFrom.date.month, day: this.archiveForm.value.publishDateFrom.date.day};
+        }
+        if (this.archiveForm.value.publishDateTo?.date) {
+            this.publishMaxDate = {year: this.archiveForm.value.publishDateTo.date.year, month: this.archiveForm.value.publishDateTo.date.month, day: this.archiveForm.value.publishDateTo.date.day};
+        }
+
+        if (this.archiveForm.value.activeFrom?.date) {
+            this.activeMinDate = {year: this.archiveForm.value.activeFrom.date.year, month: this.archiveForm.value.activeFrom.date.month, day: this.archiveForm.value.activeFrom.date.day};
+        }
+        if (this.archiveForm.value.activeTo?.date) {
+            this.activeMaxDate = {year: this.archiveForm.value.activeTo.date.year, month: this.archiveForm.value.activeTo.date.month, day: this.archiveForm.value.activeTo.date.day};
+        }
     }
 
     resetForm() {
@@ -98,9 +129,39 @@ export class ArchivesComponent implements OnDestroy, OnInit {
         this.firstQueryHasBeenDone = false;
         this.hasResult = false;
         this.resultsNumber = 0;
+        this.publishMinDate = null;
+        this.publishMaxDate = null;
+        this.activeMinDate = null;
+        this.activeMaxDate = null;
+
+    }
+
+
+    onDateTimeChange(event: Event) {
+        this.dateTimeFilterChange.next();
+    }
+
+    private displayMessage(i18nKey: string, msg: string, severity: MessageLevel = MessageLevel.ERROR) {
+        this.store.dispatch(new AlertMessage({alertMessage: {message: msg, level: severity, i18n: {key: i18nKey}}}));
     }
 
     sendQuery(page_number): void {
+        const publishStart = this.extractTime(this.archiveForm.get('publishDateFrom'));
+        const publishEnd = this.extractTime(this.archiveForm.get('publishDateTo'));
+
+        if (publishStart != null && !isNaN(publishStart) && publishEnd != null && !isNaN(publishEnd) && publishStart > publishEnd) {
+            this.displayMessage('archive.filters.publishEndDateBeforeStartDate','',MessageLevel.ERROR);
+            return;
+        }
+
+        const activeStart = this.extractTime(this.archiveForm.get('activeFrom'));
+        const activeEnd = this.extractTime(this.archiveForm.get('activeTo'));
+
+        if (activeStart != null && !isNaN(activeStart) && activeEnd != null && !isNaN(activeEnd) && activeStart > activeEnd) {
+            this.displayMessage('archive.filters.activeEndDateBeforeStartDate','',MessageLevel.ERROR);
+            return;
+        }
+
         const { value } = this.archiveForm;
         this.filtersTemplate.filtersToMap(value);
         this.filtersTemplate.filters.set('size', [this.size.toString()]);
@@ -128,6 +189,26 @@ export class ArchivesComponent implements OnDestroy, OnInit {
 
     displayTime(date) {
         return this.timeService.formatDateTime(date);
+    }
+
+    private extractTime(form: AbstractControl) {
+        const val = form.value;
+        if (!val || val == '')  {
+            return null;
+        }
+
+        if (isNaN(val.time.hour)) {
+            val.time.hour = 0;
+        }
+        if (isNaN(val.time.minute)) {
+            val.time.minute = 0;
+        }
+        if (isNaN(val.time.second)) {
+            val.time.second = 0;
+        }
+
+        const converter = new DateTimeNgb(val.date, val.time);
+        return converter.convertToNumber();
     }
 
 

--- a/ui/main/src/app/modules/feed/components/card-list/filters/feed-filter/feed-filter.component.html
+++ b/ui/main/src/app/modules/feed/components/card-list/filters/feed-filter/feed-filter.component.html
@@ -82,14 +82,14 @@
             <div style="margin-left: 2px; margin-right: 2px;margin-top:-10px;width:200px">
                 <div class="form-group" id="opfab-start">
                     <of-datetime-filter id="opfab-feed-filter-dateTimeFrom"  (change)="onDateTimeChange($event)" filterPath="start.label" formControlName="dateTimeFrom"
-                        labelKey="feed.filters.time."></of-datetime-filter>
+                      [maxDate]="startMaxDate"  labelKey="feed.filters.time."></of-datetime-filter>
                 </div>
             </div>
 
             <div style="margin-left: 2px; margin-right: 2px;margin-top:-20px;width:200px">
                 <div class="form-group" id="opfab-end">
                     <of-datetime-filter id="opfab-feed-filter-dateTimeTo" filterPath="end.label" formControlName="dateTimeTo"
-                        labelKey="feed.filters.time." (change)="onDateTimeChange($event)"></of-datetime-filter>
+                    [minDate]="endMinDate"  labelKey="feed.filters.time." (change)="onDateTimeChange($event)"></of-datetime-filter>
                 </div>
 
             </div>

--- a/ui/main/src/app/modules/logging/logging.component.html
+++ b/ui/main/src/app/modules/logging/logging.component.html
@@ -18,22 +18,22 @@
           <div class="opfab-publish-date">
             <div>
               <of-datetime-filter filterPath="publishDateFrom" formControlName="publishDateFrom"
-                labelKey="logging.filters."></of-datetime-filter>
+                labelKey="logging.filters." [maxDate]="publishMaxDate" (change)="onDateTimeChange($event)"></of-datetime-filter>
             </div>
             <div>
               <of-datetime-filter filterPath="publishDateTo" formControlName="publishDateTo"
-                labelKey="logging.filters."></of-datetime-filter>
+                labelKey="logging.filters." [minDate]="publishMinDate" (change)="onDateTimeChange($event)"></of-datetime-filter>
             </div>
           </div>
 
           <div class="opfab-vertical-bar"></div>
           <div style="margin-left:40px;width:230px;min-width: 230px;">
             <div>
-              <of-datetime-filter filterPath="activeFrom" formControlName="activeFrom" labelKey="logging.filters.">
+              <of-datetime-filter filterPath="activeFrom" formControlName="activeFrom" labelKey="logging.filters." [maxDate]="activeMaxDate" (change)="onDateTimeChange($event)">
               </of-datetime-filter>
             </div>
             <div>
-              <of-datetime-filter filterPath="activeTo" formControlName="activeTo" labelKey="logging.filters.">
+              <of-datetime-filter filterPath="activeTo" formControlName="activeTo" labelKey="logging.filters." [minDate]="activeMinDate" (change)="onDateTimeChange($event)">
               </of-datetime-filter>
             </div>
           </div>

--- a/ui/main/src/app/modules/logging/logging.component.ts
+++ b/ui/main/src/app/modules/logging/logging.component.ts
@@ -12,8 +12,8 @@ import {Component, OnDestroy, OnInit, ViewChild} from '@angular/core';
 import {Subject} from 'rxjs';
 
 import {ProcessesService} from '@ofServices/processes.service';
-import {takeUntil} from 'rxjs/operators';
-import {FormControl, FormGroup} from '@angular/forms';
+import {debounceTime, takeUntil} from 'rxjs/operators';
+import {AbstractControl, FormControl, FormGroup} from '@angular/forms';
 import {ConfigService} from '@ofServices/config.service';
 import {TimeService} from '@ofServices/time.service';
 import {CardService} from '@ofServices/card.service';
@@ -24,6 +24,11 @@ import {TranslateService} from '@ngx-translate/core';
 import {ArchivesLoggingFiltersComponent} from '../share/archives-logging-filters/archives-logging-filters.component';
 import {EntitiesService } from '@ofServices/entities.service';
 import {Utilities} from 'app/common/utilities';
+import {MessageLevel} from '@ofModel/message.model';
+import {AlertMessage} from '@ofStore/actions/alert.actions';
+import {Store} from '@ngrx/store';
+import {AppState} from '@ofStore/index';
+import {DateTimeNgb} from '@ofModel/datetime-ngb.model';
 
 
 @Component({
@@ -53,7 +58,14 @@ export class LoggingComponent implements OnDestroy, OnInit {
     listOfProcessesForFilter = [];
     listOfProcessesForRequest = []; 
 
-    constructor(
+    publishMinDate : {year: number, month: number, day: number} = null;
+    publishMaxDate : {year: number, month: number, day: number} = null;
+    activeMinDate : {year: number, month: number, day: number} = null;
+    activeMaxDate : {year: number, month: number, day: number} = null;
+
+    dateTimeFilterChange = new Subject();
+
+    constructor(private store: Store<AppState>,
                 private processesService: ProcessesService,
                 private configService: ConfigService,
                 private timeService: TimeService,
@@ -98,6 +110,28 @@ export class LoggingComponent implements OnDestroy, OnInit {
     ngOnInit() {
         this.size = this.configService.getConfigValue('logging.filters.page.size', 10);
         this.results = [];
+        this.dateTimeFilterChange.pipe(
+            takeUntil(this.unsubscribe$),
+            debounceTime(1000),
+        ).subscribe(() => this.setDateFilterBounds());
+    }
+
+
+    setDateFilterBounds(): void {
+
+        if (this.loggingForm.value.publishDateFrom?.date) {
+            this.publishMinDate = {year: this.loggingForm.value.publishDateFrom.date.year, month: this.loggingForm.value.publishDateFrom.date.month, day: this.loggingForm.value.publishDateFrom.date.day};
+        }
+        if (this.loggingForm.value.publishDateTo?.date) {
+            this.publishMaxDate = {year: this.loggingForm.value.publishDateTo.date.year, month: this.loggingForm.value.publishDateTo.date.month, day: this.loggingForm.value.publishDateTo.date.day};
+        }
+
+        if (this.loggingForm.value.activeFrom?.date) {
+            this.activeMinDate = {year: this.loggingForm.value.activeFrom.date.year, month: this.loggingForm.value.activeFrom.date.month, day: this.loggingForm.value.activeFrom.date.day};
+        }
+        if (this.loggingForm.value.activeTo?.date) {
+            this.activeMaxDate = {year: this.loggingForm.value.activeTo.date.year, month: this.loggingForm.value.activeTo.date.month, day: this.loggingForm.value.activeTo.date.day};
+        }
     }
 
     resetForm() {
@@ -105,9 +139,37 @@ export class LoggingComponent implements OnDestroy, OnInit {
         this.firstQueryHasBeenDone = false;
         this.hasResult = false;
         this.resultsNumber = 0;
+        this.publishMinDate = null;
+        this.publishMaxDate = null;
+        this.activeMinDate = null;
+        this.activeMaxDate = null;
     }
 
+    onDateTimeChange(event: Event) {
+        this.dateTimeFilterChange.next();
+    }
+
+    private displayMessage(i18nKey: string, msg: string, severity: MessageLevel = MessageLevel.ERROR) {
+        this.store.dispatch(new AlertMessage({alertMessage: {message: msg, level: severity, i18n: {key: i18nKey}}}));
+    }
+    
     sendQuery(page_number): void {
+        const publishStart = this.extractTime(this.loggingForm.get('publishDateFrom'));
+        const publishEnd = this.extractTime(this.loggingForm.get('publishDateTo'));
+
+        if (publishStart != null && !isNaN(publishStart) && publishEnd != null && !isNaN(publishEnd) && publishStart > publishEnd) {
+            this.displayMessage('logging.filters.publishEndDateBeforeStartDate','',MessageLevel.ERROR);
+            return;
+        }
+
+        const activeStart = this.extractTime(this.loggingForm.get('activeFrom'));
+        const activeEnd = this.extractTime(this.loggingForm.get('activeTo'));
+
+        if (activeStart != null && !isNaN(activeStart) && activeEnd != null && !isNaN(activeEnd) && activeStart > activeEnd) {
+            this.displayMessage('logging.filters.activeEndDateBeforeStartDate','',MessageLevel.ERROR);
+            return;
+        }
+
         const { value } = this.loggingForm;
         this.filtersTemplate.filtersToMap(value);
         this.filtersTemplate.filters.set('size', [this.size.toString()]);
@@ -127,6 +189,26 @@ export class LoggingComponent implements OnDestroy, OnInit {
                 });
                 this.results = page.content;
             });
+    }
+
+    private extractTime(form: AbstractControl) {
+        const val = form.value;
+        if (!val || val == '')  {
+            return null;
+        }
+
+        if (isNaN(val.time.hour)) {
+            val.time.hour = 0;
+        }
+        if (isNaN(val.time.minute)) {
+            val.time.minute = 0;
+        }
+        if (isNaN(val.time.second)) {
+            val.time.second = 0;
+        }
+
+        const converter = new DateTimeNgb(val.date, val.time);
+        return converter.convertToNumber();
     }
 
     cardPostProcessing(card) {

--- a/ui/main/src/app/modules/share/datetime-filter/datetime-filter.component.html
+++ b/ui/main/src/app/modules/share/datetime-filter/datetime-filter.component.html
@@ -19,6 +19,8 @@
                    id="opfab-date"
                    formControlName="date"
                    (click)="nsd.toggle()"
+                   [minDate]="minDate"
+                   [maxDate]="maxDate"
             placeholder="YYYY-MM-DD"/>
         </div>
         </td>

--- a/ui/main/src/app/modules/share/datetime-filter/datetime-filter.component.ts
+++ b/ui/main/src/app/modules/share/datetime-filter/datetime-filter.component.ts
@@ -1,4 +1,4 @@
-/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+/* Copyright (c) 2018-2021, RTE (http://www.rte-france.com)
  * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -35,6 +35,8 @@ export class DatetimeFilterComponent implements ControlValueAccessor, OnInit, On
     // no "unit of time enforcement", so be careful using offset
     @Input() offset: { amount: number, unit: string }[];
     @Output() change = new EventEmitter();
+    @Input() minDate: {year: number, month: number, day: number};
+    @Input() maxDate: {year: number, month: number, day: number};
 
     disabled = true;
     time = {hour: 0, minute: 0};

--- a/ui/main/src/assets/i18n/en.json
+++ b/ui/main/src/assets/i18n/en.json
@@ -49,8 +49,8 @@
         "titleIfFilterBasedOnBusinessDate": "Business period",
         "start.label": "Start",
         "end.label": "End",
-        "active.label": "Active"
-        
+        "active.label": "Active",
+        "endDateBeforeStartDate": "End date must be after start date"
       },
       "type": {
         "title": "Type",
@@ -148,7 +148,9 @@
       "publishDateFrom": "PUBLISH FROM",
       "publishDateTo": "PUBLISH TO",
       "activeFrom": "ACTIVE FROM",
-      "activeTo": "ACTIVE TO"
+      "activeTo": "ACTIVE TO",
+      "publishEndDateBeforeStartDate" : "Publish end date must be after start date",
+      "activeEndDateBeforeStartDate" : "Active end date must be after start date"
     },
     "result": {
       "severity": "SEVERITY",
@@ -161,13 +163,16 @@
     "noResult": "Your search did not match any results.",
     "exportToExcel" : "Export data",
     "resultsNumber":"Results number"
+
   },
   "logging": {
     "filters": {
       "publishDateFrom": "PUBLISH FROM",
       "publishDateTo": "PUBLISH TO",
       "activeFrom": "ACTIVE FROM",
-      "activeTo": "ACTIVE TO"
+      "activeTo": "ACTIVE TO",
+      "publishEndDateBeforeStartDate" : "Publish end date must be after start date",
+      "activeEndDateBeforeStartDate" : "Active end date must be after start date"
     },
     "result": {
       "severity": "SEVERITY",

--- a/ui/main/src/assets/i18n/fr.json
+++ b/ui/main/src/assets/i18n/fr.json
@@ -49,7 +49,8 @@
         "titleIfFilterBasedOnBusinessDate": "Période métier",
         "start.label": "Début",
         "end.label": "Fin",
-        "active.label": "Actif"
+        "active.label": "Actif",
+        "endDateBeforeStartDate": "La date de fin doit être postérieure à la date de début"
       },
       "type": {
         "title": "Type",
@@ -147,7 +148,9 @@
       "publishDateFrom": "PUBLIE A PARTIR DE",
       "publishDateTo": "PUBLIE JUSQU'A",
       "activeFrom": "ACTIVE A PARTIR DE",
-      "activeTo": "ACTIVE JUSQU'A"
+      "activeTo": "ACTIVE JUSQU'A",
+      "publishEndDateBeforeStartDate" : "La date de fin doit être postérieure à la date de début",
+      "activeEndDateBeforeStartDate" : "La date de fin doit être postérieure à la date de début"
     },
     "result": {
       "severity": "SEVERITE",
@@ -166,7 +169,9 @@
       "publishDateFrom": "PUBLIE A PARTIR DE",
       "publishDateTo": "PUBLIE JUSQU'A",
       "activeFrom": "ACTIVE A PARTIR DE",
-      "activeTo": "ACTIVE JUSQU'A"
+      "activeTo": "ACTIVE JUSQU'A",
+      "publishEndDateBeforeStartDate" : "La date de fin doit être postérieure à la date de début",
+      "activeEndDateBeforeStartDate" : "La date de fin doit être postérieure à la date de début"
     },
     "result": { 
       "severity": "SEVERITE",


### PR DESCRIPTION
Forbidden calendar dates are disabled. A warning message is shown when same date and end time is before start time, on logging and archives the message is shown when clicking on search button. 

Release notes

In Features section:
[1806] : Date filters : make impossible to enter a start date later than end date

Signed-off-by: Giovanni Ferrari <giovanni.ferrari@soft.it>