### PR TITLE
[OC-1805] In Archive page the values of service multifilter should not wrap

### DIFF
--- a/ui/main/src/assets/styles/styles.scss
+++ b/ui/main/src/assets/styles/styles.scss
@@ -544,13 +544,6 @@ type-ahead > .badge-primary {
 
 }
 
-// Apply only on archives and logging pages as we want only one value in to see in the input field 
-.archives-page .opfab-multiselect .c-token,
-.archives-login .opfab-multiselect .c-token
- {
- width: 85%;
-}
-
 .opfab-multiselect::after {
   content: "V";
   transform: scaleY(0.5);


### PR DESCRIPTION
Release notes

In Bugs section:
[OC-1805] : In Archive page the values of service multifilter should not wrap

Signed-off-by: Giovanni Ferrari <giovanni.ferrari@soft.it>

[OC-1805]: https://opfab.atlassian.net/browse/OC-1805