### PR TITLE
#1272 Posting a perimeter with blank string state cause 500 internal error

### DIFF
--- a/services/core/users/src/main/java/org/opfab/users/controllers/CustomExceptionHandler.java
+++ b/services/core/users/src/main/java/org/opfab/users/controllers/CustomExceptionHandler.java
@@ -15,6 +15,7 @@ import feign.FeignException;
 import lombok.extern.slf4j.Slf4j;
 import org.opfab.springtools.error.model.ApiError;
 import org.opfab.springtools.error.model.ApiErrorException;
+import org.springframework.core.convert.ConversionFailedException;
 import org.springframework.dao.DuplicateKeyException;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -93,5 +94,22 @@ public class CustomExceptionHandler extends ResponseEntityExceptionHandler {
   protected ResponseEntity<Object> handleExceptionInternal(Exception ex, Object body, HttpHeaders headers, HttpStatus status, WebRequest request) {
     log.error("Uncaught internal server exception",ex);
     return super.handleExceptionInternal(ex, body, headers, status, request);
+  }
+
+    /**
+   * Handles {@link ConversionFailedException} as 400 BAD_REQUEST error
+   * @param exception exception to handle
+   * @return Computed http response for specified exception
+   */
+  @ExceptionHandler(ConversionFailedException.class)
+  public ResponseEntity<Object> handleConversionError(ConversionFailedException exception, final WebRequest
+          request) {
+    log.error(GENERIC_MSG,exception);
+    ApiError error = ApiError.builder()
+            .status(HttpStatus.BAD_REQUEST)
+            .message("Conversion Error")
+            .error(exception.getMessage())
+            .build();
+    return new ResponseEntity<>(error, error.getStatus());
   }
 }

--- a/services/core/users/src/test/java/org/opfab/users/controllers/PerimetersControllerShould.java
+++ b/services/core/users/src/test/java/org/opfab/users/controllers/PerimetersControllerShould.java
@@ -293,6 +293,25 @@ class PerimetersControllerShould {
         }
 
         @Test
+        void createWithConversionError() throws Exception {
+            mockMvc.perform(post("/perimeters")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("{" +
+                            "\"id\": \"PERIMETER3\"," +
+                            "\"process\": \"process3\"," +
+                            "\"stateRights\": [{" +
+                              "\"state\": \"\"," +
+                              "\"right\": \"\"" +
+                              "}]" +
+                            "}")
+            )
+                    .andExpect(status().is(HttpStatus.BAD_REQUEST.value()))
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(jsonPath("$.status", is(HttpStatus.BAD_REQUEST.name())))
+                    .andExpect(jsonPath("$.message", is("Conversion Error")));
+        }
+
+        @Test
         void update() throws Exception {
             mockMvc.perform(put("/perimeters/PERIMETER1_2")
                     .contentType(MediaType.APPLICATION_JSON)


### PR DESCRIPTION
Release notes

In Bugs section:

#1272 : Posting a perimeter with blank string state cause 500 internal error

Signed-off-by: Giovanni Ferrari <giovanni.ferrari@soft.it>