### PR TITLE
Fix #1311 Moving Karate and Cypress to separate stages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ install:
   - node --version
   - sdk version
   - javac -version
+  - docker info
 jobs:
   include:
     - stage: test
@@ -49,25 +50,46 @@ jobs:
       script:
         - docker login --username ${DOCKER_CLOUD_USER} --password ${DOCKER_CLOUD_PWD}
         - docker-compose -f src/main/docker/test-environment/docker-compose.yml up -d
-        - ./gradlew --build-cache copyDependencies test jacocoTestReport dockerTag${OF_VERSION}
-        - sonar-scanner
+        - ./gradlew --build-cache copyDependencies test jacocoTestReport
         - docker-compose -f src/main/docker/test-environment/docker-compose.yml down
-        # Launch karate tests
-        - cd config/docker
+        - sonar-scanner
+    - stage: docker-tag-version
+      script:
+        - echo preparing images for version $OF_VERSION
+        - ./gradlew --build-cache copyWorkingDir dockerTag${OF_VERSION} -x test
+        - docker image ls -a|grep lfeoperatorfabric
+        - docker save $(docker images --filter=reference="lfeoperatorfabric/*" --format "{{.Repository}}:{{.Tag}}") | gzip > local_opfab_images.tar.gz
+      workspaces:
+        create:
+          name: docker-images
+          paths:
+            - local_opfab_images.tar.gz
+    - stage: karate
+      workspaces:
+        use: docker-images
+      script:
+        - docker load < local_opfab_images.tar.gz
+        - docker image ls -a|grep lfeoperatorfabric
+        - cd $OF_HOME/config/docker
         - ./docker-compose.sh
-        - cd ../../bin
+        - cd $OF_HOME/bin
         - ./waitForOpfabToStart.sh
-        - cd ../src/test/api/karate
+        - cd $OF_HOME/src/test/api/karate
         - ./launchAll.sh
-        - cd ../../../../config/docker
+        - cd $OF_HOME/config/docker
         - docker-compose down
-        # Launch cypress tests
+    - stage: cypress
+      workspaces:
+        use: docker-images
+      script:
+        - docker load < local_opfab_images.tar.gz
+        - cd $OF_HOME/config/docker
         - ./docker-compose-cypress.sh
-        - cd ../../bin
+        - cd $OF_HOME/bin
         - ./waitForOpfabToStart.sh
         - cd $OF_HOME
         - ./gradlew runCypressTests
-        - cd ./config/docker
+        - cd $OF_HOME/config/docker
         - docker-compose down
     - stage: doc
       script:
@@ -89,16 +111,17 @@ jobs:
         - docker login --username ${DOCKER_CLOUD_USER} --password ${DOCKER_CLOUD_PWD}
         - ./gradlew --build-cache copyWorkingDir dockerPushLatest -x test
         - docker image ls -a|grep lfeoperatorfabric
-    - stage: docker-tag-version
-      script:
-        - echo preparing images for version $OF_VERSION
-        - ./gradlew --build-cache copyWorkingDir dockerTag${OF_VERSION} -x test
-        - docker image ls -a|grep lfeoperatorfabric
 stages:
   # Note: The condition on type is necessary to exclude PRs because their base branch is usually develop
   - name: test
     if: type = pull_request AND head_repo != opfab/operatorfabric-core
   - name: test-sonar
+    if: NOT (type = pull_request AND head_repo != opfab/operatorfabric-core)
+  - name: docker-tag-version
+    if: NOT (type = pull_request AND head_repo != opfab/operatorfabric-core)
+  - name: karate
+    if: NOT (type = pull_request AND head_repo != opfab/operatorfabric-core)
+  - name: cypress
     if: NOT (type = pull_request AND head_repo != opfab/operatorfabric-core)
   - name: doc
     if: ((((type = cron OR commit_message =~ ci_documentation) AND branch = develop) OR (commit_message =~ ci_documentation AND NOT commit_message =~ ci_latest AND branch =~ .+hotfixes$)) AND NOT type = pull_request)
@@ -108,8 +131,6 @@ stages:
     if: (((type = cron OR commit_message =~ ci_docker) AND (branch = develop OR branch =~ .+hotfixes$)) OR branch = master) AND NOT type = pull_request
   - name: docker-push-latest
     if: branch = master OR (branch =~ .+hotfixes$ AND commit_message =~ ci_latest) AND NOT type = pull_request
-  - name: docker-tag-version
-    if: (branch =~ .+release$) OR (NOT (branch IN (master,develop)) AND commit_message =~ ci_docker)
 before_cache:
   # cleanup gradle caches
   - rm -f  ${HOME}/.gradle/caches/modules-2/modules-2.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,12 +64,12 @@ jobs:
           name: docker-images
           paths:
             - local_opfab_images.tar.gz
-    - stage: karate
+    - stage: integration-tests
       workspaces:
         use: docker-images
+      name: karate
       script:
         - docker load < local_opfab_images.tar.gz
-        - docker image ls -a|grep lfeoperatorfabric
         - cd $OF_HOME/config/docker
         - ./docker-compose.sh
         - cd $OF_HOME/bin
@@ -78,10 +78,7 @@ jobs:
         - ./launchAll.sh
         - cd $OF_HOME/config/docker
         - docker-compose down
-    - stage: cypress
-      workspaces:
-        use: docker-images
-      script:
+    - script:
         - docker load < local_opfab_images.tar.gz
         - cd $OF_HOME/config/docker
         - ./docker-compose-cypress.sh
@@ -91,6 +88,7 @@ jobs:
         - ./gradlew runCypressTests
         - cd $OF_HOME/config/docker
         - docker-compose down
+      name: cypress
     - stage: doc
       script:
         - ./gradlew --build-cache generateSwaggerUI asciidoctor


### PR DESCRIPTION
Signed-off-by: Alexandra Guironnet <alexandra.guironnet@rte-france.com>

TODO Update pipeline doc (hooks etc.)
Docker push should use workspace as well
ui build runs again (rather than being taken from cache) when generating the docker images... 2m40 out of 5m25 (logged #1413)