### PR TITLE
Fix #1282 Update timeline dependency @swimlane/ngx-charts to v18

### DIFF
--- a/ui/main/package-lock.json
+++ b/ui/main/package-lock.json
@@ -4029,10 +4029,11 @@
       }
     },
     "@swimlane/ngx-charts": {
-      "version": "17.0.1",
-      "resolved": "https://registry.npmjs.org/@swimlane/ngx-charts/-/ngx-charts-17.0.1.tgz",
-      "integrity": "sha512-4pvSznkFo/vM59YUnXH0Y/f8n9cUBBelHuh7UoNlMchl1jI083eFk0zK5fEL2sF3c+vvEpBeYB523GxWvWoifw==",
+      "version": "18.0.1",
+      "resolved": "https://registry.npmjs.org/@swimlane/ngx-charts/-/ngx-charts-18.0.1.tgz",
+      "integrity": "sha512-yTSKIPyzcrR13wUnJf5K4cem+nrYhfKeywdipLM+7/qgJiLcs7HFRvcUhCTp3jQl2K+y8a6OWJAAmS8azcAshg==",
       "requires": {
+        "@types/d3-shape": "^2.0.0",
         "d3-array": "^2.9.1",
         "d3-brush": "^2.1.0",
         "d3-color": "^2.0.0",
@@ -4099,6 +4100,19 @@
       "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.10.tgz",
       "integrity": "sha512-C7srjHiVG3Ey1nR6d511dtDkCEjxuN9W1HWAEjGq8kpcwmNM6JJkpC0xvabM7BXTG2wDq8Eu33iH9aQKa7IvLQ==",
       "dev": true
+    },
+    "@types/d3-path": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-2.0.1.tgz",
+      "integrity": "sha512-6K8LaFlztlhZO7mwsZg7ClRsdLg3FJRzIIi6SZXDWmmSJc2x8dd2VkESbLXdk3p8cuvz71f36S0y8Zv2AxqvQw=="
+    },
+    "@types/d3-shape": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-2.1.2.tgz",
+      "integrity": "sha512-LeRBMzX30vohbkES3YEjXDKjOuP1QVJbvzIk9VaI2+wZaEyzar7cJckJNeHTCPSIVbDGE0SiIf46UkCygFz8DQ==",
+      "requires": {
+        "@types/d3-path": "^2"
+      }
     },
     "@types/eslint": {
       "version": "7.2.13",
@@ -6320,9 +6334,9 @@
       "dev": true
     },
     "d3-array": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.0.tgz",
-      "integrity": "sha512-T6H/qNldyD/1OlRkJbonb3u3MPhNwju8OPxYv0YSjDb/B2RUeeBEHzIpNrYiinwpmz8+am+puMrpcrDWgY9wRg==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
       "requires": {
         "internmap": "^1.0.0"
       }
@@ -6387,14 +6401,14 @@
       "integrity": "sha512-ZwZQxKhBnv9yHaiWd6ZU4x5BtCQ7pXszEV9CU6kRgwIQVQGLMv1oiL4M+MK/n79sYzsj+gcgpPQSctJUsLN7fA=="
     },
     "d3-scale": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-3.2.3.tgz",
-      "integrity": "sha512-8E37oWEmEzj57bHcnjPVOBS3n4jqakOeuv1EDdQSiSrYnMCBdMd3nc4HtKk7uia8DUHcY/CGuJ42xxgtEYrX0g==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-3.3.0.tgz",
+      "integrity": "sha512-1JGp44NQCt5d1g+Yy+GeOnZP7xHo0ii8zsQp6PGzd+C1/dl0KGsp9A7Mxwp+1D1o4unbTTxVdU/ZOIEBoeZPbQ==",
       "requires": {
         "d3-array": "^2.3.0",
         "d3-format": "1 - 2",
         "d3-interpolate": "1.2.0 - 2",
-        "d3-time": "1 - 2",
+        "d3-time": "^2.1.1",
         "d3-time-format": "2 - 3"
       }
     },
@@ -6412,9 +6426,12 @@
       }
     },
     "d3-time": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-2.0.0.tgz",
-      "integrity": "sha512-2mvhstTFcMvwStWd9Tj3e6CEqtOivtD8AUiHT8ido/xmzrI9ijrUUihZ6nHuf/vsScRBonagOdj0Vv+SEL5G3Q=="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-2.1.1.tgz",
+      "integrity": "sha512-/eIQe/eR4kCQwq7yxi7z4c6qEXf2IYGcjoWB5OOQy4Tq9Uv39/947qlDcN2TLkiTzQWzvnsuYPB9TrWaNfipKQ==",
+      "requires": {
+        "d3-array": "2"
+      }
     },
     "d3-time-format": {
       "version": "3.0.0",

--- a/ui/main/package.json
+++ b/ui/main/package.json
@@ -39,7 +39,7 @@
     "@ngrx/store": "12.0.0",
     "@ngx-translate/core": "13.0.0",
     "@ngx-translate/http-loader": "6.0.0",
-    "@swimlane/ngx-charts": "17.0.1",
+    "@swimlane/ngx-charts": "18.0.1",
     "@types/jwt-decode": "2.2.1",
     "ag-grid-angular": "25.3.0",
     "ag-grid-community": "25.3.0",

--- a/ui/main/src/app/modules/feed/components/time-line/custom-timeline-chart/custom-timeline-chart.component.ts
+++ b/ui/main/src/app/modules/feed/components/time-line/custom-timeline-chart/custom-timeline-chart.component.ts
@@ -24,7 +24,13 @@ import {
   ViewEncapsulation
 } from '@angular/core';
 import {scaleLinear, scaleTime} from 'd3-scale';
-import {BaseChartComponent, calculateViewDimensions, ChartComponent, ViewDimensions} from '@swimlane/ngx-charts';
+import {
+  BaseChartComponent,
+  calculateViewDimensions,
+  ChartComponent,
+  ScaleType,
+  ViewDimensions
+} from '@swimlane/ngx-charts';
 import * as moment from 'moment';
 import {Store} from '@ngrx/store';
 import {selectCurrentUrl} from '@ofStore/selectors/router.selectors';
@@ -234,7 +240,7 @@ export class CustomTimelineChartComponent extends BaseChartComponent implements 
       xAxisHeight: this.xAxisHeight,
       yAxisWidth: this.yAxisWidth,
       showLegend: false,
-      legendType: 'time'
+      legendType: ScaleType.Time
     });
     this.xScale =  scaleTime().range([0, this.dims.width]).domain(this.xDomain);
     this.yScale =  scaleLinear().range([this.dims.height, 0]).domain([0, 5]);


### PR DESCRIPTION
Release notes : 

In Tasks section : 

#1282 : Update timeline dependency @swimlane/ngx-charts to v18

Signed-off-by: vlo-rte <valerie.longa@rte-france.com>