### PR TITLE
#1353 Removing doc-dry-run stage in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,9 +77,6 @@ jobs:
       script:
         - ./gradlew --build-cache generateSwaggerUI asciidoctor
         - ./CICD/travis/upload_doc.sh --updateLatest true
-    - stage: doc-dry-run
-      script:
-        - ./gradlew --build-cache generateSwaggerUI asciidoctor
     - stage: docker-push-version
       script:
         - echo preparing images for version $OF_VERSION
@@ -107,8 +104,6 @@ stages:
     if: ((((type = cron OR commit_message =~ ci_documentation) AND branch = develop) OR (commit_message =~ ci_documentation AND NOT commit_message =~ ci_latest AND branch =~ .+hotfixes$)) AND NOT type = pull_request)
   - name: doc-latest
     if: (branch = master OR (branch =~ .+hotfixes$ AND commit_message =~ ci_latest)) AND NOT type = pull_request
-  - name: doc-dry-run
-    if: (NOT branch =~ .+hotfixes$) AND (NOT (branch IN (master,develop)) AND commit_message =~ ci_documentation)
   - name: docker-push-version
     if: (((type = cron OR commit_message =~ ci_docker) AND (branch = develop OR branch =~ .+hotfixes$)) OR branch = master) AND NOT type = pull_request
   - name: docker-push-latest

--- a/src/docs/asciidoc/CICD/pipeline_conf.adoc
+++ b/src/docs/asciidoc/CICD/pipeline_conf.adoc
@@ -34,7 +34,6 @@ repository to update the documentation for this release on the website.
 doc-latest:: Generates the documentation (from asciidoc sources and API documentation) and pushes it to the
 opfab.github.io repository to update the documentation for this release, as well as the "current" documentation on the
 website.
-doc-dry-run:: Generates the documentation without pushing it
 docker-push-version:: Builds Docker images, tags them with the current version (either `SNAPSHOT` or `X.X.X.RELEASE`) and
 pushes them to DockerHub
 docker-push-latest:: Builds Docker images, tags them with `latest` and pushes them to DockerHub
@@ -66,7 +65,6 @@ e|test-sonar          |X|X| | |X|X|X| | | |X| | |internal
 e|test                | | | | | | | | | | | | | |external
 e|doc                 |X| |X| | | | |X| | | | | |
 e|doc-latest          | | | | | |X| | | |X| | | |
-e|doc-dry-run         | | | | |X| | | | | | |X| |
 e|docker-push-version |X| | |X| |X| | |X| | | | |
 e|docker-push-latest  | | | | | |X| | | |X| | | |
 e|docker-tag-version  | | | | |X| | | | | | | |X|

--- a/src/docs/asciidoc/community/workflow.adoc
+++ b/src/docs/asciidoc/community/workflow.adoc
@@ -136,7 +136,7 @@ be merged back into `develop`.
 
 Once the `X.X.X.release` branch has been created, a new commit should be made on this branch to change the repository
 version from `SNAPSHOT` to `X.X.X.RELEASE`.
-Then, pushing the branch will trigger a build and a "dry-run" generation of documentation and docker images. The aim
+Then, pushing the branch will trigger a build and a "dry-run" generation of docker images. The aim
 is to detect any issue with this generation before moving to master.
 
 Finally, the `X.X.X.release` can be merged into `master`, triggering


### PR DESCRIPTION
fix #1353 

This PR remove the doc-dry-run stage from the travis configuration and documentation. It as meant so we could test the documentation generation on the CI without actually publishing to the website, but there's little point (it's not that often that the documentation generation fails and we can test it locally).

No need to mention it in release notes I would say.

Signed-off-by: Alexandra Guironnet <alexandra.guironnet@rte-france.com>