### PR TITLE
Only trigger UI build if task is not up to date (#1413)

### DIFF
--- a/ui/main/build.gradle
+++ b/ui/main/build.gradle
@@ -1,26 +1,48 @@
-npm_run_build {
-    args = ['--', '--configuration=production', '--baseHref=/ui/', '--deployUrl=/ui/']
+npmInstall {
+    inputs.files(fileTree('node_modules'))
+    inputs.file('package.json')
+    inputs.file('package-lock.json')
+    inputs.file('angular.json')
+    inputs.file('tslint.json')
+
+    outputs.dir('build')
+
 }
 
-task npmBuildDebug(type: NpmTask) {
-    args = ['run', 'build','--', '--configuration=productionDebug', '--baseHref=/ui/', '--deployUrl=/ui/']
+task runBuild(type: NpmTask) {
+    inputs.files(fileTree('src'))
+    inputs.files(fileTree('node_modules'))
+    inputs.file('package.json')
+    inputs.file('package-lock.json')
+    inputs.file('angular.json')
+    inputs.file('tslint.json')
+
+    outputs.dir('build')
+
+    dependsOn npmInstall
+    args = ['run', 'build', '--configuration=production', '--baseHref=/ui/', '--deployUrl=/ui/']
 }
 
-npm_run_test {
-    args = ['--', '--browsers', 'ChromeHeadless', '--watch=false', '--code-coverage']
+task runHeadlessTests(type: NpmTask) {
+    inputs.files(fileTree('src'))
+    inputs.files(fileTree('node_modules'))
+    inputs.file('package.json')
+    inputs.file('package-lock.json')
+    inputs.file('angular.json')
+    inputs.file('tslint.json')
+
+    outputs.dir('reports')
+
+    dependsOn npmInstall
+    args = ['run', 'headless']
 }
 
-npm_run_headless.dependsOn(npm_install)
-test.dependsOn(npm_run_headless)
-if(project.hasProperty('uiDebug'))
-    build.dependsOn(npmBuildDebug)
-else
-    build.dependsOn(npm_run_build)
+test.dependsOn(runHeadlessTests)
 
 task securityReport {
     dependsOn 'npm_run_audit'
 }
 
-build.dependsOn(npm_run_build)
+build.dependsOn(runBuild)
 
-assemble.dependsOn(npm_run_build)
+assemble.dependsOn(runBuild)


### PR DESCRIPTION
Fixes #1413 

Now the ui build and tests are only run if either (or both) of the following statements is true :

1. Something has changed in their inputs:
- src (except for npm install)
- node_modules
- package.json
- package-lock.json
- angular.json
- tslint.json
2. Something has changed in their outputs (most likely, the output has been cleaned): build directory for the build task, reports directory for the test tasks.

I also took this opportunity to remove custom tasks that were neither used nor documented.

I tested changing the source, changing a dependency version in package.json, deleting the build altogether: in all these cases, the ui build is run.

I think it's worth a word in the release notes just in case someone notices the change in behaviour. Under tasks:
* 1413 : Only trigger UI build if inputs or outputs have changed

Signed-off-by: Alexandra Guironnet <alexandra.guironnet@rte-france.com>