### PR TITLE
Removing dependency reporting plugins (#1359)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -120,7 +120,6 @@ cache:
     # caches gradle caches
     - ${HOME}/.gradle/caches/
     - ${HOME}/.gradle/wrapper/
-    - ${HOME}/.gradle/dependency-check-data/
     # cache ui dependencies
     - ui/main/nodes_modules
     # cache cypress dependencies and binary

--- a/build.gradle
+++ b/build.gradle
@@ -1,11 +1,8 @@
-import com.github.jk1.license.render.*
 plugins {
-    id "com.github.jk1.dependency-license-report" version "1.16"
     id "com.github.node-gradle.node" version "3.1.0"
     id "org.asciidoctor.convert" version "1.6.1" //Upgrading to 2.4.0 changed the behaviour of {gradle-rootdir}, breaking all cross-document links
     id "maven-publish"
     id "signing"
-    id "org.owasp.dependencycheck" version "6.2.1"
     id 'org.springframework.boot' version '2.5.1'
     id 'org.sonarqube' version '3.2.0' apply false
 }
@@ -107,10 +104,6 @@ ext.apk.proxy.httpsuri = hasProperty('apk.proxy.httpsuri') && property('apk.prox
 ext.apk.proxy.user = hasProperty('apk.proxy.user') && property('apk.proxy.user') != null && property('apk.proxy.user') != "" ? property('apk.proxy.user') : System.env.APK_PROXY_USER != null ? "$System.env.APK_PROXY_USER" : ""
 ext.apk.proxy.password = hasProperty('apk.proxy.password') && property('apk.proxy.password') != null && property('apk.proxy.password') != "" ? property('apk.proxy.password') : System.env.APK_PROXY_PASSWORD != null ? "$System.env.APK_PROXY_PASSWORD" : ""
 
-licenseReport {
-    renderers = [new InventoryHtmlReportRenderer()]
-}
-
 //tag::asciidoctor_gradle_task_config[]
 asciidoctor {
 
@@ -141,22 +134,9 @@ subprojects {
 
     group operatorfabric.group
     version operatorfabric.version
-    apply plugin: "com.github.jk1.dependency-license-report"
-    apply plugin: 'org.owasp.dependencycheck'
-    
-
-    if (project.name != 'main-user-interface') {
-        task securityReport {
-            dependsOn 'dependencyCheckAnalyze'
-        }
-    }   
     
     if (project.parent.path.startsWith(':services:')){
         apply plugin: 'org.sonarqube'
-    }
-
-    licenseReport {
-        renderers = [new InventoryHtmlReportRenderer()]
     }
 
     repositories {

--- a/ui/main/build.gradle
+++ b/ui/main/build.gradle
@@ -39,10 +39,6 @@ task runHeadlessTests(type: NpmTask) {
 
 test.dependsOn(runHeadlessTests)
 
-task securityReport {
-    dependsOn 'npm_run_audit'
-}
-
 build.dependsOn(runBuild)
 
 assemble.dependsOn(runBuild)


### PR DESCRIPTION
Fix #1359 

In release notes, under tasks:

#1359 : Remove dependency reporting plugins from Gradle build
+
Reports regarding dependency licences and security vulnerabilities are now provided by [LFX Security](https://security.lfx.linuxfoundation.org/#/a094100001Cb6HaAAJ/foundation-details)

Signed-off-by: Alexandra Guironnet <alexandra.guironnet@rte-france.com>