### PR TITLE
Caching cypress installation (#1312)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -123,4 +123,5 @@ cache:
     - ${HOME}/.gradle/dependency-check-data/
     # cache ui dependencies
     - ui/main/nodes_modules
+    - src/test/cypress/node_modules
     - ${HOME}/.sdkman


### PR DESCRIPTION
Fixes #1312 

In release notes, under tasks:
#1312 : Caching cypress installation
Maybe bundle it with other issues under "Speeding up Gradle build"?

Signed-off-by: Alexandra Guironnet <alexandra.guironnet@rte-france.com>