### PR TITLE
Updating card detail header to use state type (#1430)

### DIFF
--- a/src/test/cypress/cypress/integration/Acknowledgment.spec.js
+++ b/src/test/cypress/cypress/integration/Acknowledgment.spec.js
@@ -15,6 +15,10 @@ describe('Acknowledgment  tests', function () {
         cy.resetUIConfigurationFiles();
 
         cy.loadTestConf();
+
+        // Clean up existing cards
+        cy.deleteAllCards();
+
         // Send a card with ack config set to Always
         // ack is possible 
         cy.sendCard('cypress/ack/message1.json');
@@ -38,15 +42,6 @@ describe('Acknowledgment  tests', function () {
         // Send a card with ack config set to OnlyWhenResponseDisabledForUser and user can respond and lttd is not expired
         // ack is not possible before lttd is expired
         cy.sendCard('cypress/ack/message6.json');
-    });
-
-    after('Clean', function () {
-        cy.deleteCard('cypress.message1');
-        cy.deleteCard('cypress.message2');
-        cy.deleteCard('cypress.message3');
-        cy.deleteCard('cypress.message4');
-        cy.deleteCard('cypress.message5');
-        cy.deleteCard('cypress.message6');
     });
 
     it('Check acknowledgment for operator 1', function () {

--- a/src/test/cypress/cypress/integration/Archives.spec.js
+++ b/src/test/cypress/cypress/integration/Archives.spec.js
@@ -1,10 +1,10 @@
 
 describe ('Archives screen tests',function () {
 
-    before('Set up configuration', function () {
+    before('Set up configuration and clean archived cards', function () {
         cy.loadTestConf();
         cy.deleteAllArchivedCards();
-        cy.sendTestCards();
+        cy.send6TestCards();
     });
 
 
@@ -27,14 +27,14 @@ describe ('Archives screen tests',function () {
         cy.get('#opfab-archive-results-number').should('have.text', ' Results number  : 6 ')
 
         // We delete the test cards and we check that we still have the corresponding archived cards
-        cy.deleteTestCards();
+        cy.deleteAllCards();
         cy.get('#opfab-archives-btn-search').click();
         cy.get('#opfab-archives-cards-list').find('.opfab-archives-table-line').should('have.length',6);
         cy.get('of-card-detail').should('not.exist');
         cy.get('#opfab-archive-results-number').should('have.text', ' Results number  : 6 ')
 
         // We send again the test cards and we check that the we have 12 archived cards (10 archived cards displayed for first page)
-        cy.sendTestCards();
+        cy.send6TestCards();
         cy.get('#opfab-archives-btn-search').click();
         cy.get('#opfab-archives-cards-list').find('.opfab-archives-table-line').should('have.length',10);
         cy.get('of-card-detail').should('not.exist');

--- a/src/test/cypress/cypress/integration/FeedConfigurationTests.spec.js
+++ b/src/test/cypress/cypress/integration/FeedConfigurationTests.spec.js
@@ -9,10 +9,10 @@
 
 describe ('Feed configuration tests',function () {
 
-    before('Set up configuration', function () {
+    before('Set up configuration and cards', function () {
         cy.loadTestConf();
-        cy.deleteTestCards();
-        cy.sendTestCards(); // The feed needs to have cards so the "Acknowledge all cards" feature can be shown
+        cy.deleteAllCards();
+        cy.send6TestCards(); // The feed needs to have cards so the "Acknowledge all cards" feature can be shown
     });
 
     beforeEach('Reset UI configuration file ', function () {

--- a/src/test/cypress/cypress/integration/FeedTests.spec.js
+++ b/src/test/cypress/cypress/integration/FeedTests.spec.js
@@ -15,13 +15,13 @@ describe ('FeedScreen tests',function () {
         cy.resetUIConfigurationFiles();
 
         cy.loadTestConf();
-        cy.deleteTestCards();
-        cy.sendTestCards();
+
+        // Clean up existing cards
+        cy.deleteAllCards();
+
+        cy.send6TestCards();
     });
 
-    after('Clean', function () {
-        cy.deleteTestCards();
-    });
 
 
     it('Check card reception and read behaviour', function () {
@@ -108,7 +108,9 @@ describe ('FeedScreen tests',function () {
 
 
         // If we delete all the cards, the feed should be empty and the detail view should also be empty
-        cy.deleteTestCards();
+        // Note: Here we use the `delete6TestCards` method which relies on API calls to delete cards as we want
+        // the deletion to be reflected in the feed immediately.
+        cy.delete6TestCards();
         cy.get('of-light-card').should('have.length',0);
         cy.get('of-card-details').should('not.exist');
 

--- a/src/test/cypress/cypress/integration/ResponseCard.spec.js
+++ b/src/test/cypress/cypress/integration/ResponseCard.spec.js
@@ -9,18 +9,16 @@
 
 describe ('Response card tests',function () {
 
-    before('Set up configuration', function () {
+    before('Set up configuration and clean cards', function () {
 
         // This can stay in a `before` block rather than `beforeEach` as long as the test does not change configuration
         cy.resetUIConfigurationFiles();
 
         cy.loadTestConf();
-        cy.deleteTestCards();
-        cy.sendCard('defaultProcess/question.json');
-    });
+        // Clean up existing cards
+        cy.deleteAllCards();
 
-    after('Clean', function () {
-        cy.deleteTestCards();
+        cy.sendCard('defaultProcess/question.json');
     });
 
 

--- a/src/test/cypress/cypress/integration/StateTypeTests.spec.js
+++ b/src/test/cypress/cypress/integration/StateTypeTests.spec.js
@@ -22,7 +22,7 @@ describe('State type tests', function () {
         {type: "INPROGRESS", color: orange, en_label: "IN PROGRESS", test_card: "state_type1"},
         {type: "FINISHED", color: green, en_label: "FINISHED", test_card: "state_type2"},
         {type: "CANCELED", color: red, en_label: "CANCELED",test_card: "state_type3"}
-        ];
+    ];
 
     const testDataNoStateNoLttd = [
         {type: null, test_card: "state_type4"},
@@ -55,13 +55,15 @@ describe('State type tests', function () {
 
     });
 
+    describe('Check UI behaviour that depends on state type', function () {
 
-    describe('Check card detail header', function () {
+        it(`Check card detail header`, function () {
 
-        testDataStateNoLttd.forEach((test_data) => {
-            it(`State type ${test_data.type} with no lttd`, function () {
+            cy.loginOpFab('operator1', 'test');
 
-                cy.loginOpFab('operator1', 'test');
+            // ----------------- Tests with state present and no lttd
+            testDataStateNoLttd.forEach((test_data) => {
+                cy.log(`State type ${test_data.type} with no lttd`);
 
                 // Click on the card with the state under test to display its details
                 cy.get(`#opfab-feed-light-card-${process}-${test_data.test_card}`).click();
@@ -76,13 +78,11 @@ describe('State type tests', function () {
                 cy.get('#opfab-card-response-header-left').contains('|').should('not.exist');
                 cy.get('#opfab-card-response-header-left').find('of-countdown').should('not.exist');
 
-            });
-        })
+            })
 
-        testDataNoStateNoLttd.forEach((test_data) => {
-            it(`State type ${test_data.type} with no lttd`, function () {
-
-                cy.loginOpFab('operator1', 'test');
+            // ----------------- Tests with no state (null or absent) and no lttd
+            testDataNoStateNoLttd.forEach((test_data) => {
+                cy.log(`State type ${test_data.type} with no lttd`);
 
                 // Click on the card with the state under test to display its details
                 cy.get(`#opfab-feed-light-card-${process}-${test_data.test_card}`).click();
@@ -90,12 +90,11 @@ describe('State type tests', function () {
                 // Check card details header: it should contain nothing on the left
                 cy.get('#opfab-card-response-header-left').should('be.empty');
 
-            });
-        })
 
-        it(`State (type FINISHED) with lttd`, function () {
+            })
 
-            cy.loginOpFab('operator1', 'test');
+            // ----------------- Test with state and lttd present
+            cy.log(`State (type FINISHED) with lttd`);
 
             // Click on the card with the state under test to display its details
             cy.get(`#opfab-feed-light-card-${process}-state_type6`).click();
@@ -110,18 +109,15 @@ describe('State type tests', function () {
             cy.get('#opfab-card-response-header-left').contains('|');
             cy.get('#opfab-card-response-header-left').find('.lttd-icon, .lttd-timeleft');
 
-        });
-
-        it(`No state (type null) with lttd`, function () {
-
-            cy.loginOpFab('operator1', 'test');
+            // ----------------- Test with no state but lttd present
+            cy.log(`No state (type null) with lttd`);
 
             // Click on the card with the state under test to display its details
             cy.get(`#opfab-feed-light-card-${process}-state_type7`).click();
 
             // Check card details header: it should contain only the time left before lttd and the clock
             cy.get('#opfab-card-response-header-left').contains('|').should('not.exist');
-                        cy.get('#opfab-card-response-header-left').find('.lttd-icon');
+            cy.get('#opfab-card-response-header-left').find('.lttd-icon');
             cy.get('#opfab-card-response-header-left').find('.lttd-text');
 
         });

--- a/src/test/cypress/cypress/integration/StateTypeTests.spec.js
+++ b/src/test/cypress/cypress/integration/StateTypeTests.spec.js
@@ -1,0 +1,131 @@
+/* Copyright (c) 2021, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
+ */
+
+/* This test file focuses on some state-type specific behaviour in card details header. As the Cypress test suite grows,
+it might make sense to merge it with other tests.
+* */
+describe('State type tests', function () {
+
+    const orange = 'rgb(255, 165, 0)';
+    const green = 'rgb(0, 128, 0)';
+    const red = 'rgb(255, 0, 0)';
+
+    const process = "cypress";
+
+    const testDataStateNoLttd = [
+        {type: "INPROGRESS", color: orange, en_label: "IN PROGRESS", test_card: "state_type1"},
+        {type: "FINISHED", color: green, en_label: "FINISHED", test_card: "state_type2"},
+        {type: "CANCELED", color: red, en_label: "CANCELED",test_card: "state_type3"}
+        ];
+
+    const testDataNoStateNoLttd = [
+        {type: null, test_card: "state_type4"},
+        {type: "absent", test_card: "state_type5"},
+    ];
+
+    before('Set up configuration', function () {
+
+        // This can stay in a `before` block rather than `beforeEach` as long as the test does not change configuration
+        cy.resetUIConfigurationFiles();
+        cy.loadTestConf();
+        cy.deleteAllCards();
+        cy.deleteAllArchivedCards();
+
+        // Tests with state present and no lttd
+        cy.sendCard('cypress/state_types/state_type1.json');
+        cy.sendCard('cypress/state_types/state_type2.json');
+        cy.sendCard('cypress/state_types/state_type3.json');
+
+
+        // Tests with no state (null or absent) and no lttd
+        cy.sendCard('cypress/state_types/state_type4.json');
+        cy.sendCard('cypress/state_types/state_type5.json');
+
+        // Test with state and lttd present
+        cy.sendCard('cypress/state_types/state_type6.json');
+
+        // Test with no state but lttd present
+        cy.sendCard('cypress/state_types/state_type7.json');
+
+    });
+
+
+    describe('Check card detail header', function () {
+
+        testDataStateNoLttd.forEach((test_data) => {
+            it(`State type ${test_data.type} with no lttd`, function () {
+
+                cy.loginOpFab('operator1', 'test');
+
+                // Click on the card with the state under test to display its details
+                cy.get(`#opfab-feed-light-card-${process}-${test_data.test_card}`).click();
+
+                // Check card details header: it should contain the static text, the correct state type with the
+                // appropriate color, but no pipe or countdown element as there is no lttd
+                cy.get('#opfab-card-response-header-left').find('#opfab-card-response-header-status')
+                    .contains('Process Status')
+                cy.get('#opfab-card-response-header-left').find('[class^="opfab-typeOfState-"]')
+                    .should('have.text',`${test_data.en_label}`)
+                    .should('have.css','color',`${test_data.color}`);
+                cy.get('#opfab-card-response-header-left').contains('|').should('not.exist');
+                cy.get('#opfab-card-response-header-left').find('of-countdown').should('not.exist');
+
+            });
+        })
+
+        testDataNoStateNoLttd.forEach((test_data) => {
+            it(`State type ${test_data.type} with no lttd`, function () {
+
+                cy.loginOpFab('operator1', 'test');
+
+                // Click on the card with the state under test to display its details
+                cy.get(`#opfab-feed-light-card-${process}-${test_data.test_card}`).click();
+
+                // Check card details header: it should contain nothing on the left
+                cy.get('#opfab-card-response-header-left').should('be.empty');
+
+            });
+        })
+
+        it(`State (type FINISHED) with lttd`, function () {
+
+            cy.loginOpFab('operator1', 'test');
+
+            // Click on the card with the state under test to display its details
+            cy.get(`#opfab-feed-light-card-${process}-state_type6`).click();
+
+            // Check card details header: it should contain the static text, the correct state type with the
+            // appropriate color, then pipe and countdown
+            cy.get('#opfab-card-response-header-left').find('#opfab-card-response-header-status')
+                .contains('Process Status')
+            cy.get('#opfab-card-response-header-left').find('[class^="opfab-typeOfState-"]')
+                .should('have.text',"FINISHED")
+                .should('have.css','color',green);
+            cy.get('#opfab-card-response-header-left').contains('|');
+            cy.get('#opfab-card-response-header-left').find('.lttd-icon, .lttd-timeleft');
+
+        });
+
+        it(`No state (type null) with lttd`, function () {
+
+            cy.loginOpFab('operator1', 'test');
+
+            // Click on the card with the state under test to display its details
+            cy.get(`#opfab-feed-light-card-${process}-state_type7`).click();
+
+            // Check card details header: it should contain only the time left before lttd and the clock
+            cy.get('#opfab-card-response-header-left').contains('|').should('not.exist');
+                        cy.get('#opfab-card-response-header-left').find('.lttd-icon');
+            cy.get('#opfab-card-response-header-left').find('.lttd-text');
+
+        });
+
+    });
+
+})

--- a/src/test/cypress/cypress/support/commands.js
+++ b/src/test/cypress/cypress/support/commands.js
@@ -51,7 +51,7 @@ Cypress.Commands.add('loadTestConf', () => {
     cy.exec('cd .. && ./resources/loadTestConf.sh '+Cypress.env('host'));
 })
 
-Cypress.Commands.add('sendTestCards', () => {
+Cypress.Commands.add('send6TestCards', () => {
     cy.exec('cd .. && ./resources/send6TestCards.sh '+Cypress.env('host'));
 })
 
@@ -59,7 +59,7 @@ Cypress.Commands.add('sendCard', (cardFile) => {
     cy.exec('cd ../resources/cards/ && ./sendCard.sh '+ cardFile + ' ' + Cypress.env('host'));
 })
 
-Cypress.Commands.add('deleteTestCards', () => {
+Cypress.Commands.add('delete6TestCards', () => {
     cy.exec('cd .. && ./resources/delete6TestCards.sh '+Cypress.env('host'));
 })
 

--- a/src/test/cypress/cypress/support/commands.js
+++ b/src/test/cypress/cypress/support/commands.js
@@ -111,3 +111,7 @@ Cypress.Commands.add('deleteCoreMenuFromConf', (menu) => {
 Cypress.Commands.add('deleteAllArchivedCards', () => {
     cy.exec('cd .. && ./resources/deleteAllArchivedCards.sh '+Cypress.env('host'));
 })
+
+Cypress.Commands.add('deleteAllCards', () => {
+    cy.exec('cd .. && ./resources/deleteAllCards.sh '+Cypress.env('host'));
+})

--- a/src/test/resources/bundles/cypress/config.json
+++ b/src/test/resources/bundles/cypress/config.json
@@ -32,6 +32,49 @@
         "lock": true,
         "state": "messageStateWithOnlyWhenResponseDisabledForUserAck"  
         }
+    },
+    "stateOfTypeINPROGRESS": {
+      "name":  "stateOfTypeINPROGRESS.title",
+      "templateName": "template",
+      "type" : "INPROGRESS",
+      "response": {
+        "state": "dummyResponseState"
+      }
+    },
+    "stateOfTypeFINISHED": {
+      "name":  "stateOfTypeFINISHED.title",
+      "templateName": "template",
+      "type" : "FINISHED",
+      "response": {
+        "state": "dummyResponseState"
+      }
+    },
+    "stateOfTypeCANCELED": {
+      "name":  "stateOfTypeCANCELED.title",
+      "templateName": "template",
+      "type" : "CANCELED",
+      "response": {
+        "state": "dummyResponseState"
+      }
+    },
+    "stateOfTypeNull": {
+      "name":  "stateOfTypeNull.title",
+      "templateName": "template",
+      "type" : null,
+      "response": {
+        "state": "dummyResponseState"
+      }
+    },
+    "stateWithNoType": {
+      "name":  "stateWithNoType.title",
+      "templateName": "template",
+      "response": {
+        "state": "dummyResponseState"
+      }
+    },
+    "dummyResponseState": {
+      "name":  "dummyResponseState.title",
+      "templateName": "template"
     }
   }
 }

--- a/src/test/resources/bundles/cypress/i18n/en.json
+++ b/src/test/resources/bundles/cypress/i18n/en.json
@@ -12,6 +12,26 @@
 	} ,
 	"messageStateWithOnlyWhenResponseDisabledForUserAck": {
 		"description": "Message with ack only when response disable for user "
+	},
+	"stateOfType": {
+		"summary": "Shared summary for tests"
+	},
+	"stateOfTypeINPROGRESS": {
+		"title": "Test state of type INPROGRESS"
+	},
+	"stateOfTypeCANCELED": {
+		"title": "Test state of type CANCELED"
+	},
+	"stateOfTypeFINISHED": {
+		"title": "Test state of type FINISHED"
+	},
+	"stateOfTypeNull": {
+		"title": "Test state of type null"
+	},
+	"stateWithNoType": {
+		"title": "Test state with no type"
+	},
+	"dummyResponseState": {
+		"title": "Dummy response state for tests"
 	}
-	
 }

--- a/src/test/resources/bundles/cypress/i18n/fr.json
+++ b/src/test/resources/bundles/cypress/i18n/fr.json
@@ -8,10 +8,28 @@
 		"description": "Message"
 	},
 	"messageStateWithNoAck": {
-		"description": "Message with no ack"
+		"description": "Message sans ack"
 	},
 	"messageStateWithOnlyWhenResponseDisabledForUserAck": {
-		"description": "Message with ack only when response disable for user "
+		"description": "Message avec ack uniquement si la réponse est désactivée"
+	},	
+	"stateOfTypeINPROGRESS": {
+	"title": "Etat de test de type INPROGRESS"
+},
+	"stateOfTypeCANCELED": {
+		"title": "Etat de test de type CANCELED"
+	},
+	"stateOfTypeFINISHED": {
+		"title": "Etat de test de type FINISHED"
+	},
+	"stateOfTypeNull": {
+		"title": "Etat de test de type null"
+	},
+	"stateWithNoType": {
+		"title": "Etat de test sans type"
+	},
+	"dummyResponseState": {
+		"title": "Etat de réponse factice pour tests"
 	}
 }
 

--- a/src/test/resources/bundles/defaultProcess_V1/template/fr/question.handlebars
+++ b/src/test/resources/bundles/defaultProcess_V1/template/fr/question.handlebars
@@ -2,7 +2,7 @@
 
 <form id='question-form'>
    <div class="form-group">
-      <h4>  Indisponibilité  de 2 heures à prevoir pour la ligne HVDC France-Angleterre </h4>
+      <h4>Indisponibilité de 2 heures à prévoir pour la ligne HVDC France-Angleterre</h4>
       <br/>
        Merci de confirmer les créneaux qui vous conviennent:  <br/><br/>
        <label class="opfab-checkbox" style="margin-left:40px"> Le 10/08/2020 entre 8h and 10h <input  type="checkbox" id="choice1" name="choice1" >  <span id="question-choice1" class="opfab-checkbox-checkmark"> </span> </label>

--- a/src/test/resources/cards/cypress/state_types/state_type1.json
+++ b/src/test/resources/cards/cypress/state_types/state_type1.json
@@ -1,0 +1,18 @@
+{
+	"publisher" : "publisher_test",
+	"processVersion" : "1",
+	"process"  :"cypress",
+	"processInstanceId" : "state_type1",
+	"state": "stateOfTypeINPROGRESS",
+	"userRecipients": ["operator1","operator2"],
+	"severity" : "INFORMATION",
+	"startDate" : ${current_date_in_milliseconds_from_epoch_plus_2hours},
+	"endDate" : ${current_date_in_milliseconds_from_epoch_plus_8hours} ,
+	"summary" : {"key" : "stateOfType.summary"},
+	"title" : {"key" : "stateOfTypeINPROGRESS.title"},
+	"data" : {"message":" State type tests card number 1"},
+	"timeSpans" : [
+		{"start" :${current_date_in_milliseconds_from_epoch_plus_2hours}},
+		{"start" : ${current_date_in_milliseconds_from_epoch_plus_8hours}}
+		]
+}

--- a/src/test/resources/cards/cypress/state_types/state_type2.json
+++ b/src/test/resources/cards/cypress/state_types/state_type2.json
@@ -1,0 +1,18 @@
+{
+	"publisher" : "publisher_test",
+	"processVersion" : "1",
+	"process"  :"cypress",
+	"processInstanceId" : "state_type2",
+	"state": "stateOfTypeFINISHED",
+	"userRecipients": ["operator1","operator2"],
+	"severity" : "INFORMATION",
+	"startDate" : ${current_date_in_milliseconds_from_epoch_plus_2hours},
+	"endDate" : ${current_date_in_milliseconds_from_epoch_plus_8hours} ,
+	"summary" : {"key" : "stateOfType.summary"},
+	"title" : {"key" : "stateOfTypeFINISHED.title"},
+	"data" : {"message":" State type tests card number 2"},
+	"timeSpans" : [
+		{"start" :${current_date_in_milliseconds_from_epoch_plus_2hours}},
+		{"start" : ${current_date_in_milliseconds_from_epoch_plus_8hours}}
+		]
+}

--- a/src/test/resources/cards/cypress/state_types/state_type3.json
+++ b/src/test/resources/cards/cypress/state_types/state_type3.json
@@ -1,0 +1,18 @@
+{
+	"publisher" : "publisher_test",
+	"processVersion" : "1",
+	"process"  :"cypress",
+	"processInstanceId" : "state_type3",
+	"state": "stateOfTypeCANCELED",
+	"userRecipients": ["operator1","operator2"],
+	"severity" : "INFORMATION",
+	"startDate" : ${current_date_in_milliseconds_from_epoch_plus_2hours},
+	"endDate" : ${current_date_in_milliseconds_from_epoch_plus_8hours} ,
+	"summary" : {"key" : "stateOfType.summary"},
+	"title" : {"key" : "stateOfTypeCANCELED.title"},
+	"data" : {"message":" State type tests card number 3"},
+	"timeSpans" : [
+		{"start" :${current_date_in_milliseconds_from_epoch_plus_2hours}},
+		{"start" : ${current_date_in_milliseconds_from_epoch_plus_8hours}}
+		]
+}

--- a/src/test/resources/cards/cypress/state_types/state_type4.json
+++ b/src/test/resources/cards/cypress/state_types/state_type4.json
@@ -1,0 +1,18 @@
+{
+	"publisher" : "publisher_test",
+	"processVersion" : "1",
+	"process"  :"cypress",
+	"processInstanceId" : "state_type4",
+	"state": "stateOfTypeNull",
+	"userRecipients": ["operator1","operator2"],
+	"severity" : "INFORMATION",
+	"startDate" : ${current_date_in_milliseconds_from_epoch_plus_2hours},
+	"endDate" : ${current_date_in_milliseconds_from_epoch_plus_8hours} ,
+	"summary" : {"key" : "stateOfType.summary"},
+	"title" : {"key" : "stateOfTypeNull.title"},
+	"data" : {"message":" State type tests card number 4"},
+	"timeSpans" : [
+		{"start" :${current_date_in_milliseconds_from_epoch_plus_2hours}},
+		{"start" : ${current_date_in_milliseconds_from_epoch_plus_8hours}}
+		]
+}

--- a/src/test/resources/cards/cypress/state_types/state_type5.json
+++ b/src/test/resources/cards/cypress/state_types/state_type5.json
@@ -1,0 +1,18 @@
+{
+	"publisher" : "publisher_test",
+	"processVersion" : "1",
+	"process"  :"cypress",
+	"processInstanceId" : "state_type5",
+	"state": "stateOfTypeNull",
+	"userRecipients": ["operator1","operator2"],
+	"severity" : "INFORMATION",
+	"startDate" : ${current_date_in_milliseconds_from_epoch_plus_2hours},
+	"endDate" : ${current_date_in_milliseconds_from_epoch_plus_8hours} ,
+	"summary" : {"key" : "stateOfType.summary"},
+	"title" : {"key" : "stateWithNoType.title"},
+	"data" : {"message":" State type tests card number 5"},
+	"timeSpans" : [
+		{"start" :${current_date_in_milliseconds_from_epoch_plus_2hours}},
+		{"start" : ${current_date_in_milliseconds_from_epoch_plus_8hours}}
+		]
+}

--- a/src/test/resources/cards/cypress/state_types/state_type6.json
+++ b/src/test/resources/cards/cypress/state_types/state_type6.json
@@ -1,0 +1,19 @@
+{
+	"publisher" : "publisher_test",
+	"processVersion" : "1",
+	"process"  :"cypress",
+	"processInstanceId" : "state_type6",
+	"state": "stateOfTypeFINISHED",
+	"userRecipients": ["operator1","operator2"],
+	"severity" : "INFORMATION",
+	"startDate" : ${current_date_in_milliseconds_from_epoch_plus_2hours},
+	"endDate" : ${current_date_in_milliseconds_from_epoch_plus_8hours} ,
+	"lttd" : ${current_date_in_milliseconds_from_epoch_plus_3minutes},
+	"summary" : {"key" : "stateOfType.summary"},
+	"title" : {"key" : "stateOfTypeFINISHED.title"},
+	"data" : {"message":" State type tests card number 6"},
+	"timeSpans" : [
+		{"start" :${current_date_in_milliseconds_from_epoch_plus_2hours}},
+		{"start" : ${current_date_in_milliseconds_from_epoch_plus_8hours}}
+		]
+}

--- a/src/test/resources/cards/cypress/state_types/state_type7.json
+++ b/src/test/resources/cards/cypress/state_types/state_type7.json
@@ -1,0 +1,19 @@
+{
+	"publisher" : "publisher_test",
+	"processVersion" : "1",
+	"process"  :"cypress",
+	"processInstanceId" : "state_type7",
+	"state": "stateOfTypeNull",
+	"userRecipients": ["operator1","operator2"],
+	"severity" : "INFORMATION",
+	"startDate" : ${current_date_in_milliseconds_from_epoch},
+	"endDate" : ${current_date_in_milliseconds_from_epoch_plus_8hours} ,
+	"lttd" : ${current_date_in_milliseconds_from_epoch},
+	"summary" : {"key" : "stateOfType.summary"},
+	"title" : {"key" : "stateOfTypeNull.title"},
+	"data" : {"message":" State type tests card number 7"},
+	"timeSpans" : [
+		{"start" :${current_date_in_milliseconds_from_epoch_plus_2hours}},
+		{"start" : ${current_date_in_milliseconds_from_epoch_plus_8hours}}
+		]
+}

--- a/src/test/resources/deleteAllCards.sh
+++ b/src/test/resources/deleteAllCards.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Copyright (c) 2021, RTE (http://www.rte-france.com)
+# See AUTHORS.txt
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# SPDX-License-Identifier: MPL-2.0
+# This file is part of the OperatorFabric project.
+
+# This starts by moving to the directory where the script is located so the paths below still work even if the script
+# is called from another folder
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+url=$1
+if [[ -z $url ]]
+then
+	url="http://localhost"
+fi
+(
+	docker exec $(docker ps --format "{{.Names}}" | grep "mongodb") bash -c "mongo mongodb://root:password@localhost:27017 --eval \"db=db.getSiblingDB('operator-fabric'); db['cards'].drop();\""
+)

--- a/src/test/resources/perimeters/cypress.json
+++ b/src/test/resources/perimeters/cypress.json
@@ -13,6 +13,30 @@
     {
       "state": "messageStateWithOnlyWhenResponseDisabledForUserAck",
       "right": "ReceiveAndWrite"
+    },
+    {
+      "state": "stateOfTypeINPROGRESS",
+      "right": "ReceiveAndWrite"
+    },
+    {
+      "state": "stateOfTypeFINISHED",
+      "right": "ReceiveAndWrite"
+    },
+    {
+      "state": "stateOfTypeCANCELED",
+      "right": "ReceiveAndWrite"
+    },
+    {
+      "state": "stateOfTypeNull",
+      "right": "ReceiveAndWrite"
+    },
+    {
+      "state": "stateWithNoType",
+      "right": "ReceiveAndWrite"
+    },
+    {
+      "state": "dummyResponseState",
+      "right": "ReceiveAndWrite"
     }
   ]
 }

--- a/ui/main/src/app/app.component.scss
+++ b/ui/main/src/app/app.component.scss
@@ -112,4 +112,8 @@
 
 .opfab-alert-close:hover, .opfab-alert-close:focus {
   color: var(--opfab-navbar-color);
-} 
+}
+
+.opfab-typeOfState-INPROGRESS {color: orange;}
+.opfab-typeOfState-FINISHED {color: green;}
+.opfab-typeOfState-CANCELED {color: red;}

--- a/ui/main/src/app/modules/cards/components/detail/detail.component.html
+++ b/ui/main/src/app/modules/cards/components/detail/detail.component.html
@@ -66,7 +66,8 @@
             <div id="opfab-card-response-header-left" style="width:30%;">
               <span id="opfab-card-response-header-status" *ngIf="!!cardState.type">
                 <span style="padding-left:15px" translate>response.status</span> :
-                <span class="opfab-typeOfState-{{cardState.type}}" translate>monitoring.filters.typeOfState.{{cardState.type}}</span>
+                <!--The translate directive should stay there rather than in the element see OC-1603-->
+                <span class="opfab-typeOfState-{{cardState.type}}">{{"global.typeOfState."+cardState.type | translate}}</span>
               </span>
               <span *ngIf="!!card.lttd && !!cardState.type"> | </span>
               <span *ngIf="!!card.lttd"><of-countdown [lttd]="card.lttd"></of-countdown></span>

--- a/ui/main/src/app/modules/cards/components/detail/detail.component.html
+++ b/ui/main/src/app/modules/cards/components/detail/detail.component.html
@@ -63,16 +63,16 @@
 
         <div *ngIf='responseDataExists && showDetailCardHeader' class="opfab-card-response-header">
           <div class="flex-container">
-            <div style="width:30%;">
-              <span *ngIf="!!cardState.type">
-              <span style="padding-left:15px" translate>response.status</span> :
-              <span class="opfab-typeOfState-{{cardState.type}}" translate>monitoring.filters.typeOfState.{{cardState.type}}&nbsp;&nbsp;</span>
+            <div id="opfab-card-response-header-left" style="width:30%;">
+              <span id="opfab-card-response-header-status" *ngIf="!!cardState.type">
+                <span style="padding-left:15px" translate>response.status</span> :
+                <span class="opfab-typeOfState-{{cardState.type}}" translate>monitoring.filters.typeOfState.{{cardState.type}}</span>
               </span>
               <span *ngIf="!!card.lttd && !!cardState.type"> | </span>
               <span *ngIf="!!card.lttd"><of-countdown [lttd]="card.lttd"></of-countdown></span>
             </div>
 
-            <div style="width:70%;text-align: right">
+            <div id="opfab-card-response-header-right" style="width:70%;text-align: right">
               <div id="opfab-answer-help" class="opfab-icon-help" placement="left" [ngbPopover]="helpContent"
                 container="body" triggers="mouseenter:mouseleave" popoverClass="opfab-popover">
               </div>

--- a/ui/main/src/app/modules/cards/components/detail/detail.component.html
+++ b/ui/main/src/app/modules/cards/components/detail/detail.component.html
@@ -64,10 +64,12 @@
         <div *ngIf='responseDataExists && showDetailCardHeader' class="opfab-card-response-header">
           <div class="flex-container">
             <div style="width:30%;">
+              <span *ngIf="!!cardState.type">
               <span style="padding-left:15px" translate>response.status</span> :
-              <span class="opfab-question-card-state-name" >{{i18nPrefix+this.cardState.name | translate}} &nbsp;</span>
-              <span *ngIf="!!this.card.lttd"> |<of-countdown [lttd]="this.card.lttd"></of-countdown></span>
-             
+              <span class="opfab-typeOfState-{{cardState.type}}" translate>monitoring.filters.typeOfState.{{cardState.type}}&nbsp;&nbsp;</span>
+              </span>
+              <span *ngIf="!!card.lttd && !!cardState.type"> | </span>
+              <span *ngIf="!!card.lttd"><of-countdown [lttd]="card.lttd"></of-countdown></span>
             </div>
 
             <div style="width:70%;text-align: right">

--- a/ui/main/src/app/modules/cards/components/detail/detail.component.scss
+++ b/ui/main/src/app/modules/cards/components/detail/detail.component.scss
@@ -154,10 +154,6 @@
   mask: url(../../../../../assets/images/icons/help.svg);
 }
 
-.opfab-question-card-state-name{
-  color: var(--opfab-light-card-lttd-timeleft);
-}
-
 .label-help {
   display: block;
 }

--- a/ui/main/src/app/modules/cards/components/detail/detail.component.ts
+++ b/ui/main/src/app/modules/cards/components/detail/detail.component.ts
@@ -25,7 +25,7 @@ import {Card, CardForPublishing} from '@ofModel/card.model';
 import {ProcessesService} from '@ofServices/processes.service';
 import {HandlebarsService} from '../../services/handlebars.service';
 import {DomSanitizer, SafeHtml, SafeResourceUrl} from '@angular/platform-browser';
-import {AcknowledgmentAllowedEnum, State as CardState} from '@ofModel/processes.model';
+import {AcknowledgmentAllowedEnum, State} from '@ofModel/processes.model';
 import {DetailContext} from '@ofModel/detail-context.model';
 import {Store} from '@ngrx/store';
 import {AppState} from '@ofStore/index';
@@ -108,7 +108,7 @@ const maxVisibleEntitiesToRespond = 3;
 })
 export class DetailComponent implements OnChanges, OnInit, OnDestroy, AfterViewChecked, DoCheck {
 
-    @Input() cardState: CardState;
+    @Input() cardState: State;
     @Input() card: Card;
     @Input() childCards: Card[];
     @Input() user: User;

--- a/ui/main/src/app/modules/monitoring/components/monitoring-table/monitoring-table.component.html
+++ b/ui/main/src/app/modules/monitoring/components/monitoring-table/monitoring-table.component.html
@@ -29,7 +29,7 @@
             <td translate>{{line.processName}}</td>
             <td translate [translateParams]="line.title.parameters">{{line.title.key}}</td>
             <td translate [translateParams]="line.summary.parameters">{{line.summary.key}}</td>
-            <td class="opfab-monitoring-typeOfState-{{line.typeOfState}}" translate>monitoring.filters.typeOfState.{{line.typeOfState}} </td>
+            <td class="opfab-typeOfState-{{line.typeOfState}}" translate>monitoring.filters.typeOfState.{{line.typeOfState}} </td>
         </tr>
     </tbody>
 </table>

--- a/ui/main/src/app/modules/monitoring/components/monitoring-table/monitoring-table.component.scss
+++ b/ui/main/src/app/modules/monitoring/components/monitoring-table/monitoring-table.component.scss
@@ -35,7 +35,3 @@
 .opfab-monitoring-table-line:hover {
 border: 2px solid #2268FF;
 }
-
-.opfab-monitoring-typeOfState-INPROGRESS {color: orange;}
-.opfab-monitoring-typeOfState-FINISHED {color: green;}
-.opfab-monitoring-typeOfState-CANCELED {color: red;}

--- a/ui/main/src/assets/i18n/en.json
+++ b/ui/main/src/assets/i18n/en.json
@@ -298,7 +298,7 @@
     "answers": "Answers",
     "answered": "Answered",
     "unanswered": "Not answered yet",
-    "status": "Status"
+    "status": "Process Status"
   },
   "cardAcknowledgment": {
     "button": {

--- a/ui/main/src/assets/i18n/en.json
+++ b/ui/main/src/assets/i18n/en.json
@@ -1,7 +1,12 @@
 {
   "global":{
     "connectionLost":"Connection lost",
-    "tryToReconnect":"Try to reconnect ..."
+    "tryToReconnect":"Try to reconnect ...",
+    "typeOfState" : {
+      "INPROGRESS" : "IN PROGRESS",
+      "FINISHED": "FINISHED",
+      "CANCELED" : "CANCELED"
+    }
   },
   "menu": {
     "feed": "Card Feed",

--- a/ui/main/src/assets/i18n/fr.json
+++ b/ui/main/src/assets/i18n/fr.json
@@ -1,7 +1,12 @@
 {
   "global":{
     "connectionLost":"Connexion perdue",
-    "tryToReconnect":"Tentative de reconnexion ..."
+    "tryToReconnect":"Tentative de reconnexion ...",
+    "typeOfState": {
+      "INPROGRESS": "EN COURS",
+      "FINISHED": "TERMINÉ",
+      "CANCELED": "ANNULÉ"
+    }
   },
   "menu": {
     "feed": "Flux de cartes",

--- a/ui/main/src/assets/i18n/fr.json
+++ b/ui/main/src/assets/i18n/fr.json
@@ -298,7 +298,7 @@
     "answers": "Réponses",
     "answered": "A répondu",
     "unanswered": "Pas encore répondu",
-    "status": "Status"
+    "status": "Statut du processus"
   },
   "cardAcknowledgment": {
     "button": {

--- a/ui/main/src/scss/styles.scss
+++ b/ui/main/src/scss/styles.scss
@@ -44,6 +44,10 @@ body {
   scrollbar-color:var(--opfab-scrollbar-bar-bgcolor-firefox)  var(--opfab-scrollbar-bgcolor-firefox) ;
 } 
 
+// Colors for state types
+.opfab-typeOfState-INPROGRESS {color: orange;}
+.opfab-typeOfState-FINISHED {color: green;}
+.opfab-typeOfState-CANCELED {color: red;}
 
 // CUSTOM SCROLLBAR STYLE
 // for chromium based browser 


### PR DESCRIPTION
Fixes #1430 

In the release notes, under Features:

- #1430 : Card detail header for question cards now displays state type rather than state name

Signed-off-by: Alexandra Guironnet <alexandra.guironnet@rte-france.com>