### PR TITLE
Fix #1503 Automatic user creation with AuthFlow NONE

### DIFF
--- a/src/docs/asciidoc/deployment/configuration/security_configuration.adoc
+++ b/src/docs/asciidoc/deployment/configuration/security_configuration.adoc
@@ -267,12 +267,6 @@ Setting automated user creation==. Creation user requires a user id. Given name 
 |operatorfabric.security.jwt.family-name-claim|family-name|no| Jwt claim is used to set the user's family name
 |===
 
-=== Automated User creation with NONE flow
-
-Currently users with not be automatically created when using the `NONE` flow. 
-An administrator can add the users that are allowed to login to Operator Fabric.
-
-
 [[jwt_mode]]
 == Alternative way to manage groups (and/or entities)
 

--- a/ui/main/src/app/services/authentication/authentication.service.ts
+++ b/ui/main/src/app/services/authentication/authentication.service.ts
@@ -554,19 +554,10 @@ export class NoAuthenticationHandler implements AuthenticationModeHandler {
         const currentUser = this.userService.currentUserWithPerimeters();
         currentUser.subscribe(foundUser => {
             if (foundUser != null) {
-                const existingUser = this.userService.askUserApplicationRegistered(foundUser.userData.login);
-                existingUser.subscribe(registeredUser => {
-                    if (registeredUser != null) {
-                        console.log(new Date().toISOString(), 'Registered User ('+ foundUser.userData.login +') found');
-                        const clientId = this.guidService.getCurrentGuid();
-                        this.store.dispatch(new AcceptLogIn(new PayloadForSuccessfulAuthentication(foundUser.userData.login,clientId,null,null, foundUser.userData.firstName, foundUser.userData.lastName)));
-                        redirectToCurrentLocation(this.router);
-                    }
-                    else {
-                        console.log(new Date().toISOString(), 'Registered User ('+ foundUser.userData.login +') not found');
-                        this.store.dispatch(new RejectLogIn({error: new Message('Unable to authenticate the user', MessageLevel.ERROR, new I18n('login.error.authenticate', null))}));
-                    }
-                });
+                console.log(new Date().toISOString(), 'User ('+ foundUser.userData.login +') found');
+                const clientId = this.guidService.getCurrentGuid();
+                this.store.dispatch(new AcceptLogIn(new PayloadForSuccessfulAuthentication(foundUser.userData.login,clientId,null,null, foundUser.userData.firstName, foundUser.userData.lastName)));
+                redirectToCurrentLocation(this.router);
             } else {
                 this.store.dispatch(new RejectLogIn({error: new Message('Unable to authenticate the user', MessageLevel.ERROR, new I18n('login.error.authenticate', null))}));
             }


### PR DESCRIPTION
Removed checking if user is already existing in OpFab with AuthFlow NONE. Now the user will be automatically created, just like the other AuthFlows. Changed documentation to reflect this change.

Signed-off-by: Gerben Danen <geppyz@gmail.com>