### PR TITLE
Passing environment as a command line option is not necessary anymore (#1459)

### DIFF
--- a/ui/main/build.gradle
+++ b/ui/main/build.gradle
@@ -20,7 +20,7 @@ task runBuild(type: NpmTask) {
     outputs.dir('build')
 
     dependsOn npmInstall
-    args = ['run', 'build', '--configuration=production', '--baseHref=/ui/', '--deployUrl=/ui/']
+    args = ['run', 'build','--baseHref=/ui/', '--deployUrl=/ui/']
 }
 
 task runHeadlessTests(type: NpmTask) {


### PR DESCRIPTION
nothing in release note 