### PR TITLE
Add configuration to exclude some states from the notification configuration screen (#1263)

### DIFF
--- a/services/core/businessconfig/src/main/java/org/opfab/businessconfig/model/ProcessStatesData.java
+++ b/services/core/businessconfig/src/main/java/org/opfab/businessconfig/model/ProcessStatesData.java
@@ -30,6 +30,7 @@ public class ProcessStatesData implements ProcessStates {
     @Singular
     private List<String> styles;
     private TypeOfStateEnum type;
+    private Boolean isOnlyAChildState;
 
     @Override
     public Response getResponse() {

--- a/services/core/businessconfig/src/main/modeling/swagger.yaml
+++ b/services/core/businessconfig/src/main/modeling/swagger.yaml
@@ -419,6 +419,9 @@ definitions:
             type:
               description: Type of state ("INPROGRESS", "FINISHED" or "CANCELED")
               $ref: '#/definitions/TypeOfStateEnum'
+            isOnlyAChildState:
+              description: If true, this state is only used for child cards and shall not be seen on feed notification screen and in archives filters
+              type: boolean
       uiVisibility:
         type: object
         properties:

--- a/src/docs/asciidoc/reference_doc/response_cards.adoc
+++ b/src/docs/asciidoc/reference_doc/response_cards.adoc
@@ -80,8 +80,9 @@ appropriate configuration in the config.json of the concerned process. Here is a
       "acknowledgmentAllowed": "Never",
       "showDetailCardHeader" : true
     },
-    "responseState" :{
-      "name" :"response.title"
+    "responseState": {
+      "name" : "response.title",
+      "isOnlyAChildState" : true
     }
   }
 }
@@ -95,6 +96,8 @@ and state "questionState", the user will have the possibility to respond if he h
 the config file of cards-publication service, in "externalRecipients-url" element. This field is optional.
 - The field "showDetailCardHeader" permits to display the card header or not. This header contains the list of entities
 that have already responded or not, and a countdown indicating the time remaining to respond, if necessary.
+- The field "isOnlyAChildState" indicates whether the state is only used for child cards or not. If yes, the state
+is displayed neither in the feed notification configuration screen nor in archives screen filters.
 
 
 NOTE: The state to be used for the response can also be set dynamically based on the contents of the card or the

--- a/src/test/cypress/cypress/integration/Archives.spec.js
+++ b/src/test/cypress/cypress/integration/Archives.spec.js
@@ -41,5 +41,26 @@ describe ('Archives screen tests',function () {
         cy.get('#opfab-archives-cards-list').find('.opfab-archives-icon-plus').should('have.length',6);
         cy.get('of-card-detail').should('not.exist');
         cy.get('#opfab-archive-results-number').should('have.text', ' Results number  : 6 ')
+
+        // We select all process groups
+        cy.get('#opfab-processGroup').click();
+        cy.get('#opfab-processGroup').contains('Select All').click();
+
+        // We choose the process 'Process example'
+        cy.get('#opfab-process').click();
+        cy.get('#opfab-process').contains('Process example').click();
+        cy.get('#opfab-process').click();
+
+        // We check every state is present except 'Planned outage date response' because 'isOnlyAChildState' attribute is set to true for this state
+        cy.get('#opfab-state').click();
+        cy.get('#opfab-state').contains('Message').should('exist');
+        cy.get('#opfab-state').contains('A Chart').should('exist');
+        cy.get('#opfab-state').contains('Process example').should('exist');
+        cy.get('#opfab-state').contains('Electricity consumption forecast').should('exist');
+        cy.get('#opfab-state').contains('Action required').should('exist');
+        cy.get('#opfab-state').contains('Additional information required').should('exist');
+        cy.get('#opfab-state').contains('Network Contingencies').should('exist');
+        cy.get('#opfab-state').contains('Planned outage date response').should('not.exist');
+
     })
 })

--- a/src/test/cypress/cypress/integration/FeedNotificationConfiguration.spec.js
+++ b/src/test/cypress/cypress/integration/FeedNotificationConfiguration.spec.js
@@ -1,0 +1,69 @@
+/* Copyright (c) 2021, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
+ */
+
+describe ('Feed notification configuration tests',function () {
+
+    before('Set up configuration', function () {
+        cy.loadTestConf();
+    });
+
+    it('Check feed notification configuration screen', function () {
+        cy.loginOpFab('operator1', 'test');
+
+        // We move to feed notification configuration screen
+        cy.get('#opfab-navbar-drop_user_menu').click();
+        cy.get('#opfab-menu-icon-notification').click();
+
+        cy.get('.opfab-feedconfiguration-title').should('have.text', ' NOTIFICATION RECEPTION CONFIGURATION\n');
+        cy.get('.opfab-feedconfiguration-processlist').should('have.length', 3);
+
+
+        // First process group
+        cy.get('.opfab-feedconfiguration-processlist').first().find('h5').should('have.text', 'Base Examples');
+
+        // We check the number of processes and their titles
+        cy.get('.opfab-feedconfiguration-processlist').first().find('p').should('have.length', 2);
+        cy.get('.opfab-feedconfiguration-processlist').first().find('p').first().should('have.text', 'IGCC');
+        cy.get('.opfab-feedconfiguration-processlist').first().find('p').last().should('have.text', 'Process example ');
+
+        // We check the number of states for each process
+        cy.get('.opfab-feedconfiguration-processlist').first().find('.col-md').first().find('.row').should('have.length', 6);
+        cy.get('.opfab-feedconfiguration-processlist').first().find('.col-md').last().find('.row').should('have.length', 7);
+
+        // We check the following state is absent because property 'isOnlyAChildState' is set to true
+        cy.get('.opfab-feedconfiguration-processlist').first().find('.col-md').last().find('.row').contains('Planned outage date response').should('not.exist');
+
+
+        // Second process group
+        cy.get('.opfab-feedconfiguration-processlist').eq(1).find('h5').should('have.text', 'User card examples');
+
+        // We check the number of processes and their titles
+        cy.get('.opfab-feedconfiguration-processlist').eq(1).find('p').should('have.length', 3);
+        cy.get('.opfab-feedconfiguration-processlist').eq(1).find('p').first().should('have.text', 'Examples for new cards ');
+        cy.get('.opfab-feedconfiguration-processlist').eq(1).find('p').eq(1).should('have.text', 'Examples for new cards 2');
+        cy.get('.opfab-feedconfiguration-processlist').eq(1).find('p').last().should('have.text', 'Examples for new cards 3');
+
+        // We check the number of states for each process
+        cy.get('.opfab-feedconfiguration-processlist').eq(1).find('.col-md').first().find('.row').should('have.length', 2);
+        cy.get('.opfab-feedconfiguration-processlist').eq(1).find('.col-md').eq(1).find('.row').should('have.length', 2);
+        cy.get('.opfab-feedconfiguration-processlist').eq(1).find('.col-md').last().find('.row').should('have.length', 1);
+
+
+        // Processes without group
+        // We check the number of processes and their titles
+        cy.get('.opfab-feedconfiguration-processlist').last().find('p').should('have.length', 1);
+        cy.get('.opfab-feedconfiguration-processlist').last().find('p').should('have.text', 'Test process for cypress');
+
+        // We check the number of states for each process
+        cy.get('.opfab-feedconfiguration-processlist').last().find('.col-md').first().find('.row').should('have.length', 8);
+
+        // We check the following state is absent because property 'isOnlyAChildState' is set to true
+        cy.get('.opfab-feedconfiguration-processlist').last().find('.col-md').first().find('.row').contains('Dummy response state for tests').should('not.exist');
+    })
+})

--- a/src/test/resources/bundles/cypress/config.json
+++ b/src/test/resources/bundles/cypress/config.json
@@ -74,7 +74,8 @@
     },
     "dummyResponseState": {
       "name":  "dummyResponseState.title",
-      "templateName": "template"
+      "templateName": "template",
+      "isOnlyAChildState": true
     }
   }
 }

--- a/src/test/resources/bundles/defaultProcess_V1/config.json
+++ b/src/test/resources/bundles/defaultProcess_V1/config.json
@@ -99,7 +99,8 @@
         "style"
       ],
       "acknowledgmentAllowed": "Always",
-      "type" : "INPROGRESS"
+      "type" : "INPROGRESS",
+      "isOnlyAChildState": true
     }
 
   }

--- a/ui/main/src/app/model/processes.model.ts
+++ b/ui/main/src/app/model/processes.model.ts
@@ -57,7 +57,8 @@ export class State {
         readonly userCard?: UserCard,
         readonly description?: string,
         readonly showDetailCardHeader?: boolean,
-        readonly type?: TypeOfStateEnum
+        readonly type?: TypeOfStateEnum,
+        readonly isOnlyAChildState?: boolean
     ) {
     }
 }

--- a/ui/main/src/app/modules/archives/archives.component.html
+++ b/ui/main/src/app/modules/archives/archives.component.html
@@ -12,7 +12,8 @@
       <div class="opfab-archives">
         <div style="display: flex;">
 
-          <of-archives-logging-filters [parentForm]="archiveForm" [visibleProcesses]="listOfProcesses" #filters></of-archives-logging-filters>
+          <of-archives-logging-filters [parentForm]="archiveForm" [visibleProcesses]="listOfProcesses"
+                                       [hideChildStates]=true #filters></of-archives-logging-filters>
 
           <div class="opfab-vertical-bar"></div>
           <div class="opfab-publish-date">

--- a/ui/main/src/app/modules/feedconfiguration/feedconfiguration.component.ts
+++ b/ui/main/src/app/modules/feedconfiguration/feedconfiguration.component.ts
@@ -139,7 +139,7 @@ export class FeedconfigurationComponent implements OnInit {
                 for (const stateId of Object.keys(process.states)) {
                     const state = process.states[stateId];
 
-                    if ((!this.checkPerimeterForSearchFields) || this.userService.isReceiveRightsForProcessAndState(process.id, stateId)) {
+                    if ((! state.isOnlyAChildState) && ((!this.checkPerimeterForSearchFields) || this.userService.isReceiveRightsForProcessAndState(process.id, stateId))) {
                         let stateLabel = this.computeI18n(process, state.name, stateId);
                         this.translateService.get(stateLabel).subscribe(translate => { stateLabel = translate; });
 

--- a/ui/main/src/app/modules/navbar/navbar.component.html
+++ b/ui/main/src/app/modules/navbar/navbar.component.html
@@ -156,7 +156,7 @@
     <div class="opfab-right-menu-item" *ngIf="(displayFeedConfiguration)">
       <a  id="opfab-navbar-right-menu-feedconfiguration" class="opfab-right-menu-link" routerLink="/feedconfiguration"  routerLinkActive
         #rla="routerLinkActive">
-        <div class="opfab-menu-icon opfab-menu-icon-notification"></div>
+        <div class="opfab-menu-icon opfab-menu-icon-notification" id="opfab-menu-icon-notification"></div>
         <div translate> menu.feedConfiguration</div>
       </a>
     </div>

--- a/ui/main/src/app/modules/share/archives-logging-filters/archives-logging-filters.component.ts
+++ b/ui/main/src/app/modules/share/archives-logging-filters/archives-logging-filters.component.ts
@@ -52,6 +52,7 @@ export class ArchivesLoggingFiltersComponent implements OnInit, OnDestroy {
     @Input() public card: Card | LightCard;
     @Input() parentForm: FormGroup;
     @Input() visibleProcesses: [];
+    @Input() hideChildStates?: boolean;
 
     unsubscribe$: Subject<void> = new Subject<void>();
 
@@ -263,7 +264,8 @@ export class ArchivesLoggingFiltersComponent implements OnInit, OnDestroy {
             const statesDropdownList = [];
             for (const state in process.states) {
 
-                if ((!this.checkPerimeterForSearchFields) || this.userService.isReceiveRightsForProcessAndState(process.id, state)) {
+                if (!(this.hideChildStates && process.states[state].isOnlyAChildState) &&
+                    ((!this.checkPerimeterForSearchFields) || this.userService.isReceiveRightsForProcessAndState(process.id, state))) {
                     statesDropdownList.push({
                         id: process.id + '.' + state,
                         itemName: process.states[state].name,


### PR DESCRIPTION
Release notes : 

In Features section : 

Add configuration to exclude some states from the notification configuration screen (#1263). For more information : https://opfab.github.io/documentation/current/reference_doc/#_configure_the_response_in_config_json

Signed-off-by: vlo-rte <valerie.longa@rte-france.com>