### PR TITLE
Sonarcloud warnings : correct "Immediately return this expression instead of assigning it to the temporary variable" (Fix #1622)

### DIFF
--- a/tools/spring/spring-oauth2-utilities/src/main/java/org/opfab/springtools/configuration/oauth/OAuth2GenericConfiguration.java
+++ b/tools/spring/spring-oauth2-utilities/src/main/java/org/opfab/springtools/configuration/oauth/OAuth2GenericConfiguration.java
@@ -77,8 +77,7 @@ public class OAuth2GenericConfiguration {
         return new Converter<Jwt, AbstractAuthenticationToken>(){
             @Override
             public AbstractAuthenticationToken convert(Jwt jwt) throws FeignException {
-            	AbstractAuthenticationToken authenticationToken = generateOpFabJwtAuthenticationToken(jwt);
-                return authenticationToken;
+                return generateOpFabJwtAuthenticationToken(jwt);
             }
         };
     }

--- a/tools/spring/spring-oauth2-utilities/src/main/java/org/opfab/springtools/configuration/oauth/jwt/groups/GroupsUtils.java
+++ b/tools/spring/spring-oauth2-utilities/src/main/java/org/opfab/springtools/configuration/oauth/jwt/groups/GroupsUtils.java
@@ -41,16 +41,13 @@ public class GroupsUtils {
 	 */
 	public List<GrantedAuthority> createAuthorityList(Jwt jwt) {
 		List<String> listGroupsFromListRolesClaim = createGroupsList(jwt);
-		List<GrantedAuthority> listGrantedAuthority = computeAuthorities(listGroupsFromListRolesClaim);
-		
-		return listGrantedAuthority;
+		return computeAuthorities(listGroupsFromListRolesClaim);
 	}
 	
 	public List<String> createGroupsList(Jwt jwt) {
 		
 		List<RoleClaim> listRoleClaim = groupsProperties.getListRoleClaim();
-		List<String> listGroupsFromListRolesClaim = getGroupsFromListRolesClaim(jwt, listRoleClaim);
-		return listGroupsFromListRolesClaim;
+		return getGroupsFromListRolesClaim(jwt, listRoleClaim);
 	} 
 	
 	/**

--- a/tools/spring/spring-oauth2-utilities/src/main/java/org/opfab/springtools/configuration/oauth/jwt/groups/roles/RoleClaim.java
+++ b/tools/spring/spring-oauth2-utilities/src/main/java/org/opfab/springtools/configuration/oauth/jwt/groups/roles/RoleClaim.java
@@ -77,9 +77,8 @@ public abstract class RoleClaim {
         
 		int payloadIndexInJwt = 1;
 		String base64EncodedBody = tokenSplit[payloadIndexInJwt];
-        String payload = new String(Base64.getUrlDecoder().decode(base64EncodedBody));
- 
-		return payload;
+
+		return new String(Base64.getUrlDecoder().decode(base64EncodedBody));
 	}
 	
 	/**


### PR DESCRIPTION
Nothing in release notes.