### PR TITLE
Fixing client app build

### DIFF
--- a/src/test/clientApp/clientApp.gradle
+++ b/src/test/clientApp/clientApp.gradle
@@ -28,8 +28,7 @@ bootJar {
 				"Specification-Title"    : "OperatorFabric Businessconfig Parties Manager",
 				"Implementation-Title"   : "OperatorFabric Businessconfig Parties Manager",
 				"Implementation-Version" : operatorfabric.version,
-				"Specification-Version"  : operatorfabric.version,
-				'Main-Class': 'org.opfab.client.ClientApplication'
+				"Specification-Version"  : operatorfabric.version
 		)
 	}
 }


### PR DESCRIPTION
The build of the client application fails with the following message:

> Error: Could not find or load main class org.opfab.client.ClientApplication
> Caused by: java.lang.ClassNotFoundException: org.opfab.client.ClientApplication

Removing "'Main-Class': 'org.opfab.client.ClientApplication'" from the bootJar task in clientApp.gradle (to be consistent with the other bootjar tasks) makes this error go away. I think I remember it had something to do with the spring-boot update a few weeks ago.

Signed-off-by: Alexandra Guironnet <alexandra.guironnet@rte-france.com>