### PR TITLE
Add getDisplayContext() method to the template to know in which context the rendering is done (#1647)

### DIFF
--- a/src/docs/asciidoc/reference_doc/template_description.adoc
+++ b/src/docs/asciidoc/reference_doc/template_description.adoc
@@ -529,6 +529,18 @@ To adapt the template content on screen size it is possible to receive from Oper
 - 'md' : medium size window
 - 'lg' : large size window
 
+=== Get display context
+
+To adapt the template content to the display context it is possible to get from OperatorFabric the page context where the template will be rendered by calling the javascript function _templateGateway.getDisplayContext()_. 
+The function returns a string with one of the following values :
+
+- 'realtime' : realtime page context (feed, monitoring)
+- 'archive' : archive page context 
+- 'preview': preview context (user card)
+
+An example of usage can be found in operator fabric git: (https://github.com/opfab/operatorfabric-core/tree/master/src/test/resources/bundles/userCardExamples2/template/en/question.handlebars[src/test/resources/bundles/userCardExamples2/template/en/question.handlebars]).
+
+
 === Redirect to business application from a card
 
 It's possible to redirect from a card to a business application declared in `ui-menu.json`.

--- a/src/test/resources/bundles/userCardExamples2/template/en/question.handlebars
+++ b/src/test/resources/bundles/userCardExamples2/template/en/question.handlebars
@@ -19,7 +19,9 @@
 
 
 <script>
-
+    if (templateGateway.getDisplayContext() != 'realtime' ) {
+       document.getElementById("response").disabled = true;
+    }
     templateGateway.applyChildCards = () => {
 
         if (templateGateway.childCards[0]) {

--- a/src/test/resources/bundles/userCardExamples2/template/fr/question.handlebars
+++ b/src/test/resources/bundles/userCardExamples2/template/fr/question.handlebars
@@ -17,7 +17,9 @@
 
 
 <script>
-
+    if (templateGateway.getDisplayContext() != 'realtime' ) {
+       document.getElementById("response").disabled = true;
+    }
     templateGateway.applyChildCards = () => {
 
         if (templateGateway.childCards[0]) {

--- a/ui/main/src/app/model/templateGateway.model.ts
+++ b/ui/main/src/app/model/templateGateway.model.ts
@@ -1,0 +1,13 @@
+/* Copyright (c) 2021, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
+ */
+
+
+export enum DisplayContext {
+    REALTIME='realtime', ARCHIVE='archive', PREVIEW='preview'
+}

--- a/ui/main/src/app/modules/archives/archives.component.html
+++ b/ui/main/src/app/modules/archives/archives.component.html
@@ -134,7 +134,7 @@
   </div>
   <div class="modal-body">
       <div>
-          <of-card-detail [card]="selectedCard" [screenSize]="'lg'"> </of-card-detail>
+          <of-card-detail [card]="selectedCard" [screenSize]="'lg'" [displayContext]="displayContext"> </of-card-detail>
       </div>
       <div>
       <span class="opfab-card-received-footer">

--- a/ui/main/src/app/modules/archives/archives.component.ts
+++ b/ui/main/src/app/modules/archives/archives.component.ts
@@ -29,7 +29,7 @@ import { EntitiesService } from '@ofServices/entities.service';
 import {MessageLevel} from '@ofModel/message.model';
 import {AlertMessage} from '@ofStore/actions/alert.actions';
 import {DateTimeNgb} from '@ofModel/datetime-ngb.model';
-
+import {DisplayContext} from '@ofModel/templateGateway.model';
 
 @Component({
     selector: 'of-archives',
@@ -68,6 +68,8 @@ export class ArchivesComponent implements OnDestroy, OnInit {
     dateTimeFilterChange = new Subject();
 
     lastRequestID: number;
+
+    displayContext: any = DisplayContext.ARCHIVE;
 
     constructor(private store: Store<AppState>,
                 private processesService: ProcessesService,

--- a/ui/main/src/app/modules/calendar/calendar.component.html
+++ b/ui/main/src/app/modules/calendar/calendar.component.html
@@ -20,7 +20,7 @@
     <ng-template #cardDetail let-modal>
       <div class="modal-body">
         <div>
-          <of-card-details [parentModalRef] = "modalRef" [screenSize]="'lg'"> </of-card-details>
+          <of-card-details [parentModalRef] = "modalRef" [screenSize]="'lg'" [displayContext]="displayContext"> </of-card-details>
         </div>
       </div>
   </ng-template>

--- a/ui/main/src/app/modules/calendar/calendar.component.ts
+++ b/ui/main/src/app/modules/calendar/calendar.component.ts
@@ -26,6 +26,7 @@ import {ApplyFilter} from '@ofStore/actions/feed.actions';
 import {FilterType} from '@ofServices/filter.service';
 import {HourAndMinutes} from '@ofModel/card.model';
 import {ProcessesService} from '@ofServices/processes.service';
+import {DisplayContext} from '@ofModel/templateGateway.model';
 
 @Component({
   selector: 'of-calendar',
@@ -47,6 +48,7 @@ export class CalendarComponent implements OnInit, OnDestroy, AfterViewInit {
   @ViewChild('calendar') calendarComponent: FullCalendarComponent; // the #calendar in the template
   @ViewChild('cardDetail') cardDetailTemplate: ElementRef; // the #cardDetail in the template
 
+  displayContext = DisplayContext.REALTIME;
   private unsubscribe$ = new Subject<void>();
   calendarVisible = true;
   locales = allLocales;

--- a/ui/main/src/app/modules/cards/components/card-details/card-details.component.ts
+++ b/ui/main/src/app/modules/cards/components/card-details/card-details.component.ts
@@ -20,6 +20,7 @@ import {selectCurrentUrl} from '@ofStore/selectors/router.selectors';
 import {AppService} from '@ofServices/app.service';
 import {State as CardState, State} from '@ofModel/processes.model';
 import { NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
+import {DisplayContext} from '@ofModel/templateGateway.model';
 
 @Component({
     selector: 'of-card-details',
@@ -27,7 +28,7 @@ import { NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
 
             <div *ngIf="card && cardState" style="font-size:13px;">
                 <of-detail   [cardState]="cardState" [card]="card" [childCards]="childCards"
-                           [currentPath]="_currentPath" [parentModalRef]="parentModalRef" [screenSize]="screenSize">
+                           [currentPath]="_currentPath" [parentModalRef]="parentModalRef" [screenSize]="screenSize" [displayContext]="displayContext">
                 </of-detail>
             </div>
         `
@@ -37,6 +38,7 @@ export class CardDetailsComponent implements OnInit, OnDestroy {
 
     @Input() parentModalRef: NgbModalRef;
     @Input() screenSize: string = 'md';
+    @Input() displayContext: any = DisplayContext.REALTIME;
 
     card: Card;
     childCards: Card[];

--- a/ui/main/src/app/modules/cards/components/detail/detail.component.ts
+++ b/ui/main/src/app/modules/cards/components/detail/detail.component.ts
@@ -47,6 +47,7 @@ import {AlertMessage} from '@ofStore/actions/alert.actions';
 import {MessageLevel} from '@ofModel/message.model';
 import {AcknowledgeService} from '@ofServices/acknowledge.service';
 import {UserPermissionsService} from '@ofServices/user-permissions-.service';
+import {DisplayContext} from '@ofModel/templateGateway.model';
 
 declare const templateGateway: any;
 
@@ -91,6 +92,7 @@ export class DetailComponent implements OnChanges, OnInit, OnDestroy, AfterViewC
     @Input() currentPath: string;
     @Input() parentModalRef: NgbModalRef;
     @Input() screenSize: string;
+    @Input() displayContext: any = DisplayContext.REALTIME;
 
     @ViewChild('cardDeletedWithNoErrorPopup') cardDeletedWithNoErrorPopupRef: TemplateRef<any>;
     @ViewChild('impossibleToDeleteCardPopup') impossibleToDeleteCardPopupRef: TemplateRef<any>;
@@ -171,6 +173,8 @@ export class DetailComponent implements OnChanges, OnInit, OnDestroy, AfterViewC
 
     ngOnChanges(): void {
         templateGateway.initTemplateGateway();
+
+        templateGateway.displayContext = this.displayContext;
         if (this.cardState.response != null && this.cardState.response !== undefined) {
             this.isCardAQuestionCard = true;
             this.computeEntitiesForResponses();

--- a/ui/main/src/app/modules/monitoring/components/monitoring-table/monitoring-table.component.html
+++ b/ui/main/src/app/modules/monitoring/components/monitoring-table/monitoring-table.component.html
@@ -50,7 +50,7 @@
 <ng-template #cardDetail let-modal>
     <div class="modal-body">
         <div>
-            <of-card-details [parentModalRef] = "modalRef" [screenSize]="'lg'"> </of-card-details>
+            <of-card-details [parentModalRef] = "modalRef" [screenSize]="'lg'" [displayContext]="displayContext"> </of-card-details>
         </div>
     </div>
 </ng-template>

--- a/ui/main/src/app/modules/monitoring/components/monitoring-table/monitoring-table.component.ts
+++ b/ui/main/src/app/modules/monitoring/components/monitoring-table/monitoring-table.component.ts
@@ -27,6 +27,8 @@ import {JsonToArray} from 'app/common/jsontoarray/json-to-array';
 import {CardService} from '@ofServices/card.service';
 import {Process} from '@ofModel/processes.model';
 import {EntitiesService} from '@ofServices/entities.service';
+import {DisplayContext} from '@ofModel/templateGateway.model';
+
 
 @Component({
     selector: 'of-monitoring-table',
@@ -39,6 +41,8 @@ export class MonitoringTableComponent implements OnChanges, OnDestroy {
     @Input() result: LineOfMonitoringResult[];
     @Input() displayProcessGroupColumn: boolean;
     @Input() maxNbOfRowsToDisplay: number;
+
+    displayContext = DisplayContext.REALTIME;
 
     exportMonitoringData: Array<any> = [];
     jsonToArray : JsonToArray;

--- a/ui/main/src/app/modules/share/card-detail/card-detail.component.ts
+++ b/ui/main/src/app/modules/share/card-detail/card-detail.component.ts
@@ -35,6 +35,7 @@ export class CardDetailComponent implements OnInit, OnDestroy {
 
     @Input() card: Card;
     @Input() screenSize: string = 'md';
+    @Input() displayContext: any;
 
     public active = false;
     unsubscribe$: Subject<void> = new Subject<void>();
@@ -113,6 +114,9 @@ export class CardDetailComponent implements OnInit, OnDestroy {
 
     private initializeHandlebarsTemplates() {
         templateGateway.initTemplateGateway();
+
+        templateGateway.displayContext =  this.displayContext;
+
         this.businessconfigService.queryProcessFromCard(this.card).pipe(
             takeUntil(this.unsubscribe$),
             switchMap(process => {

--- a/ui/main/src/app/modules/usercard/usercard.component.html
+++ b/ui/main/src/app/modules/usercard/usercard.component.html
@@ -127,7 +127,7 @@
             </div>
             <div class="opfab-section-header"><span translate>userCard.contentPreview</span></div>
             <div>
-             <of-card-detail [card]="card" [screenSize]="'md'"> </of-card-detail>
+             <of-card-detail [card]="card" [screenSize]="'md'" [displayContext]="displayContext"> </of-card-detail>
              </div>
 
         </div>

--- a/ui/main/src/app/modules/usercard/usercard.component.ts
+++ b/ui/main/src/app/modules/usercard/usercard.component.ts
@@ -39,9 +39,9 @@ import {RightsEnum} from '@ofModel/perimeter.model';
 import {Utilities} from '../../common/utilities';
 import {Entity} from '@ofModel/entity.model';
 import {ConfigService} from '@ofServices/config.service';
+import {DisplayContext} from '@ofModel/templateGateway.model';
 
 declare const templateGateway: any;
-
 
 @Component({
     selector: 'of-usercard',
@@ -51,6 +51,8 @@ declare const templateGateway: any;
 export class UserCardComponent implements OnDestroy, OnInit {
 
     @Input() modal;
+
+    displayContext = DisplayContext.PREVIEW;
 
     messageForm: FormGroup;
     recipientForm: FormGroup;

--- a/ui/main/src/assets/js/templateGateway.js
+++ b/ui/main/src/assets/js/templateGateway.js
@@ -7,13 +7,13 @@
  * This file is part of the OperatorFabric project.
  */
 
-
 const templateGateway = {
     opfabEntityNames : null, 
     childCards: [],
     userAllowedToRespond : false,
     userMemberOfAnEntityRequiredToRespond : false,
     entitiesAllowedToRespond: [],
+    displayContext: '',
 
     setEntityNames: function(entityNames){
         this.opfabEntityNames = entityNames;
@@ -58,6 +58,9 @@ const templateGateway = {
         return this.entitiesAllowedToRespond;
     },
 
+    getDisplayContext() {
+        return this.displayContext;
+    },
 
     //
     // FUNCTIONS TO OVERRIDE BY TEMPLATES 
@@ -69,6 +72,7 @@ const templateGateway = {
         this.userAllowedToRespond = false;
         this.userMemberOfAnEntityRequiredToRespond = false;
         this.entitiesAllowedToRespond = [];
+        this.displayContext = '';
 
         // OpFab calls this function to inform the template that the card is locked
         this.lockAnswer = function () {


### PR DESCRIPTION
Fix #1647 

Release notes:

In Featues section:
#1647 Add getDisplayContext() method to the template to know in which context the rendering is done


Signed-off-by: Giovanni Ferrari <giovanni.ferrari@soft.it>