### PR TITLE
Do not show popover when lttd expired icon is not visible (#1677)

### DIFF
--- a/ui/main/src/app/modules/share/countdown/countdown.component.html
+++ b/ui/main/src/app/modules/share/countdown/countdown.component.html
@@ -12,7 +12,11 @@
 
 <span *ngIf="this.countDown.isCounting()" class="lttd-timeleft" placement="right" [ngbPopover]="tipLttd" popoverClass="opfab-popover" container="body" triggers="mouseenter:mouseleave">{{this.countDown.getCountDown()}}<em class="far fa-clock lttd-icon lttd-timeleft"></em>
 </span>
-<span *ngIf="this.countDown.isEnded()" placement="right" [ngbPopover]="tipLttd" popoverClass="opfab-popover" container="body" triggers="mouseenter:mouseleave">
+<span *ngIf="this.countDown.isEnded() && showExpiredIcon" placement="right" [ngbPopover]="tipLttd" popoverClass="opfab-popover" container="body" triggers="mouseenter:mouseleave">
         <span *ngIf="showExpiredLabel" class="lttd-text">{{translatedExpiredLabel}}</span>  
         <span *ngIf="showExpiredIcon"><em class="far fa-clock lttd-icon" ></em></span> 
+</span>
+<span *ngIf="this.countDown.isEnded() && !showExpiredIcon">
+    <span *ngIf="showExpiredLabel" class="lttd-text">{{translatedExpiredLabel}}</span>  
+    <span *ngIf="showExpiredIcon"><em class="far fa-clock lttd-icon" ></em></span> 
 </span>


### PR DESCRIPTION
Fix #1677 

Release notes

In Bugs section:
#1677 Do not show popover when lttd expired icon is not visible 

Signed-off-by: Giovanni Ferrari <giovanni.ferrari@soft.it>