### PR TITLE
Add method getEntityUsedForUserResponse in templateGateway (#1645)

### DIFF
--- a/src/docs/asciidoc/reference_doc/response_cards.adoc
+++ b/src/docs/asciidoc/reference_doc/response_cards.adoc
@@ -256,3 +256,7 @@ An example of _templateGateway.setLttdExpired(true)_ usage can be found in the f
 
 == Entities allowed to respond 
 If inside your template, you want to get the ids of the entities allowed to send a response, you can call the method _templateGateway.getEntitiesAllowedToRespond()_ . This method returns an array containing the ids. An example of _templateGateway.getEntitiesAllowedToRespond()_ usage can be found in the file https://github.com/opfab/operatorfabric-core/tree/master/src/test/resources/bundles/userCardExamples2/template/en/question.handlebars[src/test/resources/bundles/userCardExamples2/template/en/question.handlebars].
+
+== Entity used for user to respond 
+If inside your template, you want to get the id of the entity used by the user to send a response, you can call the method _templateGateway.getEntityUsedForUserResponse()_ . 
+An example of usage can be found in the file https://github.com/opfab/operatorfabric-core/tree/master/src/test/resources/bundles/userCardExamples2/template/en/question.handlebars[src/test/resources/bundles/userCardExamples2/template/en/question.handlebars].

--- a/src/test/cypress/cypress/integration/CardDetail.spec.js
+++ b/src/test/cypress/cypress/integration/CardDetail.spec.js
@@ -49,6 +49,7 @@ describe('Card detail', function () {
             cy.get("#templateGateway-getEntityName-unknownEntity").contains("unknownEntity");
             cy.get("#templateGateway-isUserAllowedToRespond").contains("true");
             cy.get("#templateGateway-isUserMemberOfAnEntityRequiredToRespond").contains("true");
+            cy.get("#templateGateway-getEntityUsedForUserResponse").contains(/^ENTITY1$/);
             cy.get("#templateGateway-getDisplayContext").contains(/^realtime$/);
             
             

--- a/src/test/resources/bundles/cypress/template/en/kitchenSink.handlebars
+++ b/src/test/resources/bundles/cypress/template/en/kitchenSink.handlebars
@@ -50,6 +50,10 @@ function loadData() {
             responses += templateGateway.isUserMemberOfAnEntityRequiredToRespond();
             responses += '</span></div>';
 
+            responses += '<div> getEntityUsedForUserResponse() : <span id="templateGateway-getEntityUsedForUserResponse">';
+            responses += templateGateway.getEntityUsedForUserResponse();
+            responses += '</span></div>';
+
             responses += '<div> getDisplayContext() : <span id="templateGateway-getDisplayContext">';
             responses += templateGateway.getDisplayContext();
             responses += '</span></div>';

--- a/src/test/resources/bundles/cypress/template/fr/kitchenSink.handlebars
+++ b/src/test/resources/bundles/cypress/template/fr/kitchenSink.handlebars
@@ -50,6 +50,14 @@ function loadData() {
             responses += templateGateway.isUserMemberOfAnEntityRequiredToRespond();
             responses += '</span></div>';
 
+            responses += '<div> getEntityUsedForUserResponse() : <span id="templateGateway-getEntityUsedForUserResponse">';
+            responses += templateGateway.getEntityUsedForUserResponse();
+            responses += '</span></div>';
+
+            responses += '<div> getDisplayContext() : <span id="templateGateway-getDisplayContext">';
+            responses += templateGateway.getDisplayContext();
+            responses += '</span></div>';
+
             templateGatewayResults.innerHTML = responses;
 }
 

--- a/src/test/resources/bundles/userCardExamples2/template/en/question.handlebars
+++ b/src/test/resources/bundles/userCardExamples2/template/en/question.handlebars
@@ -14,8 +14,8 @@
 <div id="childs-div"></div>
 <br/>
  <div id="entities-div"> </div>
-
-
+<br/>
+ <div id="response-entity-div"> </div>
 
 
 <script>
@@ -68,6 +68,15 @@
         if (entities.length>0) entitiesDiv.innerHTML = text;
     }
     loadEntitiesList();
+
+    function loadEntityUsedForResponse() {
+        let responseEntityDiv = document.getElementById("response-entity-div");
+        let responseEntity = templateGateway.getEntityUsedForUserResponse();
+        let userAllowedToRespond = templateGateway.isUserAllowedToRespond();
+        if (userAllowedToRespond && responseEntity) 
+            responseEntityDiv.innerHTML = "Entity used by user to respond : " + templateGateway.getEntityName(responseEntity);
+    }
+    loadEntityUsedForResponse();
 
 </script>
 

--- a/src/test/resources/bundles/userCardExamples2/template/fr/question.handlebars
+++ b/src/test/resources/bundles/userCardExamples2/template/fr/question.handlebars
@@ -14,6 +14,8 @@
 <div id="childs-div"></div>
 <br/>
  <div id="entities-div"> </div>
+<br/>
+ <div id="response-entity-div"> </div>
 
 
 <script>
@@ -68,6 +70,14 @@
     }
     loadEntitiesList();
 
+    function loadEntityUsedForResponse() {
+        let responseEntityDiv = document.getElementById("response-entity-div");
+        let responseEntity = templateGateway.getEntityUsedForUserResponse();
+        let userAllowedToRespond = templateGateway.isUserAllowedToRespond();
+        if (userAllowedToRespond && responseEntity) 
+            responseEntityDiv.innerHTML = "Entité utilisée par l'utilisateur pour répondre : " +  templateGateway.getEntityName(responseEntity);;
+    }
+    loadEntityUsedForResponse();
 </script>
 
 </p>

--- a/ui/main/src/app/modules/cards/components/detail/detail.component.ts
+++ b/ui/main/src/app/modules/cards/components/detail/detail.component.ts
@@ -464,6 +464,7 @@ export class DetailComponent implements OnChanges, OnInit, OnDestroy, AfterViewC
         templateGateway.userAllowedToRespond = this.isUserEnabledToRespond;
         templateGateway.entitiesAllowedToRespond = this.entityIdsAllowedOrRequiredToRespondAndAllowedToSendCards;
         templateGateway.userMemberOfAnEntityRequiredToRespond = this.userMemberOfAnEntityRequiredToRespondAndAllowedToSendCards;
+        templateGateway.entityUsedForUserResponse = this.userEntityIdToUseForResponse;
     }
 
     private initializeHrefsOfCssLink() {

--- a/ui/main/src/assets/js/templateGateway.js
+++ b/ui/main/src/assets/js/templateGateway.js
@@ -13,6 +13,7 @@ const templateGateway = {
     userAllowedToRespond : false,
     userMemberOfAnEntityRequiredToRespond : false,
     entitiesAllowedToRespond: [],
+    entityUsedForUserResponse: null,
     displayContext: '',
 
     setEntityNames: function(entityNames){
@@ -58,6 +59,10 @@ const templateGateway = {
         return this.entitiesAllowedToRespond;
     },
 
+    getEntityUsedForUserResponse() {
+        return this.entityUsedForUserResponse;
+    },
+
     getDisplayContext() {
         return this.displayContext;
     },
@@ -72,6 +77,7 @@ const templateGateway = {
         this.userAllowedToRespond = false;
         this.userMemberOfAnEntityRequiredToRespond = false;
         this.entitiesAllowedToRespond = [];
+        this.entityUsedForUserResponse = null;
         this.displayContext = '';
 
         // OpFab calls this function to inform the template that the card is locked


### PR DESCRIPTION
Fix #1645 

Release notes:

In Features section:
#1645 Add a method for template to get the entity used for response

Signed-off-by: Giovanni Ferrari <giovanni.ferrari@soft.it>