### PR TITLE
Add spinner when loading cards on monitoring screen (#1681)

### DIFF
--- a/ui/main/src/app/modules/monitoring/monitoring.component.html
+++ b/ui/main/src/app/modules/monitoring/monitoring.component.html
@@ -12,7 +12,18 @@
         ></of-monitoring-filters>
 </div>
 
-<div style="height:5%"> </div>
+<div style="height: 50px"> 
+    <div  *ngIf="loadingInProgress" class="opfab-loading-spinner">
+        <ng-template #tipLoadingInProgress>
+            <span translate>feed.tips.loadingInProgress</span>
+        </ng-template>
+        <div [ngbPopover]="tipLoadingInProgress" popoverClass="opfab-popover" container="body"
+        triggers="mouseenter:mouseleave">
+        <em  class="fas fa-spinner fa-spin opfab-slow-spin"  ></em>
+        </div>
+
+     </div>
+</div>
 
 <div *ngIf="result ; else noResult" style="margin-left:5%;margin-right:5%">
     <of-monitoring-table [result]="result"

--- a/ui/main/src/app/modules/monitoring/monitoring.component.scss
+++ b/ui/main/src/app/modules/monitoring/monitoring.component.scss
@@ -1,4 +1,4 @@
-/* Copyright (c) 2018-2020, RTE (http://www.rte-france.com)
+/* Copyright (c) 2018-2021, RTE (http://www.rte-france.com)
  * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -10,3 +10,18 @@
 .alert-info {
   color: var(--opfab-text-color);
 }
+
+.opfab-loading-spinner{
+  float: right;
+  margin-right: 5%;
+  font-size: 30px;
+  border: solid 1px var(--opfab-bgcolor);
+  text-align: center;
+  background-color: var(--opfab-bgcolor);
+  color: #aaaaaa;
+}
+
+.opfab-slow-spin {
+  -webkit-animation: fa-spin 2s infinite linear;
+  animation: fa-spin 2s infinite linear;
+} 

--- a/ui/main/src/app/modules/monitoring/monitoring.component.ts
+++ b/ui/main/src/app/modules/monitoring/monitoring.component.ts
@@ -45,6 +45,8 @@ export class MonitoringComponent implements OnInit, OnDestroy {
 
     maxNbOfRowsToDisplay: number;
 
+    loadingInProgress = false;
+
     constructor(private store: Store<AppState>
                 , private processesService: ProcessesService
                 , private lightCardsService: LightCardsService
@@ -88,6 +90,8 @@ export class MonitoringComponent implements OnInit, OnDestroy {
                 catchError(err => of([]))
         );
         this.monitoringResult$.subscribe(lines => this.result = lines);
+        this.lightCardsService.getLoadingInProgress().subscribe( (inProgress: boolean ) => this.loadingInProgress = inProgress)
+
     }
 
 


### PR DESCRIPTION
Fix #1681 

Release notes
In Tasks section:
#1681 Add spinner when loading cards on monitoring screen 

Signed-off-by: Giovanni Ferrari <giovanni.ferrari@soft.it>