### PR TITLE
Process name not translated in monitoring screen when no process group defined (#1678)

### DIFF
--- a/ui/main/src/app/modules/monitoring/components/monitoring-filters/monitoring-filters.component.html
+++ b/ui/main/src/app/modules/monitoring/components/monitoring-filters/monitoring-filters.component.html
@@ -36,7 +36,7 @@
             </div>
             <div *ngIf="! displayProcessGroupsFilter() && ! isThereProcessGroup()" style="margin-top: 28px;margin-right: 40px;position:relative; min-width:300px;max-width:400px;">
                 <of-multi-filter filterPath="process" id="opfab-process"
-                                 [parentForm]="monitoringForm" [values]="processDropdownList"
+                                 [parentForm]="monitoringForm" [values]="processDropdownList" [translateValues]="true"
                                  [dropdownSettings]="processDropdownSettings" [selectedItems]="[]" i18nRootLabelKey="monitoring.filters.">
                 </of-multi-filter>
             </div>


### PR DESCRIPTION
Fix #1678

Release notes
In bugs section
#1678 Process name not translated in monitoring screen when no process group defined

Signed-off-by: Giovanni Ferrari <giovanni.ferrari@soft.it>