### PR TITLE
Fix some deprecated features in Gradle build (#1545)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ jobs:
         - echo ${DOCKER_CLOUD_PWD} | docker login --username ${DOCKER_CLOUD_USER} --password-stdin
         - docker-compose -f src/main/docker/test-environment/docker-compose.yml up -d
         - ./gradlew --build-cache copyDependencies test jacocoTestReport dockerTag${OF_VERSION} || travis_terminate 1;
-        - sonar-scanner
+        - sonar-scanner || travis_terminate 1;
         - docker-compose -f src/main/docker/test-environment/docker-compose.yml down
         # Launch karate tests
         - cd config/docker

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,6 @@ plugins {
 }
 
 repositories {
-    jcenter()
     mavenLocal()
     mavenCentral()
     maven { url "https://repo1.maven.org/maven2" }
@@ -157,7 +156,6 @@ subprojects {
     }
 
     repositories {
-        jcenter()
         mavenLocal()
         mavenCentral()
         maven { url "https://repo1.maven.org/maven2" }

--- a/build.gradle
+++ b/build.gradle
@@ -172,9 +172,6 @@ subprojects {
         apply plugin: 'java'
         apply plugin: plugin.bom
 
-        sourceCompatibility = 1.8
-        targetCompatibility = 1.8
-
         test {
             testLogging {
                 events "passed", "skipped", "failed"

--- a/client/cards/build.gradle
+++ b/client/cards/build.gradle
@@ -1,9 +1,3 @@
-buildscript {
-    repositories {
-        jcenter()
-    }
-}
-
 plugins {
     id "com.github.davidmc24.gradle.plugin.avro" version "$gradleAvroPlugin"
 }

--- a/client/client.gradle
+++ b/client/client.gradle
@@ -91,7 +91,7 @@ subprojects {
 
     /////// CUSTOM TASKS
 
-    /*Task that copies all the dependencies under build/libs so Sonar
+    /*Task that copies all the dependencies under build/support_libs so Sonar
     can make sense of the Lombok annotations for example */
     task copyDependencies(type: Copy) {
         description 'copy dependencies to build/support_libs'

--- a/client/client.gradle
+++ b/client/client.gradle
@@ -95,9 +95,9 @@ subprojects {
     /*Task that copies all the dependencies under build/libs so Sonar
     can make sense of the Lombok annotations for example */
     task copyDependencies(type: Copy) {
-        description 'copy dependencies to build/libs'
+        description 'copy dependencies to build/support_libs'
         from configurations.compileClasspath
-        into 'build/libs'
+        into 'build/support_libs'
     }
 
     tasks.jacocoTestReport.dependsOn test

--- a/client/client.gradle
+++ b/client/client.gradle
@@ -1,6 +1,5 @@
 buildscript {
     repositories {
-        jcenter()
         mavenLocal()
         mavenCentral()
         maven { url "https://repo.spring.io/release" }

--- a/services/core/build.gradle
+++ b/services/core/build.gradle
@@ -1,6 +1,5 @@
 buildscript {
     repositories {
-        jcenter()
         mavenLocal()
         mavenCentral()
         maven { url "https://repo.spring.io/release" }

--- a/services/services.gradle
+++ b/services/services.gradle
@@ -78,6 +78,14 @@ subprojects {
             }
         }
 
+        // This will never actually serve as services rely on bootJars not jars
+        // It's just a temporary workaround so build/libs is not flagged as an implicit dependency of docker
+        sourceSets {
+            main {
+                java.destinationDirectory.set(file('build/unused_plain_jar'))
+            }
+        }
+
         task unitTest(type: Test) {
             description 'runs unit tests'
             filter {
@@ -139,6 +147,7 @@ subprojects {
         tasks.docker.dependsOn copyWorkingDir
         tasks.docker.dependsOn build
         tasks.jacocoTestReport.dependsOn test
+        tasks.dockerPrepare.dependsOn bootJar
 
         Map[] commands = [
                 [command: ["up"], dependsOn: "copyWorkingDir"],

--- a/services/services.gradle
+++ b/services/services.gradle
@@ -125,7 +125,7 @@ subprojects {
 
         /////// CUSTOM TASKS
 
-        /*Task that copies all the dependencies under build/libs so Sonar
+        /*Task that copies all the dependencies under build/support_libs so Sonar
         can make sense of the Lombok annotations for example */
         task copyDependencies(type: Copy) {
             description 'copy dependencies to build/support_libs'

--- a/services/services.gradle
+++ b/services/services.gradle
@@ -1,6 +1,5 @@
 buildscript {
     repositories {
-        jcenter()
         mavenLocal()
         mavenCentral()
         maven { url "https://repo.spring.io/release" }

--- a/services/services.gradle
+++ b/services/services.gradle
@@ -121,9 +121,9 @@ subprojects {
         /*Task that copies all the dependencies under build/libs so Sonar
         can make sense of the Lombok annotations for example */
         task copyDependencies(type: Copy) {
-            description 'copy dependencies to build/libs'
+            description 'copy dependencies to build/support_libs'
             from configurations.compileClasspath
-            into 'build/libs'
+            into 'build/support_libs'
         }
 
         /* convenient copy for generating modifiable configuration from template*/

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,7 +1,6 @@
 pluginManagement {
     repositories {
         gradlePluginPortal()
-        jcenter()
         mavenLocal()
         mavenCentral()
         maven { url "https://repo1.maven.org/maven2" }

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -8,7 +8,7 @@ sonar.coverage.exclusions=**/config*/**/*,ui/**/*
 sonar.cpd.exclusions=**/model/**/*
 sonar.jacoco.reportPaths=build/jacoco/test.exec
 sonar.java.binaries=build/classes
-sonar.java.libraries=build/libs/*.jar
+sonar.java.libraries=build/libs/*.jar,build/support_libs/*.jar
 
 #Sonar exclusions - please add a justification for each rule
 # **/generated/**/*    : generated code

--- a/src/docs/asciidoc/dev_env/gradle.adoc
+++ b/src/docs/asciidoc/dev_env/gradle.adoc
@@ -21,7 +21,7 @@ to gradle and plugins official documentation.
 * Other:
 ** copyWorkingDir: copies [sub-project]/src/main/docker/volume to
 [sub-project]/build/
-** copyDependencies: copy dependencies to build/libs
+** copyDependencies: copy dependencies to build/support_libs (for Sonar)
 
 === Core
 

--- a/src/test/clientApp/clientApp.gradle
+++ b/src/test/clientApp/clientApp.gradle
@@ -1,7 +1,6 @@
 
 buildscript {
 	repositories {
-		jcenter()
 		mavenLocal()
 		mavenCentral()
 		maven { url "https://plugins.gradle.org/m2/" }

--- a/src/test/externalApp/externalApp.gradle
+++ b/src/test/externalApp/externalApp.gradle
@@ -1,7 +1,6 @@
 
 buildscript {
 	repositories {
-		jcenter()
 		mavenLocal()
 		mavenCentral()
 		maven { url "https://plugins.gradle.org/m2/" }

--- a/tools/tools.gradle
+++ b/tools/tools.gradle
@@ -1,6 +1,5 @@
 buildscript {
     repositories {
-        jcenter()
         mavenLocal()
         mavenCentral()
         maven { url "https://repo.spring.io/release" }

--- a/tools/tools.gradle
+++ b/tools/tools.gradle
@@ -60,7 +60,7 @@ subprojects {
 
     tasks.jacocoTestReport.dependsOn test
 
-    /*Task that copies all the dependencies under build/libs so Sonar
+    /*Task that copies all the dependencies under build/support_libs so Sonar
     can make sense of the Lombok annotations for example */
     task copyDependencies(type: Copy) {
         description 'copy dependencies to build/support_libs'

--- a/tools/tools.gradle
+++ b/tools/tools.gradle
@@ -60,4 +60,12 @@ subprojects {
     }
 
     tasks.jacocoTestReport.dependsOn test
+
+    /*Task that copies all the dependencies under build/libs so Sonar
+    can make sense of the Lombok annotations for example */
+    task copyDependencies(type: Copy) {
+        description 'copy dependencies to build/support_libs'
+        from configurations.compileClasspath
+        into 'build/support_libs'
+    }
 }

--- a/web-ui/web-ui.gradle
+++ b/web-ui/web-ui.gradle
@@ -1,6 +1,5 @@
 buildscript {
 	repositories {
-		jcenter()
 		mavenLocal()
 		mavenCentral()
 		maven { url "https://plugins.gradle.org/m2/" }


### PR DESCRIPTION
This PR fixes some (but not all, so the issue should remain open) deprecated features in the Gradle build that should allow the  optimizations to work properly on the back, hopefully speeding up the build.

It also removes compatibility properties that likely caused the client jars to still be generated with Java 8 rather than Java 11.

Nothing in release notes.