### PR TITLE
Fixing flaky Cypress tests (#1751) and adding doc

### DIFF
--- a/src/test/cypress/README.adoc
+++ b/src/test/cypress/README.adoc
@@ -176,6 +176,10 @@ it's better to target the element by id or data attribute using a `cy.get()` com
 assertion with `should()`.
 This way, you will get an expected/actual error message if the assertion fails, you will avoid false positives (text is
 found in another sibling element) and hard to debug behaviour with retries.
+* Be careful with `find()` (see #1751 for an example of issue that it can cause). See the Cypress documentation for
+https://docs.cypress.io/guides/core-concepts/retry-ability#Only-the-last-command-is-retried[an
+explanation] and https://docs.cypress.io/guides/core-concepts/retry-ability#Merging-queries[a less flaky alternative].
+
 
 == Configuration
 

--- a/src/test/cypress/cypress/integration/Acknowledgment.spec.js
+++ b/src/test/cypress/cypress/integration/Acknowledgment.spec.js
@@ -92,7 +92,7 @@ describe('Acknowledgment  tests', function () {
         cy.get('of-light-card').should('have.length', 6);
 
         // Check icon is present
-        cy.get('#opfab-feed-light-card-cypress-message1').find('.fa-check');
+        cy.get('#opfab-feed-light-card-cypress-message1 .fa-check');
 
         // Click on card message
         cy.get('#opfab-feed-light-card-cypress-message1').click();
@@ -101,7 +101,7 @@ describe('Acknowledgment  tests', function () {
         cy.get('#opfab-card-details-btn-ack').click();
 
         // Check icon is not present
-        cy.get('#opfab-feed-light-card-cypress-message1').find('.fa-check').should('not.exist');
+        cy.get('#opfab-feed-light-card-cypress-message1 .fa-check').should('not.exist');
 
         // Click on Ack all cards
         cy.get('#opfab-feed-ack-all-link').click();
@@ -110,20 +110,19 @@ describe('Acknowledgment  tests', function () {
         cy.get('#opfab-ack-all-btn-cancel').click();
 
         // Check icon is not present
-        cy.get('#opfab-feed-light-card-cypress-message1').find('.fa-check').should('not.exist');
+        cy.get('#opfab-feed-light-card-cypress-message1 .fa-check').should('not.exist');
 
         // Click on Ack all cards
         cy.get('#opfab-feed-ack-all-link').click();
 
         // Confirm 
         cy.get('#opfab-ack-all-btn-confirm').click();
-        cy.waitDefaultTime();
 
         // Check that all cards except one are acknowledged
-        cy.get('#opfab-feed-light-card-cypress-message1').find('.fa-check');
-        cy.get('#opfab-feed-light-card-cypress-message2').find('.fa-check');
-        cy.get('#opfab-feed-light-card-cypress-message3').find('.fa-check').should('not.exist');
-        cy.get('#opfab-feed-light-card-cypress-message4').find('.fa-check').should('not.exist');
+        cy.get('#opfab-feed-light-card-cypress-message1 .fa-check');
+        cy.get('#opfab-feed-light-card-cypress-message2 .fa-check');
+        cy.get('#opfab-feed-light-card-cypress-message3 .fa-check').should('not.exist');
+        cy.get('#opfab-feed-light-card-cypress-message4 .fa-check').should('not.exist');
 
     });
 
@@ -137,10 +136,10 @@ describe('Acknowledgment  tests', function () {
         cy.get('#opfab-feed-filter-btn-filter').click();
 
         // Check that all cards except one are acknowledged
-        cy.get('#opfab-feed-light-card-cypress-message1').find('.fa-check');
-        cy.get('#opfab-feed-light-card-cypress-message2').find('.fa-check');
-        cy.get('#opfab-feed-light-card-cypress-message3').find('.fa-check').should('not.exist');
-        cy.get('#opfab-feed-light-card-cypress-message4').find('.fa-check').should('not.exist');
+        cy.get('#opfab-feed-light-card-cypress-message1 .fa-check')
+        cy.get('#opfab-feed-light-card-cypress-message2 .fa-check')
+        cy.get('#opfab-feed-light-card-cypress-message3 .fa-check').should('not.exist');
+        cy.get('#opfab-feed-light-card-cypress-message4 .fa-check').should('not.exist');
     });
 
     it('Check no acknowledgment for operator 2  ', function () {


### PR DESCRIPTION
Fixes (#1751 )

See https://github.com/opfab/operatorfabric-core/issues/1751#issuecomment-923017715 for details on the cause of the problem.

I also fixed a test in CardDetails that was susceptible to the same problem (because of the `find` command).

This command is also used extensively in 5 other specs, but for the moment I left them as is and we'll see if they cause any trouble in the future we'll just apply the same solution.

Nothing in the release notes I think as it's only for tests ?

Signed-off-by: Alexandra Guironnet <alexandra.guironnet@rte-france.com>