### PR TITLE
Fixing doc references (#1283)

### DIFF
--- a/src/docs/asciidoc/community/workflow.adoc
+++ b/src/docs/asciidoc/community/workflow.adoc
@@ -38,7 +38,7 @@ The repository version on the `develop` branch should always be `SNAPSHOT`.
 The daily CRON Travis job generating the documentation and docker images for the `SNAPSHOT` version are run from
 this branch (see our
 ifdef::single-page-doc[<<CICD, CICD documentation>>]
-ifndef::single-page-doc[<</documentation/current/CICD/index.adoc, CICD documentation>>]
+ifndef::single-page-doc[<</documentation/current/CICD/index.adoc#CICD, CICD documentation>>]
 for details).
 
 === `master` branch

--- a/src/docs/asciidoc/deployment/configuration/configuration.adoc
+++ b/src/docs/asciidoc/deployment/configuration/configuration.adoc
@@ -103,7 +103,7 @@ The user service has these specific properties :
 
 |===
 
-
+[[cards-pub-conf]]
 ==== Cards-publication service
 
 The cards-publication service has these specific properties :

--- a/src/docs/asciidoc/dev_env/kafka.adoc
+++ b/src/docs/asciidoc/dev_env/kafka.adoc
@@ -79,7 +79,9 @@ opfab:
 
 ----
 
-<<Cards-publication service>> for more settings.
+ifdef::single-page-doc[<<cards-pub-conf, Cards-publication service>>]
+ifndef::single-page-doc[<</documentation/current/deployment/index.adoc#cards-pub-conf, Cards-publication service>>]
+for more settings.
 
 See link:{kafka_schema}[Schema management] for detailed information on using and benefits of a schema registry.
 
@@ -165,10 +167,12 @@ When you dump the card (which is about to be put on a topic) to stdout, you shou
 ----
 
 == Response Cards
-OperatorFabric <<response_cards>> can be sent by REST of put on a Kafka topic. The Kafka response card configuration follows the
+OperatorFabric
+ifdef::single-page-doc[<<response_cards, response cards>>]
+ifndef::single-page-doc[<</documentation/current/reference_doc/index.adoc#response_cards, response cards>>]
+can be sent by REST of put on a Kafka topic. The Kafka response card configuration follows the
 convention to configure a REST endpoint. Instead of setting the 'http://host/api' URL, you set it to 'kafka:response-topic' in the `externalRecipients-url:`
 section from the cards-publication.yml file:
-
 [source, yaml]
 ----
 externalRecipients-url: "{\

--- a/src/docs/asciidoc/reference_doc/card_examples.adoc
+++ b/src/docs/asciidoc/reference_doc/card_examples.adoc
@@ -14,6 +14,7 @@ Before detailing the content of cards, let's show you what cards look like throu
 
 The OperatorFabric Card specification defines mandatory attributes, but some optional attributes are needed for cards to be useful in OperatorFabric. Let's clarify those point through few examples of minimal cards and what happens when they're used as if.
 
+[[reception_rules]]
 === Rules for receiving cards
 Whatever the recipient(s) of the card (user directly, group and/or entity), the user must have the receive right on the process/state of the card to receive it (`Receive` or `ReceiveAndWrite`).
 So the rules for receiving cards are :

--- a/src/docs/asciidoc/reference_doc/users_management.adoc
+++ b/src/docs/asciidoc/reference_doc/users_management.adoc
@@ -66,8 +66,8 @@ ifndef::single-page-doc[<</documentation/current/reference_doc/index.adoc#_send_
 The notion of group is loose and can be used to simulate role in `OperatorFabric` (examples : supervisor, dispatcher ... ).
 Groups are used to send cards to several users without a name specifically. The information about membership to a
 group is stored in the user information. A group contains a list of perimeters which define the rights of reception/writing for a couple process/state. The rules used to send cards are described in the
-ifdef::single-page-doc[<<card_recipients, recipients section>>]
-ifndef::single-page-doc[<</documentation/current/reference_doc/index.adoc#card_recipients, recipients section>>]
+ifdef::single-page-doc[<<reception_rules, recipients section>>]
+ifndef::single-page-doc[<</documentation/current/reference_doc/index.adoc#reception_rules, recipients section>>]
 .
 .
 


### PR DESCRIPTION
Fixes #1283 

Two warnings remain:

> Sep 21, 2021 2:00:18 PM uri:classloader:/gems/asciidoctor-2.0.10/lib/asciidoctor/document.rb content
> INFO: possible invalid reference: card_structure
=> I checked the link in the finished document and it works. I think the false positive is due to this reference being used as an example in the documentation guidelines.

> The JavaExecHandleBuilder.setMain(String) method has been deprecated. This is scheduled to be removed in Gradle 8.0. Please use the mainClass property instead. Consult the upgrading guide for further information: https://docs.gradle.org/7.2/userguide/upgrading_version_7.html#java_exec_properties
=> This has to be addressed by the Asciidoctor plugin, as tracked by https://github.com/asciidoctor/asciidoctor-gradle-plugin/issues/602.

No need to mention it in the release notes.

Signed-off-by: Alexandra Guironnet <alexandra.guironnet@rte-france.com>