### PR TITLE
Default value for acknowledgmentAllowed is not coherent with documentation (#1777)

### DIFF
--- a/src/docs/asciidoc/reference_doc/card_notification.adoc
+++ b/src/docs/asciidoc/reference_doc/card_notification.adoc
@@ -34,9 +34,9 @@ The user can set a card as "acknowledged" so he will not see it anymore by defau
 
 To offer the possibility for the user to acknowledged card, it has to be configured in process definition. The configuration is done on a state by setting the acknowledgmentAllowed field. Allowed values are:
 
-- "Never": acknowledgement not allowed (default value)
+- "Never": acknowledgement not allowed
 
-- "Always": acknowledgement allowed
+- "Always": acknowledgement allowed (default value)
 
 - "OnlyWhenResponseDisabledForUser": acknowledgement allowed only when 
 the response is disabled for the user


### PR DESCRIPTION
#1777 Default value for acknowledgmentAllowed is not coherent with documentation