### PR TITLE
Rename endpoint to get i18n.json file

### DIFF
--- a/services/core/businessconfig/src/main/java/org/opfab/businessconfig/configuration/oauth2/WebSecurityConfiguration.java
+++ b/services/core/businessconfig/src/main/java/org/opfab/businessconfig/configuration/oauth2/WebSecurityConfiguration.java
@@ -37,7 +37,7 @@ public class WebSecurityConfiguration extends WebSecurityConfigurerAdapter {
     public static final String ADMIN_ROLE = "ADMIN";
     public static final String THIRDS_PATH = "/businessconfig/**";
     private static final String STYLE_URL_PATTERN = "/businessconfig/processes/*/css/*";
-    private static final String I18N_URL_PATTERN = "/businessconfig/processes/*/translation*";
+    private static final String I18N_URL_PATTERN = "/businessconfig/processes/*/i18n*";
 
     public static final String AUTH_AND_IP_ALLOWED = "isAuthenticated() and @webSecurityChecks.checkUserIpAddress(authentication)";
     public static final String ADMIN_AND_IP_ALLOWED = "hasRole('ADMIN') and @webSecurityChecks.checkUserIpAddress(authentication)";

--- a/services/core/businessconfig/src/main/java/org/opfab/businessconfig/controllers/BusinessconfigController.java
+++ b/services/core/businessconfig/src/main/java/org/opfab/businessconfig/controllers/BusinessconfigController.java
@@ -73,8 +73,8 @@ public class BusinessconfigController implements BusinessconfigApi {
     }
 
     @Override
-    public byte[] getTranslation(HttpServletRequest request, HttpServletResponse response, String processId, String version) throws IOException {
-        Resource resource = processService.fetchResource(processId, ResourceTypeEnum.TRANSLATION, version, "i18n");
+    public byte[] getI18n(HttpServletRequest request, HttpServletResponse response, String processId, String version) throws IOException {
+        Resource resource = processService.fetchResource(processId, ResourceTypeEnum.I18N, version, "i18n");
         return loadResource(resource);
     }
 

--- a/services/core/businessconfig/src/main/java/org/opfab/businessconfig/model/ResourceTypeEnum.java
+++ b/services/core/businessconfig/src/main/java/org/opfab/businessconfig/model/ResourceTypeEnum.java
@@ -20,7 +20,7 @@ import org.opfab.businessconfig.services.ProcessesService;
  * <dl>
  *     <dt>CSS</dt><dd>cascading style sheet resource type</dd>
  *     <dt>TEMPLATE</dt><dd>Card template resource type</dd>
- *     <dt>TRANSLATION</dt><dd>i18n file resource type</dd>
+ *     <dt>I18N</dt><dd>i18n file resource type</dd>
  * </dl>
  *
  */
@@ -29,7 +29,7 @@ import org.opfab.businessconfig.services.ProcessesService;
 public enum ResourceTypeEnum {
   CSS("css", ".css", false),
   TEMPLATE("template", ".handlebars", false),
-  TRANSLATION(".", ".json", false);
+  I18N(".", ".json", false);
 
   /**
    * containing files subfolder name

--- a/services/core/businessconfig/src/main/modeling/swagger.yaml
+++ b/services/core/businessconfig/src/main/modeling/swagger.yaml
@@ -185,13 +185,13 @@ paths:
             format: binary
         '404':
           description: No such template
-  '/businessconfig/processes/{processId}/translation':
+  '/businessconfig/processes/{processId}/i18n':
     get:
       summary: Get i18n translation file
       description: >-
         Get i18n file, if file exists return file
         (text/plain) otherwise return error message (application/json)
-      operationId: getTranslation
+      operationId: getI18n
       produces:
         - application/json
         - text/plain

--- a/services/core/businessconfig/src/test/java/org/opfab/businessconfig/controllers/GivenAdminUserBusinessconfigControllerShould.java
+++ b/services/core/businessconfig/src/test/java/org/opfab/businessconfig/controllers/GivenAdminUserBusinessconfigControllerShould.java
@@ -170,9 +170,9 @@ class GivenAdminUserBusinessconfigControllerShould {
     }
 
     @Test
-    void fetchTranslation() throws Exception {
+    void fetchI18n() throws Exception {
         ResultActions result = mockMvc.perform(
-                get("/businessconfig/processes/first/translation")
+                get("/businessconfig/processes/first/i18n")
                         .accept("text/plain")
         );
         result
@@ -181,7 +181,7 @@ class GivenAdminUserBusinessconfigControllerShould {
                 .andExpect(content().string(is("card.title=\"Title $1\"")))
         ;
         result = mockMvc.perform(
-                get("/businessconfig/processes/first/translation?version=0.1")
+                get("/businessconfig/processes/first/i18n?version=0.1")
                         .accept("text/plain")
         );
         result
@@ -192,7 +192,7 @@ class GivenAdminUserBusinessconfigControllerShould {
 
         assertException(FileNotFoundException.class).isThrownBy(() ->
                 mockMvc.perform(
-                        get("/businessconfig/processes/first/translation?version=2.1")
+                        get("/businessconfig/processes/first/i18n?version=2.1")
                                 .accept("text/plain")
                 ));
     }

--- a/services/core/businessconfig/src/test/java/org/opfab/businessconfig/controllers/GivenNonAdminUserBusinessconfigControllerShould.java
+++ b/services/core/businessconfig/src/test/java/org/opfab/businessconfig/controllers/GivenNonAdminUserBusinessconfigControllerShould.java
@@ -175,7 +175,7 @@ class GivenNonAdminUserBusinessconfigControllerShould {
     @Test
     void fetchTranslationResource() throws Exception {
         ResultActions result = mockMvc.perform(
-                get("/businessconfig/processes/first/translation")
+                get("/businessconfig/processes/first/i18n")
                         .accept("text/plain")
         );
         result
@@ -184,7 +184,7 @@ class GivenNonAdminUserBusinessconfigControllerShould {
                 .andExpect(content().string(is("card.title=\"Title $1\"")))
         ;
         result = mockMvc.perform(
-                get("/businessconfig/processes/first/translation?version=0.1")
+                get("/businessconfig/processes/first/i18n?version=0.1")
                         .accept("text/plain")
         );
         result
@@ -195,7 +195,7 @@ class GivenNonAdminUserBusinessconfigControllerShould {
 
         assertException(FileNotFoundException.class).isThrownBy(() ->
                 mockMvc.perform(
-                        get("/businessconfig/processes/first/translation?version=2.1")
+                        get("/businessconfig/processes/first/i18n?version=2.1")
                                 .accept("text/plain")
                 ));
     }

--- a/services/core/businessconfig/src/test/java/org/opfab/businessconfig/services/ProcessesServiceShould.java
+++ b/services/core/businessconfig/src/test/java/org/opfab/businessconfig/services/ProcessesServiceShould.java
@@ -142,13 +142,13 @@ class ProcessesServiceShould {
 
     @Test
     void fetchTranslation() throws IOException {
-        File i18nFile = service.fetchResource("first", TRANSLATION,null,null, "i18n").getFile();
+        File i18nFile = service.fetchResource("first", I18N,null,null, "i18n").getFile();
         assertThat(i18nFile)
                 .exists()
                 .isFile()
                 .hasName("i18n.json")
                 .hasContent("card.title=\"Title $1\"");
-        i18nFile = service.fetchResource("first", TRANSLATION, "0.1", null, "i18n").getFile();
+        i18nFile = service.fetchResource("first", I18N, "0.1", null, "i18n").getFile();
         assertThat(i18nFile)
                 .exists()
                 .isFile()

--- a/src/test/api/karate/businessconfig/getI18n.feature
+++ b/src/test/api/karate/businessconfig/getI18n.feature
@@ -17,20 +17,20 @@ Feature: getI18n
   Scenario: Check i18n translation file
 
     # Check template
-    Given url opfabUrl + '/businessconfig/processes/'+ process +'/translation/' + '?version='+ businessconfigVersion
+    Given url opfabUrl + '/businessconfig/processes/'+ process +'/i18n/' + '?version='+ businessconfigVersion
     And header Authorization = 'Bearer ' + authToken
     When method GET
     Then status 200
 
   Scenario: Check i18n translation file without authentication
 
-    Given url opfabUrl + '/businessconfig/processes/'+ process +'/translation/' + '?version='+ businessconfigVersion
+    Given url opfabUrl + '/businessconfig/processes/'+ process +'/i18n/' + '?version='+ businessconfigVersion
     When method GET
     Then status 401
 
   Scenario: Check unknown i18n translation file version
 
-    Given url opfabUrl + '/businessconfig/processes/'+ process +'/translation/' + '?version=9999999'
+    Given url opfabUrl + '/businessconfig/processes/'+ process +'/i18n/' + '?version=9999999'
     And header Authorization = 'Bearer ' + authToken
     When method GET
    Then status 404
@@ -39,7 +39,7 @@ Feature: getI18n
 
   Scenario: Check i18n translation for an unknown businessconfig
 
-    Given url opfabUrl + '/businessconfig/processes/unknownBusinessconfig/translation/' + '?version='+ businessconfigVersion
+    Given url opfabUrl + '/businessconfig/processes/unknownBusinessconfig/i18n/' + '?version='+ businessconfigVersion
     And header Authorization = 'Bearer ' + authToken
     When method GET
     Then  status 404

--- a/tools/spring/spring-oauth2-utilities/src/main/java/org/opfab/springtools/configuration/oauth/I18nProcessesCache.java
+++ b/tools/spring/spring-oauth2-utilities/src/main/java/org/opfab/springtools/configuration/oauth/I18nProcessesCache.java
@@ -39,7 +39,7 @@ public class I18nProcessesCache {
      */
     @Cacheable(value = "i18n")
     public JsonNode fetchProcessI18nFromCacheOrProxy(String process, String version) throws FeignException {
-        return client.getTranslation(process, version);
+        return client.getI18n(process, version);
     }
 
     /** Clear all cached  data

--- a/tools/spring/spring-oauth2-utilities/src/main/java/org/opfab/springtools/configuration/oauth/I18nProcessesProxy.java
+++ b/tools/spring/spring-oauth2-utilities/src/main/java/org/opfab/springtools/configuration/oauth/I18nProcessesProxy.java
@@ -22,7 +22,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 @FeignClient(url="${operatorfabric.servicesUrls.businessconfig}", name = "translation", configuration=FeignConfiguration.class)
 public interface I18nProcessesProxy {
 
-    @GetMapping(value = "/businessconfig/processes/{process}/translation",
+    @GetMapping(value = "/businessconfig/processes/{process}/i18n",
             produces = { "application/json" })
-            JsonNode getTranslation(@PathVariable(value="process") String process, @RequestParam("version") String version) ;
+            JsonNode getI18n(@PathVariable(value="process") String process, @RequestParam("version") String version) ;
 }

--- a/tools/spring/spring-oauth2-utilities/src/test/java/org/opfab/springtools/configuration/oauth/I18nProcessesCacheShould.java
+++ b/tools/spring/spring-oauth2-utilities/src/test/java/org/opfab/springtools/configuration/oauth/I18nProcessesCacheShould.java
@@ -30,8 +30,8 @@ public class I18nProcessesCacheShould {
     @Autowired
     MockClient mockI18nClient;
 
-    private final String TEST_URL = "/businessconfig/processes/process1/translation?version=1";
-    private final String TEST_URL_2 = "/businessconfig/processes/process2/translation?version=1";
+    private final String TEST_URL = "/businessconfig/processes/process1/i18n?version=1";
+    private final String TEST_URL_2 = "/businessconfig/processes/process2/i18n?version=1";
 
     private final String TEST_PROCESS = "process1";
     private final String TEST_PROCESS_2 = "process2";

--- a/tools/spring/spring-test-utilities/src/main/java/org/opfab/springtools/configuration/test/I18nProcessesCacheTestApplication.java
+++ b/tools/spring/spring-test-utilities/src/main/java/org/opfab/springtools/configuration/test/I18nProcessesCacheTestApplication.java
@@ -43,9 +43,9 @@ public class I18nProcessesCacheTestApplication {
         String stringTestI18n = "{ \"summary\": \"Summary translated {{arg1}}\",\"title\": \"Title translated\"}";
 
         MockClient mockClient = new MockClient();   
-        mockClient = mockClient.add(HttpMethod.GET, "/businessconfig/processes/process2/translation?version=1",
+        mockClient = mockClient.add(HttpMethod.GET, "/businessconfig/processes/process2/i18n?version=1",
                 200, stringTestI18n);
-        mockClient = mockClient.add(HttpMethod.GET, "/businessconfig/processes/process1/translation?version=1",
+        mockClient = mockClient.add(HttpMethod.GET, "/businessconfig/processes/process1/i18n?version=1",
                 200, stringTestI18n);
         return mockClient;
     }


### PR DESCRIPTION
Fix #1818

Release notes

In Tasks section:
#1818: Rename endpoint /businessconfig/processes/{processId}/translation  /businessconfig/processes/{processId}/i18n 

Signed-off-by: Giovanni Ferrari <giovanni.ferrari@soft.it>