### PR TITLE
Avoid having template.isLocked value to true when displaying an archive card

### DIFF
--- a/ui/main/src/assets/js/templateGateway.js
+++ b/ui/main/src/assets/js/templateGateway.js
@@ -15,6 +15,7 @@ const templateGateway = {
     entitiesAllowedToRespond: [],
     entityUsedForUserResponse: null,
     displayContext: '',
+    isLocked: false,
 
     setEntityNames: function(entityNames){
         this.opfabEntityNames = entityNames;
@@ -79,6 +80,7 @@ const templateGateway = {
         this.entitiesAllowedToRespond = [];
         this.entityUsedForUserResponse = null;
         this.displayContext = '';
+        this.isLocked = false;
 
         // OpFab calls this function to inform the template that the card is locked
         this.lockAnswer = function () {


### PR DESCRIPTION
in release not : 

BUGS : 

#1821 Avoid having template.isLocked value to true when displaying an archive card