### PR TITLE
Make impossible to set the uid field when posting a card (#1791)

### DIFF
--- a/services/core/cards-publication/src/main/java/org/opfab/cards/publication/controllers/CardController.java
+++ b/services/core/cards-publication/src/main/java/org/opfab/cards/publication/controllers/CardController.java
@@ -28,6 +28,7 @@ import javax.validation.Valid;
 import java.security.Principal;
 import java.time.Instant;
 import java.util.Optional;
+import java.util.UUID;
 
 /**
  * Synchronous controller
@@ -43,7 +44,9 @@ public class CardController {
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    public @Valid CardCreationReportData createCardOld(@Valid @RequestBody CardPublicationData card, HttpServletResponse response, Principal principal) {
+    public @Valid CardCreationReportData createCard(@Valid @RequestBody CardPublicationData card, HttpServletResponse response, Principal principal) {
+        //Overwrite eventual uid sent by client 
+        card.setUid(UUID.randomUUID().toString());
         OpFabJwtAuthenticationToken jwtPrincipal = (OpFabJwtAuthenticationToken) principal;
         CurrentUserWithPerimeters user = null ;
         if (jwtPrincipal!=null) user = (CurrentUserWithPerimeters) jwtPrincipal.getPrincipal();


### PR DESCRIPTION
Fix #1791 

Release notes

In Features section:
#1791 : Make impossible to set the uid field when posting a card

Signed-off-by: Giovanni Ferrari <giovanni.ferrari@soft.it>