### PR TITLE
Authorize sending response from entity emitting user card (#1873)

### DIFF
--- a/services/core/businessconfig/src/main/java/org/opfab/businessconfig/model/ResponseData.java
+++ b/services/core/businessconfig/src/main/java/org/opfab/businessconfig/model/ResponseData.java
@@ -37,6 +37,8 @@ public class ResponseData implements Response {
     private Boolean lock;
     private String state;
     private List<String> externalRecipients;
+    @Builder.Default
+    private Boolean emittingEntityAllowedToRespond = false;
 
     @Override
     public void setExternalRecipients(List<String> externalRecipients) {

--- a/services/core/businessconfig/src/main/modeling/swagger.yaml
+++ b/services/core/businessconfig/src/main/modeling/swagger.yaml
@@ -469,6 +469,9 @@ definitions:
         type: array
         items:
           type: string
+      emittingEntityAllowedToRespond:
+        description: If true, entity emitting a card is allowed to respond
+        type: boolean
 
   AcknowledgmentAllowedEnum:
     type: string

--- a/src/docs/asciidoc/reference_doc/response_cards.adoc
+++ b/src/docs/asciidoc/reference_doc/response_cards.adoc
@@ -94,10 +94,12 @@ and state "questionState", the user will have the possibility to respond if he h
 - The field "state" in the response field is used to define the state to use for the response (the child card).
 - The field "externalRecipients" define the recipients of the response card. These recipients are keys referenced in
 the config file of cards-publication service, in "externalRecipients-url" element. This field is optional.
+- The field "emittingEntityAllowedToRespond" in the response field is used to allow the emitting entity to respond to a card. To be able to respond, however, the emitting entity has to be one of the recipients of the card.
 - The field "showDetailCardHeader" permits to display the card header or not. This header contains the list of entities
 that have already responded or not, and a countdown indicating the time remaining to respond, if necessary.
 - The field "isOnlyAChildState" indicates whether the state is only used for child cards or not. If yes, the state
 is displayed neither in the feed notification configuration screen nor in archives screen filters.
+
 
 
 NOTE: The state to be used for the response can also be set dynamically based on the contents of the card or the

--- a/src/test/api/karate/businessconfig/getResponseBusinessconfig.feature
+++ b/src/test/api/karate/businessconfig/getResponseBusinessconfig.feature
@@ -7,6 +7,8 @@ Feature: getResponseBusinessconfig
     * def authTokenAsTSO = signInAsTSO.authToken
     * def process = 'processAction'
     * def state = 'response_full'
+    * def questionProcess = 'api_test'
+    * def questionState = 'questionState'
     * def version = 1
 
     Scenario: get businessconfig response
@@ -15,7 +17,16 @@ Feature: getResponseBusinessconfig
       And header Authorization = 'Bearer ' + authToken
       When method get
       Then status 200
-      And match response == {"lock":true,"state":"responseState","externalRecipients":["externalRecipient1","externalRecipient2"]}
+      And match response == {"lock":true,"state":"responseState","externalRecipients":["externalRecipient1","externalRecipient2"],"emittingEntityAllowedToRespond":false}
+
+    Scenario: get businessconfig response with emittingEntityAllowedToRespond
+
+      Given url opfabUrl + '/businessconfig/processes/' + questionProcess + '/' + questionState + '/response?version=' + version
+      And header Authorization = 'Bearer ' + authToken
+      When method get
+      Then status 200
+      And match response == {"lock":null,"state":"questionState","externalRecipients":[],"emittingEntityAllowedToRespond":true}
+
 
 
   Scenario: get businessconfig response without authentication

--- a/src/test/api/karate/businessconfig/resources/bundle_api_test/config.json
+++ b/src/test/api/karate/businessconfig/resources/bundle_api_test/config.json
@@ -24,7 +24,8 @@
 					"lttdVisible" : true
 				},
 		  "response": {
-			"state": "questionState"
+			"state": "questionState",
+			"emittingEntityAllowedToRespond": true
 		  },
 		  "templateName": "question",
 		  "styles": [],

--- a/src/test/resources/bundles/userCardExamples2/config.json
+++ b/src/test/resources/bundles/userCardExamples2/config.json
@@ -34,7 +34,8 @@
         "lttdVisible" : true
 			},
       "response": {
-        "state": "questionState"
+        "state": "questionState",
+        "emittingEntityAllowedToRespond": "true"
       },
       "templateName": "question",
       "styles": [],

--- a/ui/main/src/app/model/processes.model.ts
+++ b/ui/main/src/app/model/processes.model.ts
@@ -88,7 +88,8 @@ export class Response {
     constructor(
         readonly lock?: boolean,
         readonly state?: string,
-        readonly externalRecipients?: string[]
+        readonly externalRecipients?: string[],
+        readonly emittingEntityAllowedToRespond?: boolean
     ) {
     }
 }

--- a/ui/main/src/app/services/user-permissions-.service.ts
+++ b/ui/main/src/app/services/user-permissions-.service.ts
@@ -32,9 +32,9 @@ export class UserPermissionsService {
     const checkPerimeterForResponseCard = this.configService.getConfigValue('checkPerimeterForResponseCard');
 
     if (checkPerimeterForResponseCard === false)
-      return this.isUserInEntityAllowedToRespond(user, card);
+      return this.isUserInEntityAllowedToRespond(user, card, processDefinition);
     else
-      return this.isUserInEntityAllowedToRespond(user, card)
+      return this.isUserInEntityAllowedToRespond(user, card, processDefinition)
         && this.doesTheUserHaveThePerimeterToRespond(user, card, processDefinition);
   }
 
@@ -63,7 +63,7 @@ export class UserPermissionsService {
     return (card.lttd != null && (card.lttd - new Date().getTime()) <= 0);
   }
 
-  private isUserInEntityAllowedToRespond(user: UserWithPerimeters, card: Card): boolean {
+  private isUserInEntityAllowedToRespond(user: UserWithPerimeters, card: Card, processDefinition: Process): boolean {
     let userEntitiesAllowedToRespond = [];
     let entitiesAllowedToRespondAndEntitiesRequiredToRespond = [];
 
@@ -79,8 +79,10 @@ export class UserPermissionsService {
       const entitiesAllowedToRespond = this.entitiesService.getEntities().filter(entity =>
         entitiesAllowedToRespondAndEntitiesRequiredToRespond.includes(entity.id));
 
+      const emittingEntityAllowedToRespond = processDefinition.extractState(card).response.emittingEntityAllowedToRespond;
+
       const allowed = this.entitiesService.resolveEntitiesAllowedToSendCards(entitiesAllowedToRespond)
-        .map(entity => entity.id).filter(x => x !== card.publisher);
+        .map(entity => entity.id).filter(x => x !== card.publisher || emittingEntityAllowedToRespond);
 
       console.log(new Date().toISOString(), ' Detail card - entities allowed to respond = ', allowed);
 


### PR DESCRIPTION
Fix #1873 

Release notes
In Features section:
#1873 : Authorize sending response from entity emitting user card. Use 'response.state.emittingEntityAllowedToRespond' field in bundle config.json to enable it.

Signed-off-by: Giovanni Ferrari <giovanni.ferrari@soft.it>