### PR TITLE
Admin UI: in groups and perimeters tables edit and delete icons are truncated

### DIFF
--- a/ui/main/src/app/modules/admin/components/table/admin-table.directive.ts
+++ b/ui/main/src/app/modules/admin/components/table/admin-table.directive.ts
@@ -44,6 +44,7 @@ export abstract class AdminTableDirective implements OnInit, OnDestroy {
         stateRightsCellRenderer: StateRightsCellRendererComponent
       },
       domLayout: 'autoHeight',
+      rowHeight: 50,
       defaultColDef : {
         editable: false,
         headerValueGetter: this.localizeHeader.bind(this)


### PR DESCRIPTION
Fix #2014 

Release notes
In bugs section:
#2014 : Admin UI: in groups and perimeters tables edit and delete icons are truncated

Signed-off-by: Giovanni Ferrari <giovanni.ferrari@soft.it>