### PR TITLE
Correct bug when no process group define (#2043)

### DIFF
--- a/src/test/resources/processGroups/singleProcessGroup.json
+++ b/src/test/resources/processGroups/singleProcessGroup.json
@@ -8,7 +8,8 @@
         "gridCooperation",
         "userCardExamples",
         "userCardExamples2",
-        "userCardExamples3"
+        "userCardExamples3",
+        "cypress"
       ]
     }
   ]

--- a/ui/main/src/app/modules/share/archives-logging-filters/archives-logging-filters.component.html
+++ b/ui/main/src/app/modules/share/archives-logging-filters/archives-logging-filters.component.html
@@ -34,11 +34,11 @@
                              [values]="processDropdownList" [dropdownSettings]="processDropdownSettings" [selectedItems]="[]"
                              i18nRootLabelKey="filters." [sortValues]="true">
             </of-multi-filter>
-            <of-multi-filter *ngIf="displayProcessGroupFilter()" filterPath="process" id="opfab-process" [parentForm]="this.parentForm"
+            <of-multi-filter *ngIf="isThereProcessGroup() && displayProcessGroupFilter()" filterPath="process" id="opfab-process" [parentForm]="this.parentForm"
                              [values]="processDropdownListWhenSelectedProcessGroup" [dropdownSettings]="processDropdownSettings" [selectedItems]="[]"
                              i18nRootLabelKey="filters." [sortValues]="true">
             </of-multi-filter>
-            <of-multi-filter *ngIf="!displayProcessGroupFilter() && isThereOnlyOneProcessGroupInDropdownList()" filterPath="process" id="opfab-process" [parentForm]="this.parentForm"
+            <of-multi-filter *ngIf="isThereProcessGroup() && !displayProcessGroupFilter() && isThereOnlyOneProcessGroupInDropdownList()" filterPath="process" id="opfab-process" [parentForm]="this.parentForm"
                              [values]="processesDropdownListPerProcessGroups.get(processGroupDropdownList[0].id)"
                              [dropdownSettings]="processDropdownSettings" [selectedItems]="[]" i18nRootLabelKey="filters." [sortValues]="true">
             </of-multi-filter>


### PR DESCRIPTION
In release note :

BUGS: 

When no process group define , double select field for process (in archive and logging screens) #2043 