### PR TITLE
Document sound customization (#2066)

### DIFF
--- a/config/docker/custom-sounds/README.adoc
+++ b/config/docker/custom-sounds/README.adoc
@@ -1,0 +1,17 @@
+= Customizing browser notification sounds
+
+The sounds used by default by the browser to signal a card of a given severity
+can be found under `ui/main/src/assets/sounds` in the core repository and are packaged in the `web-ui` docker image.
+
+To customize these sounds, you can put the files in the current directory and mount that directory as a volume for
+the web-ui container:
+
+.Under web-ui.volumes, add:
+[source,yaml]
+```
+- "./custom-sounds:/usr/share/nginx/html/assets/sounds"
+```
+
+NOTE: When testing, if the sounds seem not to be taken into account try clearing your browser's cache.
+
+IMPORTANT: The name of the file needs to match the existing file (for example `alarm.mp3`).

--- a/config/docker/docker-compose.yml
+++ b/config/docker/docker-compose.yml
@@ -109,6 +109,8 @@ services:
     volumes:
       - "./ui-config:/usr/share/nginx/html/opfab"
       - "./nginx.conf:/etc/nginx/conf.d/default.conf"
+# Uncomment the line below to customize sounds for notification
+#     - "./custom-sounds:/usr/share/nginx/html/assets/sounds"
   ext-app:
 # External application example, must not be activated in production mode
     image: "lfeoperatorfabric/of-external-app:SNAPSHOT"

--- a/src/docs/asciidoc/reference_doc/card_notification.adoc
+++ b/src/docs/asciidoc/reference_doc/card_notification.adoc
@@ -22,7 +22,11 @@ ifndef::single-page-doc[<</documentation/current/reference_doc/index.adoc#_proce
 
 == Sound notification 
 
-If the option is activated in the general configuration file web-ui.json, the user can choose to have a sound when a card is arriving. The configuration is to be set by the user with the settings menu.
+If the option is activated in the general configuration file web-ui.json, the user can choose to have a sound played
+when they receive a card (either by the browser or by an external device if configured).
+This can be managed by the user in the settings screen.
+
+NOTE: To customize the sounds played by the browser, see `config/docker/custom-sounds/README.adoc`.
 
 == Card read 
 


### PR DESCRIPTION
In release notes (under tasks?)

#2066 : Explain how sounds for browser notifications can be customized

Note : When testing, clear the cache / or open a new window. I first thought the volume overwrite wasn't working (the old sounds kept playing) but then I opened a new window and it worked (even though I had cache disabled from the start).

Signed-off-by: Alexandra Guironnet <alexandra.guironnet@rte-france.com>