### PR TITLE
Removing legacy plugin declaration when possible (#1350)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -87,14 +87,6 @@ ext {
             swaggerUI               : "org.webjars:swagger-ui:$swaggerUI",
     ]
 
-    plugin = [
-            base        : "base",
-            boot        : "org.springframework.boot",
-            bom         : "io.spring.dependency-management",
-            dockerBuild : "com.palantir.docker",
-            dockerRun   : "com.palantir.docker-run",
-
-    ]
     apk = [
             proxy : [uri:"",httpsuri:"",user:"",password:""]
     ]
@@ -145,7 +137,7 @@ subprojects {
 
         subprojects {
             apply plugin: 'java'
-            apply plugin: plugin.bom
+            apply plugin: 'io.spring.dependency-management'
 
             test {
                 testLogging {

--- a/services/services.gradle
+++ b/services/services.gradle
@@ -9,9 +9,9 @@ subprojects {
     if (!project.name.equals("core")) {
         apply plugin: 'java'
         apply plugin: 'jacoco'
-        apply plugin: plugin.bom
-        apply plugin: plugin.boot
-        apply plugin: plugin.dockerBuild
+        apply plugin: 'io.spring.dependency-management'
+        apply plugin: 'org.springframework.boot'
+        apply plugin: "com.palantir.docker"
 
         /////// DEPENDENCIES
 

--- a/src/test/clientApp/clientApp.gradle
+++ b/src/test/clientApp/clientApp.gradle
@@ -1,9 +1,8 @@
 plugins {
 	id "java"
 	id "org.springframework.boot"
+	id "io.spring.dependency-management"
 }
-
-apply plugin: plugin.bom
 
 
 configurations {

--- a/src/test/externalApp/externalApp.gradle
+++ b/src/test/externalApp/externalApp.gradle
@@ -3,11 +3,10 @@
 plugins {
 	id "com.palantir.docker"
 	id "org.springframework.boot"
+	id "io.spring.dependency-management"
 }
 
-apply plugin: plugin.bom
 apply plugin: 'java'
-apply plugin: plugin.dockerBuild
 
 
 configurations {

--- a/tools/tools.gradle
+++ b/tools/tools.gradle
@@ -5,7 +5,7 @@ plugins {
 subprojects {
     apply plugin: 'java'
     apply plugin: 'jacoco'
-    apply plugin: plugin.bom
+    apply plugin: "io.spring.dependency-management"
 
     dependencyManagement {
         imports {

--- a/web-ui/web-ui.gradle
+++ b/web-ui/web-ui.gradle
@@ -1,9 +1,7 @@
 plugins {
+	id "base"
 	id "com.palantir.docker"
 }
-
-apply plugin: plugin.base
-apply plugin: plugin.dockerBuild
 
 docker {
 


### PR DESCRIPTION
Fixes #1350 

In tasks : 

* #1350 : Gradle - Removing legacy/duplicate plugin declaration


Signed-off-by: Alexandra Guironnet <alexandra.guironnet@rte-france.com>

Some legacy / duplicate plugin declarations remain where we used subproject, they won't be needed anymore once we address https://github.com/opfab/operatorfabric-core/issues/1361