### PR TITLE
Fixing detached DOM error (#1891)

### DIFF
--- a/src/test/cypress/cypress/integration/UserCard.spec.js
+++ b/src/test/cypress/cypress/integration/UserCard.spec.js
@@ -63,7 +63,7 @@ describe('User Card ', function () {
       })
 
 
-    /*describe('Edit user card', function () {
+    describe('Edit user card', function () {
 
       it('Edit User card from operator1', ()=>{
   
@@ -101,7 +101,7 @@ describe('User Card ', function () {
             cy.get('#opfab-div-card-template').find('div').eq(0).contains('Hello World');
         });
       })
-    })*/
+    })
 
 
     describe('Delete user card', function () {

--- a/ui/main/src/app/modules/usercard/usercard.component.ts
+++ b/ui/main/src/app/modules/usercard/usercard.component.ts
@@ -383,7 +383,7 @@ export class UserCardComponent implements OnDestroy, OnInit {
         this.messageForm.get('state').valueChanges
         .pipe(
             takeUntil(this.unsubscribe$),
-            debounceTime(10),
+            debounceTime(10), //See #1891 Cypress usercard test was flaky without this debounce
             distinctUntilChanged()
         )
         .subscribe((state) => {

--- a/ui/main/src/app/modules/usercard/usercard.component.ts
+++ b/ui/main/src/app/modules/usercard/usercard.component.ts
@@ -383,6 +383,7 @@ export class UserCardComponent implements OnDestroy, OnInit {
         this.messageForm.get('state').valueChanges
         .pipe(
             takeUntil(this.unsubscribe$),
+            debounceTime(10),
             distinctUntilChanged()
         )
         .subscribe((state) => {


### PR DESCRIPTION
Nothing in release notes

Signed-off-by: Alexandra Guironnet <alexandra.guironnet@rte-france.com>

Adding the "distinctUntilChanged" helped as the template was no longer re-rendered when the state value didn't actually change, but the test was still flaky, failing on the CI with a detached DOM error.

After investigating for quite a while, I wasn't able to pinpoint where the unwanted re-creations of the component were coming from, but as @freddidierRTE suggested adding a debounceTime step between state changes and template loading seems to fix the problem consistently (ran it several times on the CI, no failure).
So we're keeping this solution, as in any case it's better not to fire template requests until things have settled down.