### PR TITLE
Admin UI multiselect are not sorted (#2027)

### DIFF
--- a/ui/main/src/app/modules/admin/components/editmodal/entities/edit-entity-modal.component.html
+++ b/ui/main/src/app/modules/admin/components/editmodal/entities/edit-entity-modal.component.html
@@ -50,9 +50,9 @@
             </label>
           </div>
           <div class="row">
-            <of-multi-filter filterPath="parents" id="opfab-parents" [parentForm]="entityForm"
-                             [values]="entitiesDropdownList" [translateValues]="false" [dropdownSettings]="entitiesDropdownSettings" [selectedItems]="selectedEntities"
-                             i18nRootLabelKey="admin.input.entity.">
+            <of-multi-filter filterPath="parents" id="opfab-parents" [parentForm]="entityForm" [values]="entitiesDropdownList"
+                             [translateValues]="false" [dropdownSettings]="entitiesDropdownSettings" [selectedItems]="selectedEntities"
+                             sortValues=true i18nRootLabelKey="admin.input.entity.">
             </of-multi-filter>
           </div>
         </div>

--- a/ui/main/src/app/modules/admin/components/editmodal/groups/edit-group-modal.component.html
+++ b/ui/main/src/app/modules/admin/components/editmodal/groups/edit-group-modal.component.html
@@ -44,9 +44,9 @@
           </div>
 
           <div class="row">
-            <of-multi-filter filterPath="perimeters" id="opfab-perimeters" [parentForm]="groupForm"
-                             [values]="perimetersDropdownList" [translateValues]="false" [dropdownSettings]="perimetersDropdownSettings" [selectedItems]="selectedPerimeters"
-                             i18nRootLabelKey="admin.input.group.">
+            <of-multi-filter filterPath="perimeters" id="opfab-perimeters" [parentForm]="groupForm" [values]="perimetersDropdownList"
+                             [translateValues]="false" [dropdownSettings]="perimetersDropdownSettings" [selectedItems]="selectedPerimeters"
+                             sortValues=true i18nRootLabelKey="admin.input.group.">
             </of-multi-filter>
           </div>
         </div>

--- a/ui/main/src/app/modules/admin/components/editmodal/perimeters/edit-perimeter-modal.component.html
+++ b/ui/main/src/app/modules/admin/components/editmodal/perimeters/edit-perimeter-modal.component.html
@@ -34,7 +34,8 @@
 
           <div class="row">
             <of-single-filter i18nRootLabelKey="admin.input.perimeter." [parentForm]="perimeterForm" filterPath="process"
-                              [values]="processOptions" [prefixWithValue]=true style="position:relative" placeholderKey="admin.input.selectProcessText"></of-single-filter>
+                              [values]="processOptions" [prefixWithValue]=true style="position:relative"
+                              placeholderKey="admin.input.selectProcessText" sortValues=true></of-single-filter>
           </div>
 
         </div>
@@ -45,7 +46,8 @@
                  [formGroupName]="i">
               <div class="col-7">
                 <of-single-filter i18nRootLabelKey="admin.input.perimeter." [parentForm]="stateRight" filterPath="state"
-                                  [values]="stateOptions" [prefixWithValue]=true placeholderKey="admin.input.selectStateText"></of-single-filter>
+                                  [values]="stateOptions" [prefixWithValue]=true placeholderKey="admin.input.selectStateText"
+                                  sortValues=true></of-single-filter>
               </div>
               <div class="col-3">
                 <of-single-filter i18nRootLabelKey="admin.input.perimeter." [parentForm]="stateRight" filterPath="right"

--- a/ui/main/src/app/modules/admin/components/editmodal/users/edit-user-modal.component.html
+++ b/ui/main/src/app/modules/admin/components/editmodal/users/edit-user-modal.component.html
@@ -45,15 +45,15 @@
             <div *ngIf="lastName.errors.required" translate>admin.input.lastName.required</div>
           </div>
           <div class="row">
-            <of-multi-filter filterPath="groups" id="opfab-groups" [parentForm]="userForm"
-                             [values]="groupsDropdownList" [translateValues]="false" [dropdownSettings]="groupsDropdownSettings" [selectedItems]="selectedGroups"
-                             i18nRootLabelKey="admin.input.user.">
+            <of-multi-filter filterPath="groups" id="opfab-groups" [parentForm]="userForm" [values]="groupsDropdownList"
+                             [translateValues]="false" [dropdownSettings]="groupsDropdownSettings" [selectedItems]="selectedGroups"
+                             sortValues=true i18nRootLabelKey="admin.input.user.">
             </of-multi-filter>
           </div>
           <div class="row">
-            <of-multi-filter filterPath="entities" id="opfab-entities" [parentForm]="userForm"
-                             [values]="entitiesDropdownList" [translateValues]="false" [dropdownSettings]="entitiesDropdownSettings" [selectedItems]="selectedEntities"
-                             i18nRootLabelKey="admin.input.user.">
+            <of-multi-filter filterPath="entities" id="opfab-entities" [parentForm]="userForm" [values]="entitiesDropdownList"
+                             [translateValues]="false" [dropdownSettings]="entitiesDropdownSettings" [selectedItems]="selectedEntities"
+                             sortValues=true i18nRootLabelKey="admin.input.user.">
             </of-multi-filter>
           </div>
           <div class="opfab-input row">


### PR DESCRIPTION
For perimeters, the select dropdown list for the states is sorted but without using the prefix. To be discussed maybe ?

Release notes : 

In Tasks section : 

#2027 : Admin UI multiselect are not sorted