### PR TITLE
Check on publication message in usercard test (#1891)

### DIFF
--- a/src/test/cypress/cypress/integration/UserCard.spec.js
+++ b/src/test/cypress/cypress/integration/UserCard.spec.js
@@ -32,7 +32,10 @@ describe('User Card ', function () {
           cy.get('#opfab-recipients').find('li').eq(2).click();
           cy.get('#opfab-recipients').click();
           cy.get('#opfab-usercard-btn-prepareCard').click();
+          // Validate sending of the card
           cy.get('#opfab-usercard-btn-accept').click();
+          // Check that the message indicating successful sending appears
+          cy.get('.opfab-info-message').should('have.class','opfab-alert-info').contains("Your card is published");
           cy.get('of-light-card').should('have.length',1);
           cy.get('of-light-card').eq(0).click()
           .find('[id^=opfab-feed-light-card]')
@@ -80,8 +83,10 @@ describe('User Card ', function () {
               cy.get("of-usercard").should('exist');
               cy.get('#message').should('be.visible').type(' World')
               cy.get('#opfab-usercard-btn-prepareCard').click();
-              cy.get('#opfab-usercard-btn-accept').click()
-              .get('#opfab-div-card-template').find('div').eq(0).contains('Hello World');
+              cy.get('#opfab-usercard-btn-accept').click();
+              // Check that the message indicating successful sending appears
+              cy.get('.opfab-info-message').should('have.class','opfab-alert-info').contains("Your card is published");
+              cy.get('#opfab-div-card-template').find('div').eq(0).contains('Hello World');
 
         });
       })


### PR DESCRIPTION
This morning's failure of the UserCard Cypress test on develop (https://app.travis-ci.com/github/opfab/operatorfabric-core/builds/242688841) was different from the previous ones.

In this case, judging by the logs, after filling out the usercard form, previewing it and clicking "send", Cypress doesn't find the card in the feed as expected.
Maybe the card sending (during which a "Sending card" spinner appears) took too long, or there was a problem with the sending. So to guard against that, I added a check that the green confirmation message at the top appeared. And in any case it's good to check that the confirmation message works as expected.

I also added it at the edition step.

Let's hope this fix is the last...

Nothing in release notes.

Signed-off-by: Alexandra Guironnet <alexandra.guironnet@rte-france.com>