### PR TITLE
Adding unit tests for Modbus driver (#2037)

### DIFF
--- a/services/external-devices/src/main/java/org/opfab/externaldevices/drivers/ModbusDriverFactory.java
+++ b/services/external-devices/src/main/java/org/opfab/externaldevices/drivers/ModbusDriverFactory.java
@@ -9,12 +9,20 @@
 
 package org.opfab.externaldevices.drivers;
 
+import com.intelligt.modbus.jlibmodbus.Modbus;
+import com.intelligt.modbus.jlibmodbus.master.ModbusMaster;
+import com.intelligt.modbus.jlibmodbus.master.ModbusMasterFactory;
+import com.intelligt.modbus.jlibmodbus.tcp.TcpParameters;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 
+import static org.opfab.externaldevices.drivers.ModbusDriver.RESPONSE_TIMEOUT;
+
 @Component
+@Slf4j
 public class ModbusDriverFactory implements ExternalDeviceDriverFactory {
 
     @Override
@@ -22,7 +30,21 @@ public class ModbusDriverFactory implements ExternalDeviceDriverFactory {
 
         try {
             InetAddress resolvedHost = InetAddress.getByName(host);
-            return new ModbusDriver(resolvedHost,port);
+
+            // The ModbusMaster creation is handled here rather than in the ModbusDriver constructor so it can be mocked
+            // in the tests.
+            TcpParameters tcpParameters = new TcpParameters();
+            tcpParameters.setHost(resolvedHost);
+            tcpParameters.setPort(port);
+            tcpParameters.setKeepAlive(true);
+            log.debug("Creating ModbusMaster with host {} and port {}",tcpParameters.getHost(),tcpParameters.getPort());
+            Modbus.setLogLevel(Modbus.LogLevel.LEVEL_DEBUG);
+            Modbus.setAutoIncrementTransactionId(true);
+            ModbusMaster modbusMaster = ModbusMasterFactory.createModbusMasterTCP(tcpParameters);
+            modbusMaster.setResponseTimeout(RESPONSE_TIMEOUT);
+
+            return new ModbusDriver(resolvedHost,port,modbusMaster);
+
         } catch (UnknownHostException e) {
             throw new ExternalDeviceDriverException("Unable to initialize ModbusDriver with host "+ host, e);
         }

--- a/services/external-devices/src/test/java/org/opfab/externaldevices/drivers/ModbusDriverFactoryShould.java
+++ b/services/external-devices/src/test/java/org/opfab/externaldevices/drivers/ModbusDriverFactoryShould.java
@@ -1,0 +1,53 @@
+/* Copyright (c) 2021, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
+ */
+
+package org.opfab.externaldevices.drivers;
+
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.FileNotFoundException;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@ExtendWith(MockitoExtension.class)
+@Slf4j
+public class ModbusDriverFactoryShould {
+
+    private static ModbusDriverFactory modbusDriverFactory;
+
+    @BeforeAll
+    public static void setUp() {
+        modbusDriverFactory = new ModbusDriverFactory();
+    }
+
+    @Test
+    public void modbusDriverFactoryShouldCreateDriverForResolvableHost() throws ExternalDeviceDriverException, UnknownHostException {
+
+        ExternalDeviceDriver modbusDriver = modbusDriverFactory.create("123.45.67.1",123);
+
+        assertThat(modbusDriver).isNotNull();
+        assertThat(modbusDriver.getResolvedHost()).isEqualTo(InetAddress.getByName("123.45.67.1"));
+        assertThat(modbusDriver.getPort()).isEqualTo(123);
+        assertThat(modbusDriver.isConnected()).isFalse();
+
+    }
+
+    @Test
+    public void modbusDriverFactoryShouldThrowErrorIfAttemptingToCreateDriverWithUnresolvableHost() {
+        assertThrows(ExternalDeviceDriverException.class, () -> {modbusDriverFactory.create("unresolvableHost",123);});
+    }
+
+}

--- a/services/external-devices/src/test/java/org/opfab/externaldevices/drivers/ModbusDriverShould.java
+++ b/services/external-devices/src/test/java/org/opfab/externaldevices/drivers/ModbusDriverShould.java
@@ -1,0 +1,111 @@
+/* Copyright (c) 2021, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
+ */
+
+package org.opfab.externaldevices.drivers;
+
+import com.intelligt.modbus.jlibmodbus.exception.ModbusIOException;
+import com.intelligt.modbus.jlibmodbus.exception.ModbusNumberException;
+import com.intelligt.modbus.jlibmodbus.exception.ModbusProtocolException;
+import com.intelligt.modbus.jlibmodbus.master.ModbusMaster;
+import com.intelligt.modbus.jlibmodbus.msg.request.WriteSingleRegisterRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@ExtendWith(MockitoExtension.class)
+@Slf4j
+public class ModbusDriverShould {
+
+    private static ModbusDriverFactory modbusDriverFactory;
+    private ModbusMaster modbusMaster;
+    private ModbusDriver modbusDriver;
+
+    @BeforeAll
+    public static void setUp() {
+        modbusDriverFactory = new ModbusDriverFactory();
+    }
+
+    @BeforeEach
+    public void initDriver() throws UnknownHostException {
+        modbusMaster = mock(ModbusMaster.class);
+        modbusDriver = new ModbusDriver(InetAddress.getByName("123.45.67.1"),123,modbusMaster);
+    }
+
+    @Test
+    public void modbusDriverShouldConnect() throws ExternalDeviceDriverException, ModbusIOException {
+
+        modbusDriver.connect();
+        verify(modbusMaster,times(1)).connect();
+        // We can't check the case where an exception is thrown by modbusMaster.connect() because it's a final method (Mockito limitation)
+    }
+
+    @Test
+    public void modbusDriverShouldDisconnect() throws ExternalDeviceDriverException, ModbusIOException {
+
+        modbusDriver.disconnect();
+        verify(modbusMaster,times(1)).disconnect();
+        // We can't check the case where an exception is thrown by modbusMaster.disconnect() because it's a final method (Mockito limitation)
+    }
+
+    @Test
+    public void modbusDriverShouldBeConnectedIfModbusMasterIsConnected() {
+
+        when(modbusMaster.isConnected()).thenReturn(true);
+        Assertions.assertThat(modbusDriver.isConnected()).isTrue();
+        verify(modbusMaster,times(1)).isConnected();
+
+    }
+
+    @Test
+    public void modbusDriverShouldBeDisconnectedIfModbusMasterIsDisconnected() {
+
+        when(modbusMaster.isConnected()).thenReturn(false);
+        Assertions.assertThat(modbusDriver.isConnected()).isFalse();
+        verify(modbusMaster,times(1)).isConnected();
+
+    }
+
+    @Test
+    public void modbusDriverShouldSendSignal() throws ModbusProtocolException, ModbusIOException, ExternalDeviceDriverException {
+
+        int signalId = 3;
+        ArgumentCaptor<WriteSingleRegisterRequest> requestCaptor = ArgumentCaptor.forClass(WriteSingleRegisterRequest.class);
+
+        modbusDriver.send(signalId);
+
+        // Check that the modbusMaster was asked to process a request of the correct type and with a start address
+        // corresponding to the signalId that was passed to the modbusDriver
+        verify(modbusMaster,times(1)).processRequest(requestCaptor.capture());
+        Assertions.assertThat(requestCaptor.getValue().getStartAddress()).isEqualTo(signalId);
+
+    }
+
+    @Test
+    public void modbusDriverShouldThrowIfModbusMasterCantSend() throws ModbusProtocolException, ModbusIOException {
+
+        int signalId = 3;
+
+        when(modbusMaster.processRequest(any())).thenThrow(ModbusIOException.class);
+        assertThrows(ExternalDeviceDriverException.class, () -> modbusDriver.send(signalId));
+
+    }
+
+
+}


### PR DESCRIPTION
Fixes #2037 

In release notes, if it's not already there, under tasks:

* #2037 Add unit tests for the external devices feature

Signed-off-by: Alexandra Guironnet <alexandra.guironnet@rte-france.com>