### PR TITLE
Do not cache i18n files (#2170)

### DIFF
--- a/config/dev/nginx.conf.template
+++ b/config/dev/nginx.conf.template
@@ -61,6 +61,10 @@ server {
     proxy_http_version 1.1;
     proxy_cache_bypass $http_upgrade;
   }
+
+  # To be sure new files are downloaded when version change 
+  # we set no-cache for json config files and for i18n files 
+
   location /config/web-ui.json {
     # enables `ng serve` mode
     if ($request_method = 'OPTIONS') {
@@ -101,6 +105,11 @@ server {
     add_header Cache-Control "no-cache";
     alias /usr/share/nginx/html/opfab/ui-menu.json;
   }
+  location /ui/assets/i18n/ {
+    add_header Cache-Control "no-cache";
+    alias /usr/share/nginx/html/assets/i18n/;
+  }
+
   location /businessconfig {
     # enables `ng serve` mode
     if ($request_method = 'OPTIONS') {

--- a/config/docker/nginx.conf
+++ b/config/docker/nginx.conf
@@ -3,6 +3,7 @@ resolver 127.0.0.11 ipv6=off;
 server {
   listen 80;
   server_name localhost;
+  
   ### CUSTOMIZATION - BEGIN
   # Url of the Authentication provider
   set $KeycloakBaseUrl "http://keycloak:8080";
@@ -11,6 +12,9 @@ server {
   # base64 encoded pair of authentication in the form of 'client-id:secret-id'
   set $ClientPairOFAuthentication "b3BmYWItY2xpZW50Om9wZmFiLWtleWNsb2FrLXNlY3JldA==" ;
   ### CUSTOMIZATION - END
+
+  ###  OPFAB GENERIC CONFIGURATION  ###
+  ###  BE CAREFUL WHEN MODIFYING    ###
   set $BasicValue "Basic $ClientPairOFAuthentication";
   set $KeycloakOpenIdConnect $KeycloakBaseUrl/auth/realms/$OperatorFabricRealm/protocol/openid-connect;
   gzip on;
@@ -45,6 +49,9 @@ server {
     proxy_set_header Host $host;
     proxy_pass http://keycloak:8080/auth;
   }
+
+  # To be sure new files are downloaded when version change 
+  # we set no-cache for json config files and for i18n files 
   location /config/web-ui.json {
     add_header Cache-Control "no-cache";
     alias /usr/share/nginx/html/opfab/web-ui.json;
@@ -53,6 +60,11 @@ server {
     add_header Cache-Control "no-cache";
     alias /usr/share/nginx/html/opfab/ui-menu.json;
   }
+  location /ui/assets/i18n/ {
+    add_header Cache-Control "no-cache";
+    alias /usr/share/nginx/html/assets/i18n/;
+  }
+
   location /businessconfig {
     proxy_set_header Host $http_host;
     proxy_pass http://businessconfig:8080;
@@ -86,6 +98,7 @@ server {
     proxy_pass http://cards-consultation:8080;
     proxy_set_header X-Forwarded-For $remote_addr;
   }
+
   error_page 500 502 503 504 /50x.html;
   location = /50x.html {
     root /usr/share/nginx/html;

--- a/src/docs/asciidoc/resources/index.adoc
+++ b/src/docs/asciidoc/resources/index.adoc
@@ -37,3 +37,5 @@ include::migration_guide_to_2.11.adoc[leveloffset=+1]
 include::migration_guide_to_3.0.adoc[leveloffset=+1]
 
 include::migration_guide_to_3.1.adoc[leveloffset=+1]
+
+include::migration_guide_to_3.2.adoc[leveloffset=+1]

--- a/src/docs/asciidoc/resources/migration_guide_to_3.2.adoc
+++ b/src/docs/asciidoc/resources/migration_guide_to_3.2.adoc
@@ -1,0 +1,21 @@
+// Copyright (c) 2021 RTE (http://www.rte-france.com)
+// See AUTHORS.txt
+// This document is subject to the terms of the Creative Commons Attribution 4.0 International license.
+// If a copy of the license was not distributed with this
+// file, You can obtain one at https://creativecommons.org/licenses/by/4.0/.
+// SPDX-License-Identifier: CC-BY-4.0
+
+= Migration Guide from release 3.1.0 to release 3.2.0
+
+== Cache configuration for i18n files 
+
+Add the following lines in your nginx.conf to avoid keeping in cache old translation files when migrating opfab
+
+```
+  location /ui/assets/i18n/ {
+    add_header Cache-Control "no-cache";
+    alias /usr/share/nginx/html/assets/i18n/;
+  }
+```
+
+see the reference nginx configuration file : https://github.com/opfab/operatorfabric-core/blob/master/config/docker/nginx.conf 


### PR DESCRIPTION
In release note 

in task : 

#2170 Do not cache i18n files to avoid the user having to clean his cache when upgrading opfab 