### PR TITLE
Spring dependencies updates

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,10 +1,10 @@
 # spring libs
-springBoot=2.5.6
-springCloud=2020.0.4
+springBoot=2.6.1
+springCloud=2021.0.0
 springWebflux=5.3.13
 springSecurity=5.6.0
 springRetry=1.3.1
-springOpenFeign=3.0.5
+springOpenFeign=3.1.0
 
 # logging libs
 slf4j=1.7.32
@@ -19,7 +19,7 @@ jacksonAnnotations=2.13.0
 jacksonDatabind=2.13.0
 kavroSchemaRegistryClient=6.2.1
 kavroAvroSerializer=6.2.1
-springKafka=2.7.8
+springKafka=2.8.0
 micrometer=1.7.5
 avro=1.11.0
 

--- a/services/core/cards-consultation/src/main/java/org/opfab/cards/consultation/configuration/webflux/GlobalErrorWebExceptionHandler.java
+++ b/services/core/cards-consultation/src/main/java/org/opfab/cards/consultation/configuration/webflux/GlobalErrorWebExceptionHandler.java
@@ -14,7 +14,7 @@ package org.opfab.cards.consultation.configuration.webflux;
 import lombok.extern.slf4j.Slf4j;
 import org.opfab.springtools.error.model.ApiError;
 import org.opfab.springtools.error.model.ApiErrorException;
-import org.springframework.boot.autoconfigure.web.ResourceProperties;
+import org.springframework.boot.autoconfigure.web.WebProperties;
 import org.springframework.boot.autoconfigure.web.reactive.error.AbstractErrorWebExceptionHandler;
 import org.springframework.boot.web.error.ErrorAttributeOptions;
 import org.springframework.boot.web.reactive.error.ErrorAttributes;
@@ -43,7 +43,7 @@ public class GlobalErrorWebExceptionHandler extends AbstractErrorWebExceptionHan
 
     public GlobalErrorWebExceptionHandler(GlobalErrorAttributes g, ApplicationContext applicationContext,
                                           ServerCodecConfigurer serverCodecConfigurer) {
-        super(g, new ResourceProperties(), applicationContext);
+        super(g, new WebProperties.Resources(), applicationContext);
         super.setMessageWriters(serverCodecConfigurer.getWriters());
         super.setMessageReaders(serverCodecConfigurer.getReaders());
     }


### PR DESCRIPTION
Several Spring dependencies updates that needed to be done together.
I had to change one deprecated class.

In the release notes, under Tasks:
* Dependency updates
* * Spring Cloud 2021.0.0
* * Spring OpenFeign 3.1.0
* * Spring Boot 2.6.1
* * Spring Kafka 2.8.0

Renovate Bot should auto-close its PRs once this is merged.

Signed-off-by: Alexandra Guironnet <alexandra.guironnet@rte-france.com>