### PR TITLE
Admin screen : Use state names instead of state ids (#2126)

### DIFF
--- a/ui/main/src/app/modules/admin/components/cell-renderers/state-rights-cell-renderer.component.html
+++ b/ui/main/src/app/modules/admin/components/cell-renderers/state-rights-cell-renderer.component.html
@@ -6,11 +6,11 @@
 <!-- SPDX-License-Identifier: MPL-2.0                                      -->
 <!-- This file is part of the OperatorFabric project.                      -->
 
-<span *ngFor="let stateRight of stateRightsValues">
-    <span class="badge opfab-bg-right-{{stateRight.right.toString()|lowercase}}"
+<span *ngFor="let element of _stateRightsValues">
+    <span class="badge opfab-bg-right-{{element.stateRight.right.toString()|lowercase}}"
           style="font-size: 14px; margin: 3px; color: black"
-          [ngbPopover]="stateRight.right.toString()" [openDelay]="300" placement="top" triggers="mouseenter:mouseleave" popoverClass="opfab-popover" container="body"
-    >{{stateRight.state}}</span>
+          [ngbPopover]="element.stateRight.right.toString()" [openDelay]="300" placement="top" triggers="mouseenter:mouseleave"
+          popoverClass="opfab-popover" container="body">{{element.stateName}}</span>
 </span>
 
 

--- a/ui/main/src/app/modules/admin/components/cell-renderers/state-rights-cell-renderer.component.ts
+++ b/ui/main/src/app/modules/admin/components/cell-renderers/state-rights-cell-renderer.component.ts
@@ -12,37 +12,44 @@ import {Component} from '@angular/core';
 import {ICellRendererAngularComp} from 'ag-grid-angular';
 import {ICellRendererParams} from 'ag-grid-community';
 import {StateRight} from '@ofModel/perimeter.model';
+import {Process} from "@ofModel/processes.model";
+import {ProcessesService} from "@ofServices/processes.service";
 
 @Component({
-  selector: 'of-state-rights-cell-renderer',
-  templateUrl: './state-rights-cell-renderer.component.html',
-  styleUrls: ['./state-rights-cell-renderer.component.scss']
+    selector: 'of-state-rights-cell-renderer',
+    templateUrl: './state-rights-cell-renderer.component.html',
+    styleUrls: ['./state-rights-cell-renderer.component.scss']
 })
 export class StateRightsCellRendererComponent implements ICellRendererAngularComp {
 
-  constructor() {
-  }
+    // For explanations regarding ag-grid CellRenderers see
+    // https://www.ag-grid.com/documentation/angular/component-cell-renderer/#example-rendering-using-angular-components
+    _stateRightsValues: {stateName: string, stateRight: StateRight}[] = [];
+    processesDefinition: Process[];
 
-  // For explanations regarding ag-grid CellRenderers see
-  // https://www.ag-grid.com/documentation/angular/component-cell-renderer/#example-rendering-using-angular-components
-  private _stateRightsValues: StateRight[];
+    constructor(private processesService: ProcessesService,) {
+        this.processesDefinition = this.processesService.getAllProcesses();
+    }
 
+    agInit(params: any): void {
+        const stateRightsValues = params.getValue();
 
-  agInit(params: any): void {
+        const currentProcessDef = this.processesDefinition.filter(processDef => processDef.id === params.data.process)[0];
 
-          this._stateRightsValues = params.getValue();
-
-  }
+        stateRightsValues.forEach(stateRight => {
+            this._stateRightsValues.push({stateName: currentProcessDef.states[stateRight.state].name, stateRight: stateRight});
+        });
+    }
 
     /** This method returns true to signal to the grid that this renderer doesn't need to be recreated if the underlying data changes
-   *  See https://www.ag-grid.com/documentation/angular/component-cell-renderer/#handling-refresh
-   * */
-  refresh(params: ICellRendererParams): boolean {
-    return true;
-  }
+     *  See https://www.ag-grid.com/documentation/angular/component-cell-renderer/#handling-refresh
+     * */
+    refresh(params: ICellRendererParams): boolean {
+        return true;
+    }
 
-  get stateRightsValues(): StateRight[] {
-    return this._stateRightsValues;
-  }
+    get stateRightsValues(): {stateName: string, stateRight: StateRight}[] {
+        return this._stateRightsValues;
+    }
 
 }

--- a/ui/main/src/app/modules/admin/components/editmodal/perimeters/edit-perimeter-modal.component.html
+++ b/ui/main/src/app/modules/admin/components/editmodal/perimeters/edit-perimeter-modal.component.html
@@ -46,7 +46,7 @@
                  [formGroupName]="i">
               <div class="col-7">
                 <of-single-filter i18nRootLabelKey="admin.input.perimeter." [parentForm]="stateRight" filterPath="state"
-                                  [values]="stateOptions" [prefixWithValue]=true placeholderKey="admin.input.selectStateText"
+                                  [values]="stateOptions" placeholderKey="admin.input.selectStateText"
                                   sortValues=true></of-single-filter>
               </div>
               <div class="col-3">

--- a/ui/main/src/app/modules/admin/components/table/admin-table.directive.ts
+++ b/ui/main/src/app/modules/admin/components/table/admin-table.directive.ts
@@ -134,7 +134,6 @@ export abstract class AdminTableDirective implements OnInit, OnDestroy {
         .subscribe(pageSize => {
           this.gridApi.paginationSetPageSize(pageSize);
         });
-
   }
 
   /** This function generates the ag-grid `ColumnDefs` for the grid from a list of fields


### PR DESCRIPTION
Release notes : 

In Tasks section : 

#2126 : Admin screen : Use state names instead of state ids