### PR TITLE
Exclude tooling from Sonar coverage

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -4,7 +4,12 @@ sonar.sourceEncoding=UTF8
 sonar.java.source=1.8
 sonar.junit.reportPaths=build/test-results/test
 sonar.coverage.jacoco.xmlReportPaths=build/reports/jacoco/xml/report.xml
-sonar.coverage.exclusions=**/config*/**/*,ui/**/*,**/controllers/**
+
+#Coverage exclusions - please add a justification for each rule
+# **/src/tooling/**    : one-time migration tools, not meant to evolve or be tested for regressions
+
+sonar.coverage.exclusions=**/config*/**/*,ui/**/*,**/controllers/**,**/src/tooling/**
+
 sonar.cpd.exclusions=**/model/**/*
 sonar.jacoco.reportPaths=build/jacoco/test.exec
 sonar.java.binaries=build/classes


### PR DESCRIPTION
Tooling contains one-time migration tools, that are not meant to evolve or be tested for regressions, so it should be excluded from the coverage computation.
I didn't exclude it from Sonar altogether, as I think it's still useful to be warned of code smells.

Nothing in release notes.

Signed-off-by: Alexandra Guironnet <alexandra.guironnet@rte-france.com>