### PR TITLE
Solve bug : Editing a received card "breaks" subsequent sound notifications (#2243)

### DIFF
--- a/ui/main/src/app/services/sound-notification.service.ts
+++ b/ui/main/src/app/services/sound-notification.service.ts
@@ -107,7 +107,11 @@ export class SoundNotificationService implements OnDestroy{
     }
 
     public handleLoadedCard(card: LightCard) {
-        if (card.id != this.lastSentCardId && this.lightCardsFeedFilterService.isCardVisibleInFeed(card) && this.checkCardIsRecent(card)) this.incomingCardOrReminder.next(card);
+        if (card.id === this.lastSentCardId) this.lastSentCardId = ''; // no sound as the card was send by the current user
+        else {
+            if (this.lightCardsFeedFilterService.isCardVisibleInFeed(card) && this.checkCardIsRecent(card))
+                this.incomingCardOrReminder.next(card);
+        }
     }
 
     public lastSentCard(cardId: string) {


### PR DESCRIPTION

Release note : 

Bugs : 

 - #2243: Editing a received card "breaks" subsequent sound notifications 