### PR TITLE
Instance-wide default values mechanism for settings properties can be confusing

### DIFF
--- a/src/docs/asciidoc/deployment/configuration/web-ui_configuration.adoc
+++ b/src/docs/asciidoc/deployment/configuration/web-ui_configuration.adoc
@@ -49,10 +49,10 @@ The properties lie in the `web-ui.json`.The following table describes their mean
 a|The keycloak logout URL. Is a composition of:
  - Your keycloak instance and the _auth_ keyword (ex: https://www.keycloakurl.com/auth), but we also support domains without _auth_ (ex: https://www.keycloakurl.com/customPath)
  - The realm name (Ex: dev)
- - The redirect URL (_redirect_uri_): The redirect URL after success authentification
+ - The redirect URL (_redirect_uri_): The redirect URL after success authentication
 |security.changePasswordUrl||no|URL to change the user password (if the top-right menu item "Change password" is visible)
 |security.oauth2.flow.mode|PASSWORD|no
-a|authentication mode, awailable options:
+a|authentication mode, available options:
 
  - CODE: Authorization Code Flow;
  - PASSWORD: Direct Password Flow (fallback);
@@ -129,8 +129,8 @@ It should look like:
 |logo.width|150|no|The width of the logo (in px) (only taken into account if logo.base64 is set).
 |logo.limitSize|true|no|If it is true, the height limit is 32(px) and the width limit is 200(px), it means that if the height is over than 32, it will be set to 32, if the width is over than 200, it is set to 200. If it is false, no limit restriction for the height and the width. 
 |title|OperatorFabric|no|Title of the application, displayed on the browser
-|environmentName||no| Name of the environment to display on the top-right corner (examples: PROD , TEST .. ), if the value not set the environnement name is not shown .
-|environmentColor|blue|no| Color of the background of the environnement name. The format of color is css, for example : `red` , `#4052FF`
+|environmentName||no| Name of the environment to display in the top-right corner (examples: PROD , TEST .. ), if the value not set the environment name is not shown .
+|environmentColor|blue|no| Color of the background of the environment name. The format of color is css, for example : `red` , `#4052FF`
 |showUserEntitiesOnTopRightOfTheScreen|false|no| if set to true the users entities will be displayed under the login on top right of the screen
 |checkPerimeterForResponseCard|true|no|If false, OperatorFabric will not check that a user has write rights on a process/state to respond to a card.
 |usercard.useDescriptionFieldForEntityList|false|no|If true, show entity `description` field instead of `name` in user card page

--- a/src/test/cypress/cypress/integration/SoundNotification.spec.js
+++ b/src/test/cypress/cypress/integration/SoundNotification.spec.js
@@ -110,9 +110,8 @@ describe('Sound notification test', function () {
       cy.loginOpFab(user, 'test');
       stubPlaySound();
 
-      // Activate repeating sound 
+      // Activate repeating sound (no need to click the checkbox because it is already checked, because of the default value set to true in web-ui.json)
       openSettings();
-      cy.get('#opfab-checkbox-setting-form-replay').click();
       cy.waitDefaultTime();
 
       // Open the feed and send card 
@@ -154,6 +153,7 @@ describe('Sound notification test', function () {
 
       // Set repeating interval to 20 seconds
       openSettings();
+      cy.get('#opfab-setting-replayInterval').clear();
       cy.get('#opfab-setting-replayInterval').type('20');
       cy.waitDefaultTime();
 

--- a/ui/main/src/app/modules/settings/components/settings/checkbox-setting/checkbox-setting.component.ts
+++ b/ui/main/src/app/modules/settings/components/settings/checkbox-setting/checkbox-setting.component.ts
@@ -23,6 +23,7 @@ export class CheckboxSettingComponent extends BaseSettingDirective implements On
 
   @Input() public labelClass: string;
   @Input() public name : string;
+  @Input() public checked : boolean;
 
   constructor(protected store: Store<AppState>) {
     super(store);
@@ -40,7 +41,11 @@ export class CheckboxSettingComponent extends BaseSettingDirective implements On
   }
 
   updateValue(value) {
-    this.form.get('setting').setValue(value, {emitEvent: false});
+    // Undefined or null value means the user does not have made a choice for his settings, so we set the input value "checked" (default value)
+    if ((value === null) || (value === undefined))
+      this.form.get('setting').setValue(this.checked, {emitEvent: false});
+    else
+      this.form.get('setting').setValue(value, {emitEvent: false});
   }
 
 }

--- a/ui/main/src/app/modules/settings/components/settings/settings.component.html
+++ b/ui/main/src/app/modules/settings/components/settings/settings.component.html
@@ -13,17 +13,17 @@
 
   <div class="opfab-border-box opfab-settings-item" style="margin-bottom:0px;" *ngIf="!displayInfo?.sounds">
     <label translate>settings.playSoundLabel</label>
-    <of-checkbox-setting settingPath="playSoundForAlarm" labelClass="label-sev-alarm" name="alarm"></of-checkbox-setting>
-    <of-checkbox-setting settingPath="playSoundForAction" labelClass="label-sev-action" name="action"></of-checkbox-setting>
-    <of-checkbox-setting settingPath="playSoundForCompliant" labelClass="label-sev-compliant" name="compliant"></of-checkbox-setting>
-    <of-checkbox-setting settingPath="playSoundForInformation" labelClass="label-sev-information" name="information"></of-checkbox-setting>
+    <of-checkbox-setting settingPath="playSoundForAlarm" labelClass="label-sev-alarm" name="alarm" [checked]=playSoundForAlarmDefaultValue></of-checkbox-setting>
+    <of-checkbox-setting settingPath="playSoundForAction" labelClass="label-sev-action" name="action" [checked]=playSoundForActionDefaultValue></of-checkbox-setting>
+    <of-checkbox-setting settingPath="playSoundForCompliant" labelClass="label-sev-compliant" name="compliant" [checked]=playSoundForCompliantDefaultValue></of-checkbox-setting>
+    <of-checkbox-setting settingPath="playSoundForInformation" labelClass="label-sev-information" name="information" [checked]=playSoundForInformationDefaultValue></of-checkbox-setting>
   </div>
   <div class="opfab-settings-sounds opfab-settings-item" *ngIf="!displayInfo?.sounds" >
     <div class="opfab-sound-checkbox-label">
-      <of-checkbox-setting settingPath="replayEnabled" labelClass="label-replay" name="replay"></of-checkbox-setting>
+      <of-checkbox-setting settingPath="replayEnabled" labelClass="label-replay" name="replay" [checked]=replayEnabledDefaultValue></of-checkbox-setting>
       <of-checkbox-setting settingPath="playSoundOnExternalDevice" labelClass="label-external-devices" *ngIf="externalDevicesEnabled"></of-checkbox-setting>
     </div>
-    <of-text-setting settingPath="replayInterval"></of-text-setting>
+    <of-text-setting settingPath="replayInterval" [text]=replayIntervalDefaultValue></of-text-setting>
   </div>
     <div class="opfab-settings-item" *ngIf="!displayInfo?.description">
       <of-text-setting settingPath="description" [disabled]="(disableInfos)"></of-text-setting>

--- a/ui/main/src/app/modules/settings/components/settings/settings.component.ts
+++ b/ui/main/src/app/modules/settings/components/settings/settings.component.ts
@@ -24,6 +24,12 @@ export class SettingsComponent implements OnInit {
   timeZones: string[];
   displayInfo: SettingsInputs;
   externalDevicesEnabled: boolean;
+  playSoundForAlarmDefaultValue: boolean;
+  playSoundForActionDefaultValue: boolean;
+  playSoundForCompliantDefaultValue: boolean;
+  playSoundForInformationDefaultValue: boolean;
+  replayEnabledDefaultValue: boolean;
+  replayIntervalDefaultValue: number;
 
   constructor(private store: Store<AppState>,private  configService: ConfigService) { }
 
@@ -32,6 +38,12 @@ export class SettingsComponent implements OnInit {
     this.timeZones = this.configService.getConfigValue('i10n.supported.time-zones');
     this.displayInfo = this.configService.getConfigValue('settings.infos.hide');
     this.externalDevicesEnabled = this.configService.getConfigValue('externalDevicesEnabled');
+    this.playSoundForAlarmDefaultValue = !!this.configService.getConfigValue('settings.playSoundForAlarm') ? this.configService.getConfigValue('settings.playSoundForAlarm') : false;
+    this.playSoundForActionDefaultValue = !!this.configService.getConfigValue('settings.playSoundForAction') ? this.configService.getConfigValue('settings.playSoundForAction') : false;
+    this.playSoundForCompliantDefaultValue = !!this.configService.getConfigValue('settings.playSoundForCompliant') ? this.configService.getConfigValue('settings.playSoundForCompliant') : false;
+    this.playSoundForInformationDefaultValue = !!this.configService.getConfigValue('settings.playSoundForInformation') ? this.configService.getConfigValue('settings.playSoundForInformation') : false;
+    this.replayEnabledDefaultValue = !!this.configService.getConfigValue('settings.replayEnabled') ? this.configService.getConfigValue('settings.replayEnabled') : false;
+    this.replayIntervalDefaultValue = !!this.configService.getConfigValue('settings.replayInterval') ? this.configService.getConfigValue('settings.replayInterval') : 5;
   }
 
 }

--- a/ui/main/src/app/modules/settings/components/settings/text-setting/text-setting.component.ts
+++ b/ui/main/src/app/modules/settings/components/settings/text-setting/text-setting.component.ts
@@ -23,6 +23,7 @@ export class TextSettingComponent extends BaseSettingDirective implements OnInit
 
     @Input() pattern: string;
     @Input() disabled: boolean;
+    @Input() text: string;
 
     constructor(protected store: Store<AppState>) {
         super(store);
@@ -47,7 +48,11 @@ export class TextSettingComponent extends BaseSettingDirective implements OnInit
     }
 
     updateValue(value) {
-        this.form.get('setting').setValue(value, {emitEvent: false});
+        // Undefined or null value means the user does not have made a choice for his settings, so we set the input value "text" (default value)
+        if ((value === null) || (value === undefined))
+            this.form.get('setting').setValue(this.text, {emitEvent: false});
+        else
+            this.form.get('setting').setValue(value, {emitEvent: false});
     }
 
     protected isEqual(formA, formB): boolean {


### PR DESCRIPTION
The solution I propose in my pull request do not make a PATCH request. This way, we don't lose the information of whether a particular setting value was a choice from the user or just the default values in "web-ui.json" file.

Release notes : 

In Bugs section : 

#2029 : Instance-wide default values mechanism for settings properties can be confusing