### PR TITLE
Fix some Sonar bugs

### DIFF
--- a/services/cards-consultation/src/test/java/org/opfab/cards/consultation/controllers/CardOperationsControllerShould.java
+++ b/services/cards-consultation/src/test/java/org/opfab/cards/consultation/controllers/CardOperationsControllerShould.java
@@ -247,25 +247,6 @@ public class CardOperationsControllerShould {
     }
 
     @Test
-    private Runnable createUpdateSubscriptionTask() {
-        return () -> {
-            log.info("execute update subscription task");
-            Mono<CardOperationsGetParameters> parameters = Mono.just(CardOperationsGetParameters.builder()
-                    .currentUserWithPerimeters(currentUserWithPerimeters)
-                    .clientId(TEST_ID)
-                    .test(false)
-                    .rangeStart(nowMinusThree)
-                    .rangeEnd(nowMinusTwo)
-                    .notification(true).build());
-            StepVerifier.create(controller.updateSubscriptionAndPublish(parameters))
-            .expectNextCount(1)
-            .expectComplete()
-            .verify();
-        };
-    }
-
-
-    @Test
     void receiveCardsCheckUserAcks() {
         Flux<String> publisher = controller.registerSubscriptionAndPublish(Mono.just(
                 CardOperationsGetParameters.builder()

--- a/services/cards-consultation/src/test/java/org/opfab/cards/consultation/services/CardSubscriptionServiceShould.java
+++ b/services/cards-consultation/src/test/java/org/opfab/cards/consultation/services/CardSubscriptionServiceShould.java
@@ -127,7 +127,7 @@ public class CardSubscriptionServiceShould {
         Assertions.assertThat(subscription.checkActive()).isTrue();
         try {
             await().atMost(6, TimeUnit.SECONDS).until(() -> !subscription.checkActive() && subscription.isCleared());
-            Assertions.assertThat(false).isFalse().describedAs("An exception was expected here");
+            Assertions.assertThat(false).describedAs("An exception was expected here").isFalse();
         }catch (ConditionTimeoutException e){
             //nothing, everything is alright
         }
@@ -135,7 +135,7 @@ public class CardSubscriptionServiceShould {
         Assertions.assertThat(subscription2).isSameAs(subscription);
         try {
             await().atMost(6, TimeUnit.SECONDS).until(() -> !subscription.checkActive() && subscription.isCleared());
-            Assertions.assertThat(false).isFalse().describedAs("An exception was expected here");
+            Assertions.assertThat(false).describedAs("An exception was expected here").isFalse();
         }catch (ConditionTimeoutException e){
             //nothing, everything is alright
         }


### PR DESCRIPTION
I was sad that the quality gate was failed ;-) and these were easy fixes.

Regarding the removed "test", it wasn't actually a test but a helper function that got "stuck" with the @Test annotation when the test above it was removed, hence Sonar's warnings.
I removed it because the only test using it has been removed.

Nothing in release notes.

Signed-off-by: Alexandra Guironnet <alexandra.guironnet@rte-france.com>