### PR TITLE
Monitoring screen: Missing '-' between startDate and endDate in column business period in export file (#2271)

### DIFF
--- a/ui/main/src/app/modules/monitoring/components/monitoring-table/monitoring-table.component.ts
+++ b/ui/main/src/app/modules/monitoring/components/monitoring-table/monitoring-table.component.ts
@@ -292,7 +292,9 @@ export class MonitoringTableComponent implements OnChanges, OnDestroy {
                 this.exportMonitoringData.push({
                         [this.timeColumnName]: line.data.time,
                         [this.answerColumnName]: line.data.answer,
-                        [this.businessPeriodColumnName]: this.displayTime(line.data.beginningOfBusinessPeriod).concat(this.displayTime(line.data.endOfBusinessPeriod)),
+                        [this.businessPeriodColumnName]: this.displayTime(line.data.beginningOfBusinessPeriod)
+                                                         .concat('-')
+                                                         .concat(this.displayTime(line.data.endOfBusinessPeriod)),
                         [this.titleColumnName]: line.data.title,
                         [this.summaryColumnName]: line.data.summary,
                         [this.typeOfStateColumnName]: line.data.processStatus,


### PR DESCRIPTION
In release note 

Bugs : 

#2271 : Monitoring screen: Missing '-' between startDate and endDate in column business period in export file 
