### PR TITLE
Fix Gradle docker tasks (#2290)

### DIFF
--- a/services/external-devices/build.gradle
+++ b/services/external-devices/build.gradle
@@ -76,11 +76,12 @@ tasks.named("processResources") {
 }
 
 docker {
-    if (project.version.toUpperCase().equals("SNAPSHOT"))
-        name "lfeoperatorfabric/of-${project.name.toLowerCase()}:SNAPSHOT" /* more information : https://vsupalov.com/docker-latest-tag/ */
-    else
-        name "lfeoperatorfabric/of-${project.name.toLowerCase()}"
-    tags "latest", "${project.version}"
+    /* We need to specify the version in the name because if empty, it is tagged latest (https://vsupalov.com/docker-latest-tag/)
+    * but we also need to add a "tag" property otherwise the corresponding tasks (dockerTagXXX, dockerPushXXX) are not created */
+    name "lfeoperatorfabric/of-${project.name}:${project.version}"
+    tag "${project.version}", "lfeoperatorfabric/of-${project.name}:${project.version}"
+    if (!project.version.equals("SNAPSHOT"))
+        tag "latest", "latest"
     labels (['project':"${project.group}"])
     files( "build/libs"
             , "../../config/docker/common-docker.yml"

--- a/services/services.gradle
+++ b/services/services.gradle
@@ -111,11 +111,12 @@ subprojects {
     }
 
     docker {
-        if (project.version.toUpperCase().equals("SNAPSHOT"))
-            name "lfeoperatorfabric/of-${project.name.toLowerCase()}:${project.version.toUpperCase()}" /* more information : https://vsupalov.com/docker-latest-tag/ */
-        else
-            name "lfeoperatorfabric/of-${project.name.toLowerCase()}"
-        tags "latest", "${project.version}"
+        /* We need to specify the version in the name because if empty, it is tagged latest (https://vsupalov.com/docker-latest-tag/)
+        * but we also need to add a "tag" property otherwise the corresponding tasks (dockerTagXXX, dockerPushXXX) are not created */
+        name "lfeoperatorfabric/of-${project.name}:${project.version}"
+        tag "${project.version}", "lfeoperatorfabric/of-${project.name}:${project.version}"
+        if (!project.version.equals("SNAPSHOT"))
+            tag "latest", "latest"
         labels (['project':"${project.group}"])
         files( "build/libs"
                 , "../../config/docker/common-docker.yml"

--- a/src/test/dummyModbusDevice/dummyModbusDevice.gradle
+++ b/src/test/dummyModbusDevice/dummyModbusDevice.gradle
@@ -24,11 +24,12 @@ bootJar {
 
 
 docker {
-	if (project.version.toUpperCase().equals("SNAPSHOT"))
-		name "lfeoperatorfabric/of-dummy-modbus-device:SNAPSHOT" /* more information : https://vsupalov.com/docker-latest-tag/ */
-	else
-		name "lfeoperatorfabric/of-dummy-modbus-device"
-	tags "latest", "${project.version}"
+	/* We need to specify the version in the name because if empty, it is tagged latest (https://vsupalov.com/docker-latest-tag/)
+	* but we also need to add a "tag" property otherwise the corresponding tasks (dockerTagXXX, dockerPushXXX) are not created */
+	name "lfeoperatorfabric/of-dummy-modbus-device:${project.version}"
+	tag "${project.version}", "lfeoperatorfabric/of-dummy-modbus-device:${project.version}"
+	if (!project.version.equals("SNAPSHOT"))
+		tag "latest", "latest"
     labels (['project':"${project.group}"])
 	files( "build/libs")
 	dockerfile file('src/main/docker/Dockerfile')

--- a/src/test/externalApp/externalApp.gradle
+++ b/src/test/externalApp/externalApp.gradle
@@ -28,11 +28,12 @@ bootJar {
 
 
 docker {
-	if (project.version.toUpperCase().equals("SNAPSHOT"))
-		name "lfeoperatorfabric/of-external-app:${project.version.toUpperCase()}" /* more information : https://vsupalov.com/docker-latest-tag/ */
-	else
-		name "lfeoperatorfabric/of-external-app"
-	tags "latest", "${project.version}"
+	/* We need to specify the version in the name because if empty, it is tagged latest (https://vsupalov.com/docker-latest-tag/)
+	* but we also need to add a "tag" property otherwise the corresponding tasks (dockerTagXXX, dockerPushXXX) are not created */
+	name "lfeoperatorfabric/of-external-app:${project.version}"
+	tag "${project.version}", "lfeoperatorfabric/of-external-app:${project.version}"
+	if (!project.version.equals("SNAPSHOT"))
+		tag "latest", "latest"
     labels (['project':"${project.group}"])
 	files( "build/libs")
 	dockerfile file('src/main/docker/Dockerfile')

--- a/web-ui/web-ui.gradle
+++ b/web-ui/web-ui.gradle
@@ -4,12 +4,12 @@ plugins {
 }
 
 docker {
-
-	if (project.version.toUpperCase().equals("SNAPSHOT"))
-		name "lfeoperatorfabric/of-${project.name.toLowerCase()}:${project.version.toUpperCase()}" /* more information : https://vsupalov.com/docker-latest-tag/ */
-	else
-		name "lfeoperatorfabric/of-${project.name.toLowerCase()}"
-	tags "latest", "${project.version}"
+	/* We need to specify the version in the name because if empty, it is tagged latest (https://vsupalov.com/docker-latest-tag/)
+	* but we also need to add a "tag" property otherwise the corresponding tasks (dockerTagXXX, dockerPushXXX) are not created */
+	name "lfeoperatorfabric/of-${project.name.toLowerCase()}:${project.version}"
+	tag "${project.version}", "lfeoperatorfabric/of-${project.name.toLowerCase()}:${project.version}"
+	if (!project.version.equals("SNAPSHOT"))
+		tag "latest", "latest"
 	labels(['project': "${project.group}"])
 	copySpec.with {
 				from('../ui/main/build/distribution') {


### PR DESCRIPTION
Currently, when the version is a release version, the docker task prepares an image with the following name:
`name "lfeoperatorfabric/of-${project.name.toLowerCase()}`
Which means that it has no tags, and as a result it's tagged latest (https://vsupalov.com/docker-latest-tag/).

Fixes #2290 

Nothing in release notes. The "Task XXX is existed" warning is just due to the fact that the docker configuration is repeated in several build files.

Signed-off-by: Alexandra Guironnet <alexandra.guironnet@rte-france.com>