### PR TITLE
Permit to access to log api only to members of admin group (#2257)

### DIFF
--- a/services/businessconfig/src/main/java/org/opfab/businessconfig/configuration/oauth2/WebSecurityConfiguration.java
+++ b/services/businessconfig/src/main/java/org/opfab/businessconfig/configuration/oauth2/WebSecurityConfiguration.java
@@ -34,6 +34,7 @@ import org.springframework.security.oauth2.jwt.Jwt;
 public class WebSecurityConfiguration extends WebSecurityConfigurerAdapter {
 
     public static final String PROMETHEUS_PATH ="/actuator/prometheus**";
+    public static final String LOGGERS_PATH ="/actuator/loggers/**";
     public static final String ADMIN_ROLE = "ADMIN";
     public static final String THIRDS_PATH = "/businessconfig/**";
     private static final String STYLE_URL_PATTERN = "/businessconfig/processes/*/css/*";
@@ -66,6 +67,7 @@ public class WebSecurityConfiguration extends WebSecurityConfigurerAdapter {
                 .antMatchers(HttpMethod.POST, THIRDS_PATH).access(ADMIN_AND_IP_ALLOWED)
                 .antMatchers(HttpMethod.PUT, THIRDS_PATH).access(ADMIN_AND_IP_ALLOWED)
                 .antMatchers(HttpMethod.DELETE, THIRDS_PATH).access(ADMIN_AND_IP_ALLOWED)
+                .antMatchers(LOGGERS_PATH).hasRole(ADMIN_ROLE)
                 .anyRequest().access(AUTH_AND_IP_ALLOWED)
         ;
                 

--- a/services/cards-consultation/src/main/java/org/opfab/cards/consultation/configuration/webflux/WebSecurityConfiguration.java
+++ b/services/cards-consultation/src/main/java/org/opfab/cards/consultation/configuration/webflux/WebSecurityConfiguration.java
@@ -35,6 +35,7 @@ import reactor.core.publisher.Mono;
 public class WebSecurityConfiguration {
 
     public static final String PROMETHEUS_PATH = "/actuator/prometheus**";
+    public static final String LOGGERS_PATH ="/actuator/loggers/**";
     public static final String CONNECTIONS_PATH ="/connections**";
     public static final String ADMIN_ROLE = "ADMIN";
 
@@ -69,6 +70,7 @@ public class WebSecurityConfiguration {
                 .authorizeExchange()
                 .pathMatchers(HttpMethod.GET, PROMETHEUS_PATH).permitAll()
                 .pathMatchers(CONNECTIONS_PATH).hasRole(ADMIN_ROLE)
+                .pathMatchers(LOGGERS_PATH).hasRole(ADMIN_ROLE)
                 .anyExchange().access(new IpAddressAuthorizationManager());
     }
 }

--- a/services/cards-publication/src/main/java/org/opfab/cards/publication/configuration/oauth2/WebSecurityConfiguration.java
+++ b/services/cards-publication/src/main/java/org/opfab/cards/publication/configuration/oauth2/WebSecurityConfiguration.java
@@ -37,7 +37,10 @@ import org.springframework.security.oauth2.jwt.Jwt;
 public class WebSecurityConfiguration extends WebSecurityConfigurerAdapter {
 
     public static final String PROMETHEUS_PATH ="/actuator/prometheus**";
-    
+    public static final String LOGGERS_PATH ="/actuator/loggers/**";
+
+    public static final String ADMIN_ROLE = "ADMIN";
+
     public static final String AUTH_AND_IP_ALLOWED = "isAuthenticated() and @webSecurityChecks.checkUserIpAddress(authentication)";
     public static final String ADMIN_AND_IP_ALLOWED = "hasRole('ADMIN') and @webSecurityChecks.checkUserIpAddress(authentication)";
 
@@ -65,6 +68,7 @@ public class WebSecurityConfiguration extends WebSecurityConfigurerAdapter {
             http
             .authorizeRequests()
             .antMatchers(HttpMethod.GET,PROMETHEUS_PATH).permitAll() 
+            .antMatchers(LOGGERS_PATH).hasRole(ADMIN_ROLE)
             .antMatchers("/cards/userCard/**").access(AUTH_AND_IP_ALLOWED)
             .antMatchers("/cards/translateCardField").access(AUTH_AND_IP_ALLOWED)
             .antMatchers(HttpMethod.DELETE, "/cards").access(ADMIN_AND_IP_ALLOWED)
@@ -72,6 +76,7 @@ public class WebSecurityConfiguration extends WebSecurityConfigurerAdapter {
         } else {
             http
             .authorizeRequests()
+            .antMatchers(LOGGERS_PATH).hasRole(ADMIN_ROLE)
             .antMatchers("/cards/userCard/**").access(AUTH_AND_IP_ALLOWED)
             .antMatchers("/cards/translateCardField").access(AUTH_AND_IP_ALLOWED)
             .antMatchers("/**").permitAll();

--- a/services/external-devices/src/main/java/org/opfab/externaldevices/configuration/oauth2/WebSecurityConfiguration.java
+++ b/services/external-devices/src/main/java/org/opfab/externaldevices/configuration/oauth2/WebSecurityConfiguration.java
@@ -30,10 +30,12 @@ import org.springframework.security.oauth2.jwt.Jwt;
 public class WebSecurityConfiguration extends WebSecurityConfigurerAdapter {
 
     public static final String PROMETHEUS_PATH ="/actuator/prometheus**";
-
+    public static final String LOGGERS_PATH ="/actuator/loggers/**";
     public static final String CONFIGURATIONS_ROOT_PATH = "/configurations/";
     public static final String DEVICES_ROOT_PATH = "/devices/";
     public static final String NOTIFICATIONS_ROOT_PATH = "/notifications";
+
+    public static final String ADMIN_ROLE = "ADMIN";
 
     public static final String AUTH_AND_IP_ALLOWED = "isAuthenticated() and @webSecurityChecks.checkUserIpAddress(authentication)";
     public static final String ADMIN_AND_IP_ALLOWED = "hasRole('ADMIN') and @webSecurityChecks.checkUserIpAddress(authentication)";
@@ -57,6 +59,7 @@ public class WebSecurityConfiguration extends WebSecurityConfigurerAdapter {
         http
                 .authorizeRequests()
                 .antMatchers(HttpMethod.GET,PROMETHEUS_PATH).permitAll()
+                .antMatchers(LOGGERS_PATH).hasRole(ADMIN_ROLE)
                 .antMatchers(HttpMethod.POST,NOTIFICATIONS_ROOT_PATH).access(AUTH_AND_IP_ALLOWED)
                 .antMatchers(CONFIGURATIONS_ROOT_PATH+"**").access(ADMIN_AND_IP_ALLOWED)
                 .antMatchers(DEVICES_ROOT_PATH+"**").access(ADMIN_AND_IP_ALLOWED)

--- a/services/users/src/main/java/org/opfab/users/configuration/oauth2/WebSecurityConfiguration.java
+++ b/services/users/src/main/java/org/opfab/users/configuration/oauth2/WebSecurityConfiguration.java
@@ -33,6 +33,8 @@ import lombok.extern.slf4j.Slf4j;
 public class WebSecurityConfiguration extends WebSecurityConfigurerAdapter {
 
     public static final String PROMETHEUS_PATH ="/actuator/prometheus**";
+    public static final String LOGGERS_PATH ="/actuator/loggers/**";
+
     public static final String USER_PATH = "/users/{login}";
     public static final String USERS_SETTINGS_PATH = "/users/{login}/settings";
     public static final String USERS_PERIMETERS_PATH = "/users/{login}/perimeters";
@@ -87,6 +89,7 @@ public class WebSecurityConfiguration extends WebSecurityConfigurerAdapter {
                 .antMatchers(ENTITIES_PATH).access(IS_ADMIN_AND_IP_ALLOWED)
                 .antMatchers(PERIMETERS_PATH).access(IS_ADMIN_AND_IP_ALLOWED)
                 .antMatchers(CURRENTUSER_INTERNAL_PATH).authenticated()
+                .antMatchers(LOGGERS_PATH).hasRole(ADMIN_ROLE)
                 .anyRequest().access(AUTH_AND_IP_ALLOWED);
     }
 

--- a/src/docs/asciidoc/deployment/index.adoc
+++ b/src/docs/asciidoc/deployment/index.adoc
@@ -36,6 +36,48 @@ include::RABBITMQ.adoc[leveloffset=+1]
 
 Operator Fabric provides end points for monitoring via link:https://prometheus.io/[prometheus]. The monitoring is available for the four following services: user, businessconfig, cards-consultation, cards-publication. You can start a test prometheus instance via `config/monitoring/startPrometheus.sh` , the monitoring will be accessible on http://localhost:9090/
 
+== Logging Administration
+
+Operator Fabric includes the ability to view and configure the log levels at runtime through APIs. It is possible to configure and view an individual logger configuration, which is made up of both the explicitly configured logging level as well as the effective logging level given to it by the logging framework. These levels can be one of:
+
+* TRACE
+* DEBUG
+* INFO
+* WARN
+* ERROR
+* FATAL
+* OFF
+* null
+
+null indicates that there is no explicit configuration.
+
+Querying and setting logging levels is restricted to administrators.
+
+To view the configured logging level for a given logger it is possible to send a GET request to the '/actuator/logger' URI as follows:
+----
+curl http://<server>:<port>/actuator/loggers/${logger} -H "Authorization: Bearer ${token}" -H "Content-type:application/json"
+----
+where `${token}` is a valid OAuth2 JWT for a user with administration privileges
+and `${logger}` is the logger (ex: org.opfab)
+
+The response will be a json object like the following:
+
+----
+{
+  "configuredLevel" : "INFO",
+  "effectiveLevel" : "INFO"
+}
+----
+
+To configure a given logger, POST a json entity to the '/actuator/logger' URI, as follows:
+
+----
+curl -i -X POST http://<server>:<port>/actuator/loggers/${logger} -H "Authorization: Bearer ${token}" -H 'Content-Type: application/json' -d '{"configuredLevel": "DEBUG"}'
+----
+
+To “reset” the specific level of the logger (and use the default configuration instead) it is possible to pass a value of null as the configuredLevel.
+
+
 include::users_groups_admin.adoc[leveloffset=+1]
 
 

--- a/src/test/api/karate/admin/loggersApi.feature
+++ b/src/test/api/karate/admin/loggersApi.feature
@@ -1,0 +1,124 @@
+Feature: Log Level Access
+
+  Background:
+   #Getting token for admin and operator1 user calling getToken.feature
+    * def signIn = callonce read('../common/getToken.feature') { username: 'admin'}
+    * def authToken = signIn.authToken
+    * def signInAsTSO = callonce read('../common/getToken.feature') { username: 'user_test_api_1'}
+    * def authTokenAsTSO = signInAsTSO.authToken
+
+    * def businessConfigLoggersUrl = opfabBusinessConfigUrl + 'actuator/loggers/org.opfab'
+    * def userLoggersUrl = opfabUserUrl + 'actuator/loggers/org.opfab'
+    * def cardsPublicationLoggersUrl = opfabCardsPublicationUrl + 'actuator/loggers/org.opfab'
+    * def cardsConsultationLoggersUrl = opfabCardsConsultationUrl + 'actuator/loggers/org.opfab'
+    * def externalDevicesLoggersUrl = opfabExternalDevicesUrl + 'actuator/loggers/org.opfab'
+    
+
+
+    * def info_level =
+    """
+    {
+      "configuredLevel": "INFO"
+    }
+    """
+
+    * def debug_level =
+    """
+    {
+      "configuredLevel": "DEBUG"
+    }
+    """  
+
+  Scenario Outline: get logging level is restricted to admin user
+
+    Given url <url>
+    And header Authorization = 'Bearer ' + <token>
+    When method <method>
+    Then status <expected>
+
+    Examples:
+    | url                          | method | token          | expected  |
+    | businessConfigLoggersUrl     | get    | authTokenAsTSO | 403       |
+    | businessConfigLoggersUrl     | get    | authToken      | 200       |
+    | userLoggersUrl               | get    | authTokenAsTSO | 403       |
+    | userLoggersUrl               | get    | authToken      | 200       |
+    | cardsPublicationLoggersUrl   | get    | authTokenAsTSO | 403       |
+    | cardsPublicationLoggersUrl   | get    | authToken      | 200       |
+    | cardsConsultationLoggersUrl  | get    | authTokenAsTSO | 403       |
+    | cardsConsultationLoggersUrl  | get    | authToken      | 200       |
+    | externalDevicesLoggersUrl    | get    | authTokenAsTSO | 403       |
+    | externalDevicesLoggersUrl    | get    | authToken      | 200       |
+    
+
+
+  Scenario Outline: set logging level to DEBUG is restricted to admin user
+
+    Given url <url>
+    And header Authorization = 'Bearer ' + <token>
+    And request debug_level
+    When method <method>
+    Then status <expected>
+
+    Examples:
+    | url                          | method | token          | expected  |
+    | businessConfigLoggersUrl     | post   | authTokenAsTSO | 403       |
+    | businessConfigLoggersUrl     | post   | authToken      | 204       |
+    | userLoggersUrl               | post   | authTokenAsTSO | 403       |
+    | userLoggersUrl               | post   | authToken      | 204       |
+    | cardsPublicationLoggersUrl   | post   | authTokenAsTSO | 403       |
+    | cardsPublicationLoggersUrl   | post   | authToken      | 204       |
+    | cardsConsultationLoggersUrl  | post   | authTokenAsTSO | 403       |
+    | cardsConsultationLoggersUrl  | post   | authToken      | 204       |
+    | externalDevicesLoggersUrl    | post   | authTokenAsTSO | 403       |
+    | externalDevicesLoggersUrl    | post   | authToken      | 204       |
+
+  Scenario Outline: check logging level is 'DEBUG' as admin
+
+    Given url <url>
+    And header Authorization = 'Bearer ' + authToken
+    When method get
+    Then status <expected>
+    And match response.configuredLevel == 'DEBUG'
+
+    Examples:
+    | url                          | expected  |
+    | businessConfigLoggersUrl     | 200       |
+    | userLoggersUrl               | 200       |
+    | cardsPublicationLoggersUrl   | 200       |
+    | cardsConsultationLoggersUrl  | 200       |
+    | externalDevicesLoggersUrl    | 200       |
+
+
+
+  Scenario Outline: set logging level to INFO as admin
+
+    Given url <url>
+    And header Authorization = 'Bearer ' + authToken
+    And request info_level
+    When method post
+    Then status <expected>
+
+    Examples:
+    | url                          | expected  |
+    | businessConfigLoggersUrl     | 204       |
+    | userLoggersUrl               | 204       |
+    | cardsPublicationLoggersUrl   | 204       |
+    | cardsConsultationLoggersUrl  | 204       |
+    | externalDevicesLoggersUrl    | 204       |
+
+  Scenario Outline: get logging level is 'INFO' as admin 
+
+    Given url <url>
+    And header Authorization = 'Bearer ' + authToken
+    When method get
+    Then status <expected>
+    And match response.configuredLevel == 'INFO'
+
+    Examples:
+    | url                          | expected  |
+    | businessConfigLoggersUrl     | 200       |
+    | userLoggersUrl               | 200       |
+    | cardsPublicationLoggersUrl   | 200       |
+    | cardsConsultationLoggersUrl  | 200       |
+    | externalDevicesLoggersUrl    | 200       |
+

--- a/src/test/api/karate/adminTests.txt
+++ b/src/test/api/karate/adminTests.txt
@@ -1,1 +1,3 @@
-admin/getPrometheusMonitoring.feature \
+    admin/getPrometheusMonitoring.feature \
+    admin/loggersApi.feature \
+

--- a/src/test/api/karate/karate-config.js
+++ b/src/test/api/karate/karate-config.js
@@ -17,7 +17,9 @@ function() {
       opfabUserUrl: opfab_server +":2103/",
       opfabBusinessConfigUrl: opfab_server +":2100/",
       opfabCardsConsultationUrl: opfab_server +":2104/",
-      opfabCardsPublicationUrl: opfab_server +":2102/"
+      opfabCardsPublicationUrl: opfab_server +":2102/",
+      opfabExternalDevicesUrl: opfab_server +":2105/"
+
     };
 
     karate.logger.debug('url opfab :' + config.opfabUrl );


### PR DESCRIPTION

Release notes
In Task section:
 #2257 : Permit to access to log api only to members of admin group

Signed-off-by: Giovanni Ferrari <giovanni.ferrari@soft.it>