### PR TITLE
Admin screen : Incoherence between pagination and displayed results after deleting a filter (#2270)

### DIFF
--- a/ui/main/src/app/modules/admin/components/table/admin-table.directive.html
+++ b/ui/main/src/app/modules/admin/components/table/admin-table.directive.html
@@ -16,6 +16,7 @@
             [gridOptions]="gridOptions"
             [rowData]="rowData"
             class="opfab-ag-grid-theme"
+            (filterChanged)="onFilterChanged($event)"
     >
     </ag-grid-angular>
 

--- a/ui/main/src/app/modules/admin/components/table/admin-table.directive.ts
+++ b/ui/main/src/app/modules/admin/components/table/admin-table.directive.ts
@@ -216,6 +216,11 @@ export abstract class AdminTableDirective implements OnInit, OnDestroy {
     return this.translateService.instant(this.i18NPrefix + headerIdentifier);
   }
 
+  onFilterChanged(event) {
+    this.page = 1;
+    this.gridApi.paginationGoToPage(0);
+  }
+
   onGridReady(params) {
     this.gridApi = params.api;
     // Column definitions can't be managed in the constructor like the other grid options because they rely on the `fields`


### PR DESCRIPTION
Release notes : 

In Bugs section : 

#2270 : Admin screen : Incoherence between pagination and displayed results after deleting a filter