### PR TITLE
With a screen size about 1024 x 600 the right side of the menus is not visible (#2449)

### DIFF
--- a/ui/main/src/app/modules/navbar/navbar.component.html
+++ b/ui/main/src/app/modules/navbar/navbar.component.html
@@ -51,7 +51,7 @@
       </li>
     </ul>
 
-    <ul class="navbar-nav navbar-right">
+    <ul class="navbar-nav navbar-right opfab-sticky-menu">
       <li id="opfab-newcard-menu" style="display:flex;margin-top: 12px;cursor:pointer;margin-right:20px" (click)="openCardCreation()" *ngIf="(displayCreateUserCard)">
         <span class="opfab-menu-icon-newcard"></span>
      </li>

--- a/ui/main/src/app/modules/navbar/navbar.component.scss
+++ b/ui/main/src/app/modules/navbar/navbar.component.scss
@@ -13,7 +13,7 @@
 .opfab-navbar {
     background-color: var(--opfab-bgcolor) ;
     font-size: 16px;
-
+    top: 5px;
 
     .navbar-nav {
       .nav-link {
@@ -215,3 +215,12 @@
 
 
 } 
+
+.opfab-sticky-menu {
+  position: absolute;
+  top: 3px;
+  right: 0;
+  padding-right: 30px;
+  padding-left: 15px;
+  background: var( --opfab-bgcolor);
+}


### PR DESCRIPTION
Fix #2449 

Release notes
In Bugs section:
#2449 : the right side of the menus is not visible when the screen size is about 1024 x 600

Signed-off-by: Giovanni Ferrari <giovanni.ferrari@soft.it>