### PR TITLE
Task usercard : field "minutesForReminder" overwritten by default value when editing the card (#2451)

### DIFF
--- a/src/test/resources/bundles/userCardExamples3/template/usercard_task.handlebars
+++ b/src/test/resources/bundles/userCardExamples3/template/usercard_task.handlebars
@@ -62,7 +62,7 @@
             <td style="width:32%">
                 <div class="opfab-input">
                     <label> MINUTES TO REMIND BEFORE TASK</label>
-                    <input size="2" maxlength="2" type="text" id="minutesForReminder" value="5">
+                    <input size="2" maxlength="2" type="text" id="minutesForReminder" value="{{#if card.data.minutesForReminder}}{{card.data.minutesForReminder}}{{else}}5{{/if}}">
                 </div>
             </td>
         </tr>
@@ -109,6 +109,7 @@
                 hours: hours,
                 minutes: minutes,
                 durationInMinutes: durationInMinutes,
+                minutesForReminder: minutesForReminder,
                 daysOfWeek: daysOfWeek
             }
         };


### PR DESCRIPTION
Fix #2451 

Release notes:
In Bugs section:
#2451 : Task usercard : field "minutesForReminder" overwritten by default value when editing the card 


Signed-off-by: Giovanni Ferrari <giovanni.ferrari@soft.it>