### PR TITLE
Correct bug when in usercard the first process has only one state 

### DIFF
--- a/ui/main/src/app/modules/usercard/selectStateForm/usercard-select-state-form.component.html
+++ b/ui/main/src/app/modules/usercard/selectStateForm/usercard-select-state-form.component.html
@@ -26,7 +26,7 @@
             </of-single-filter>
         </div>
 
-        <div class="col" *ngIf="!! stateOptions && stateOptions.length > 1">
+        <div class="col" [hidden]="!stateOptions || (stateOptions.length < 2)">
             <of-single-filter id="opfab-state-filter" i18nRootLabelKey="shared.filters." [parentForm]="selectStateForm"
                 filterPath="state" [values]="stateOptions" [sortValues]="true" [defaultValueSelected]=!cardIdToEdit>
             </of-single-filter>


### PR DESCRIPTION
In release note : 

-#2482 : Bug when in usercard the first process has only one state 