### PR TITLE
Monitoring screen : fix style problems  (#2450  #2455)

### DIFF
--- a/ui/main/src/app/modules/monitoring/components/monitoring-table/monitoring-table.component.html
+++ b/ui/main/src/app/modules/monitoring/components/monitoring-table/monitoring-table.component.html
@@ -1,4 +1,4 @@
-<!-- Copyright (c) 2018-2021, RTE (http://www.rte-france.com)              -->
+<!-- Copyright (c) 2018-2022, RTE (http://www.rte-france.com)              -->
 <!-- Copyright (c) 2020, RTEi (http://www.rte-international.com)           -->
 <!-- See AUTHORS.txt                                                       -->
 <!-- This Source Code Form is subject to the terms of the Mozilla Public   -->
@@ -8,7 +8,7 @@
 <!-- This file is part of the OperatorFabric project.                      -->
 
 
-<div id="opfab-monitoring-table" style="background-color: var(--opfab-bgcolor-darker);border: solid 5px var(--opfab-bgcolor-darker)">
+<div id="opfab-monitoring-table" style="background-color: var(--opfab-bgcolor-darker);border: solid 0px var(--opfab-bgcolor-darker)">
     <ag-grid-angular id="opfab-monitoring-table-grid" aria-describedby="Monitoring results table"
             (gridReady)="onGridReady($event)"
             [gridOptions]="gridOptions"

--- a/ui/main/src/app/modules/monitoring/monitoring.component.html
+++ b/ui/main/src/app/modules/monitoring/monitoring.component.html
@@ -1,4 +1,4 @@
-<!-- Copyright (c) 2018-2021, RTE (http://www.rte-france.com)              -->
+<!-- Copyright (c) 2018-2022, RTE (http://www.rte-france.com)              -->
 <!-- See AUTHORS.txt                                                       -->
 <!-- This Source Code Form is subject to the terms of the Mozilla Public   -->
 <!-- License, v. 2.0. If a copy of the MPL was not distributed with this   -->
@@ -28,7 +28,7 @@
 
      </div>
      <div  class="opfab-response-checkbox">
-        <label style="font-weight:bold; margin-left:5px" class="opfab-checkbox" translate>feed.filters.showCardsWithResponse.label
+        <label style="font-weight:bold; margin-left:5px; margin-bottom: 0px;" class="opfab-checkbox" translate>feed.filters.showCardsWithResponse.label
             <input type="checkbox" (click)="switchResponseFilter()" [checked]="responseFilterValue" id="opfab-archives-collapsible-updates">
             <span class="opfab-checkbox-checkmark"></span>
           </label>

--- a/ui/main/src/app/modules/monitoring/monitoring.component.scss
+++ b/ui/main/src/app/modules/monitoring/monitoring.component.scss
@@ -1,4 +1,4 @@
-/* Copyright (c) 2018-2021, RTE (http://www.rte-france.com)
+/* Copyright (c) 2018-2022, RTE (http://www.rte-france.com)
  * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -29,5 +29,5 @@
   border: solid 1px var(--opfab-bgcolor);
   text-align: center;
   background-color: var(--opfab-bgcolor);
-  color: #aaaaaa;
+  color: var(--opfab-text-color);
 }


### PR DESCRIPTION
Fix  #2450 
Fix #2455 

Monitoring screen : 
- "Card with response form my entity" should be darker color in day mode (#2450)
-  Problem with padding below "Cards with response... (#2455)

Release notes
In Bugs section:
#2450 : Monitoring screen - "Card with response form my entity" should be darker color in day mode
#2450 : Monitoring screen - Problem with padding below "Cards with response... 


Signed-off-by: Giovanni Ferrari <giovanni.ferrari@soft.it>