### PR TITLE
Bundles templates : problem of html encoding with handlebars (#2501)

### DIFF
--- a/src/test/cypress/cypress/integration/Monitoring.spec.js
+++ b/src/test/cypress/cypress/integration/Monitoring.spec.js
@@ -263,14 +263,16 @@ describe ('Monitoring screen tests',function () {
         cy.get('@monitoring-table').find('.ag-row').eq(1).find('.ag-cell').eq(4).should('have.text', 'Message received');
         cy.get('@monitoring-table').find('.ag-row').eq(2).find('.ag-cell').eq(4).should('have.text', 'Message received');
         cy.get('@monitoring-table').find('.ag-row').eq(3).find('.ag-cell').eq(4).should('have.text', 'Message received');
-        cy.get('@monitoring-table').find('.ag-row').eq(4).find('.ag-cell').eq(4).should('have.text', 'Message received');
+        cy.get('@monitoring-table').find('.ag-row').eq(4).find('.ag-cell').eq(4)
+            .should('have.text', 'Message received : France-England\'s interconnection is 100% operational / Result of the maintenance is <OK>');
         
         // Sorting summaries a second time
         cy.get('@monitoring-table-headers').find('.ag-header-cell').eq(4).click();
         cy.wait(500);
 
         // Cards should be sorted by summary
-        cy.get('@monitoring-table').find('.ag-row').eq(0).find('.ag-cell').eq(4).should('have.text', 'Message received');
+        cy.get('@monitoring-table').find('.ag-row').eq(0).find('.ag-cell').eq(4)
+            .should('have.text', 'Message received : France-England\'s interconnection is 100% operational / Result of the maintenance is <OK>');
         cy.get('@monitoring-table').find('.ag-row').eq(1).find('.ag-cell').eq(4).should('have.text', 'Message received');
         cy.get('@monitoring-table').find('.ag-row').eq(2).find('.ag-cell').eq(4).should('have.text', 'Message received');
         cy.get('@monitoring-table').find('.ag-row').eq(3).find('.ag-cell').eq(4).should('have.text', 'Message received');

--- a/src/test/cypress/cypress/integration/UserCard.spec.js
+++ b/src/test/cypress/cypress/integration/UserCard.spec.js
@@ -225,7 +225,7 @@ describe('User Card ', function () {
 
       cy.get('#opfab-navbarContent').find('#opfab-newcard-menu').click();
       cy.get("of-usercard").should('exist');
-      cy.get('#message').type('Hello');
+      cy.get('#message').type('Hello, that\'s a test message / Result is <OK> & work done is 100%');
       cy.setFormDateTime('startDate','2020','Jan',20,8,0);
       cy.setFormDateTime('endDate','2029','Jun',25,11,10);
       cy.get('#opfab-recipients').click();
@@ -243,7 +243,8 @@ describe('User Card ', function () {
         .then((urlId) => {
           cy.hash().should('eq', '#/feed/cards/' + urlId);
           cy.get('of-card-details').find('of-detail');
-          cy.get('#opfab-div-card-template').find('div').eq(0).contains('Hello');
+          cy.get('#opfab-div-card-template').find('div').eq(0).should('have.text', "\n  Hello, that's a test message / Result is <OK> & work done is 100%\n");
+          cy.get('#opfab-card-title').should('have.text', "Message -   Hello, that's a test message / Result is <OK> & work done is 100%");
         });
     })
 
@@ -261,7 +262,8 @@ describe('User Card ', function () {
         .then((urlId) => {
           cy.hash().should('eq', '#/feed/cards/' + urlId);
           cy.get('of-card-details').find('of-detail');
-          cy.get('#opfab-div-card-template').find('div').eq(0).contains('Hello');
+          cy.get('#opfab-div-card-template').find('div').eq(0).should('have.text', "\n  Hello, that's a test message / Result is <OK> & work done is 100%\n");
+          cy.get('#opfab-card-title').should('have.text', "Message -   Hello, that's a test message / Result is <OK> & work done is 100%");
         });
     })
   })
@@ -282,7 +284,7 @@ describe('User Card ', function () {
           cy.hash().should('eq', '#/feed/cards/' + urlId);
           cy.get('#opfab-card-edit').click();
           cy.get("of-usercard").should('exist');
-          cy.get('#message').should('be.visible').type(' World')
+          cy.get('#message').should('be.visible').type(' (updated)')
           cy.get('#opfab-usercard-btn-prepareCard').click();
           cy.get('#opfab-usercard-btn-accept').click();
           // Check that the message indicating successful sending appears
@@ -302,7 +304,8 @@ describe('User Card ', function () {
         .then((urlId) => {
           cy.hash().should('eq', '#/feed/cards/' + urlId);
           cy.get('of-card-details').find('of-detail');
-          cy.get('#opfab-div-card-template').find('div').eq(0).contains('Hello World');
+          cy.get('#opfab-div-card-template').find('div').eq(0).should('have.text', "\n   Hello, that's a test message / Result is <OK> & work done is 100%  (updated)\n");
+          cy.get('#opfab-card-title').should('have.text', "Message -    Hello, that's a test message / Result is <OK> & work done is 100%  (updated)");
         });
     })
   })
@@ -396,7 +399,8 @@ describe('User Card ', function () {
         .then((urlId) => {
           cy.hash().should('eq', '#/feed/cards/' + urlId);
           cy.get('of-card-details').find('of-detail');
-          cy.get('#opfab-div-card-template').find('div').eq(0).contains('Hello');
+          cy.get('#opfab-div-card-template').find('div').eq(0).should('have.text', '\n  Hello\n')
+          cy.get('#opfab-card-title').should('have.text', 'Message -   Hello')
         });
     })
 

--- a/src/test/resources/bundles/defaultProcess_V1/i18n.json
+++ b/src/test/resources/bundles/defaultProcess_V1/i18n.json
@@ -1,13 +1,18 @@
 {
 	"message":{
-		"title":"Message",
-		"summary":"Message received"
+		"title": "Message",
+		"summary": "Message received"
 	},
-	"chartDetail" : { "title":"A Chart"},
-	"chartLine" : { "title":"Electricity consumption forecast"},
+	"messageState":{
+		"title": "Message",
+		"summary": "Message received : {{{summary}}}",
+		"usercard": {"title": "Message - {{{title}}}"}
+	},
+	"chartDetail" : { "title": "A Chart"},
+	"chartLine" : { "title": "Electricity consumption forecast"},
 	"question" : {"title": "⚡ Planned Outage"},
-	"contingencies": {"title" : "⚠️ Network Contingencies ⚠️","summary":"Contingencies report for French network"},
+	"contingencies": {"title" : "⚠️ Network Contingencies ⚠️", "summary": "Contingencies report for French network"},
 	"processState": {
-		"title":"Process state ({{status}})"
+		"title": "Process state ({{status}})"
 	}
 }

--- a/src/test/resources/bundles/defaultProcess_V1/template/usercard_message.handlebars
+++ b/src/test/resources/bundles/defaultProcess_V1/template/usercard_message.handlebars
@@ -19,7 +19,7 @@
         const message = document.getElementById('message').value;
         const card = {
         summary : {key : "message.summary"},
-		title : {key : "message.title"},
+		title : {key : "messageState.usercard.title", parameters : {"title":message}},
         data : {message: message},
         entitiesAllowedToEdit: ['ENTITY_FR'],
         };

--- a/src/test/resources/cards/defaultProcess/message.json
+++ b/src/test/resources/cards/defaultProcess/message.json
@@ -13,9 +13,9 @@
 	"entitiesAllowedToEdit": ["ENTITY1_FR", "ENTITY2_FR"],
 	"startDate" : ${current_date_in_milliseconds_from_epoch_plus_2hours},
 	"endDate" : ${current_date_in_milliseconds_from_epoch_plus_8hours} ,
-	"summary" : {"key" : "message.summary"},
-	"title" : {"key" : "message.title"},
-	"data" : {"message":" Information card number 1"},
+	"summary" : {"key" : "messageState.summary", "parameters" : {"summary": "France-England's interconnection is 100% operational / Result of the maintenance is <OK>"}},
+	"title" : {"key" : "messageState.title"},
+	"data" : {"message": "France-England's interconnection is 100% operational / Result of the maintenance is <OK>"},
 	"timeSpans" : [
 		{"start" :${current_date_in_milliseconds_from_epoch_plus_2hours}},
 		{"start" : ${current_date_in_milliseconds_from_epoch_plus_8hours}}

--- a/ui/main/src/app/modules/cards/components/detail/detail.component.html
+++ b/ui/main/src/app/modules/cards/components/detail/detail.component.html
@@ -10,7 +10,7 @@
   <div style="display: block;  margin-top:10px;">
     <ul class="nav nav-tabs opfab-line-undertab">
       <li class="nav-item opfab-tab opfab-menu-item-left" data-toggle="tab">
-          <span class="opfab-tab text-uppercase" >{{card.titleTranslated}}</span>
+          <span class="opfab-tab text-uppercase" id="opfab-card-title">{{card.titleTranslated}}</span>
       </li>
       <li *ngIf="showButtons" class="nav-item opfab-menu-item-right">
         <div *ngIf="!isSmallscreen()" style="display:flex">


### PR DESCRIPTION
I propose to replace {{xxx}} by {{{xxx}}} in the bundles (i18n.json files) where we don't want handlebars to escape characters.

I propose to add nothing in release notes.