### PR TITLE
Logging screen : set max with on table columns (#2506)

### DIFF
--- a/ui/main/src/app/modules/logging/logging.component.scss
+++ b/ui/main/src/app/modules/logging/logging.component.scss
@@ -28,6 +28,17 @@
     padding-left: 5%;
   
   }
+
+  td {
+    max-width: 350px;
+    padding-left: 5px;
+    padding-right: 5px;
+  }
+
+  th {
+    padding-left: 5px;
+    padding-right: 5px;
+  }
  
  // ADAPT MARGINS TO SCREEN SIZE 
 
@@ -35,6 +46,7 @@
     .opfab-logging {
       padding-left : 2%;
     }
+
   } 
 
 


### PR DESCRIPTION
Fix #2506

Release notes:
In Bugs section:
#2506 : Logging screen : set max with on table columns 

Signed-off-by: Giovanni Ferrari <giovanni.ferrari@soft.it>