### PR TITLE
Entity labels : Add label with no need for the user to click enter (#2459)

### DIFF
--- a/ui/main/src/app/modules/admin/components/editmodal/entities/edit-entity-modal.component.html
+++ b/ui/main/src/app/modules/admin/components/editmodal/entities/edit-entity-modal.component.html
@@ -57,7 +57,7 @@
           </div>
           <div class="opfab-input row" style="height: auto;">
             <label for="opfab-labels" translate>admin.input.entity.labels</label>
-            <tag-input formControlName="labels" [theme]="'opfab-theme'" modelAsStrings="true" placeholder="{{labelsPlaceholder}}" secondaryPlaceholder="{{labelsPlaceholder}}" ></tag-input>
+            <tag-input formControlName="labels" [theme]="'opfab-theme'" modelAsStrings="true" addOnBlur="true" placeholder="{{labelsPlaceholder}}" secondaryPlaceholder="{{labelsPlaceholder}}" ></tag-input>
         </div>
         </div>
       </div>

--- a/ui/main/src/app/modules/admin/components/editmodal/entities/edit-entity-modal.component.ts
+++ b/ui/main/src/app/modules/admin/components/editmodal/entities/edit-entity-modal.component.ts
@@ -98,9 +98,12 @@ export class EditEntityModalComponent implements OnInit {
     // user chose to perform an action (here, update the selected item).
     // This is important as code in the corresponding table components relies on the resolution of the
     // `NgbModalRef.result` promise to trigger a refresh of the data shown on the table.
-    this.crudService.update(this.entityForm.value).subscribe(() => {
-      this.activeModal.close('Update button clicked on ' + this.type + ' modal');
-    });
+    // Wait 100ms to let labels <tag-component> update pending values
+    setTimeout(() => {
+      this.crudService.update(this.entityForm.value).subscribe(() => {
+        this.activeModal.close('Update button clicked on ' + this.type + ' modal');
+      });
+    }, 100);
   }
 
   private cleanForm() {


### PR DESCRIPTION
Fix #2459

Release notes
In Tasks section:
#2459 : Entity labels : Add label with no need for the user to click enter

Signed-off-by: Giovanni Ferrari <giovanni.ferrari@soft.it>