### PR TITLE
Monitoring: ag-grid filter is not localized (#2593)

### DIFF
--- a/ui/main/src/app/modules/monitoring/components/monitoring-table/monitoring-table.component.ts
+++ b/ui/main/src/app/modules/monitoring/components/monitoring-table/monitoring-table.component.ts
@@ -122,6 +122,11 @@ export class MonitoringTableComponent implements OnChanges, OnDestroy {
             defaultColDef : {
                 editable: false
             },
+            localeTextFunc : function (key) {
+                // To avoid clashing with opfab assets, all keys defined by ag-grid are prefixed with "ag-grid."
+                // e.g. key "to" defined by ag-grid for use with pagination can be found under "ag-grid.to" in assets
+                return translate.instant('ag-grid.' + key);
+            },
             columnTypes: {
                 'timeColumn': {
                     sortable: true,

--- a/ui/main/src/assets/i18n/en.json
+++ b/ui/main/src/assets/i18n/en.json
@@ -405,7 +405,9 @@
     "orCondition": "OR",
     "to": "to",
     "of": "of",
-    "page": "Page"
+    "page": "Page",
+    "blank": "Blank",
+    "notBlank": "Not blank"
   },
   "realTimeUsers": {
     "connected": "Connected",

--- a/ui/main/src/assets/i18n/fr.json
+++ b/ui/main/src/assets/i18n/fr.json
@@ -405,7 +405,9 @@
     "orCondition": "OU",
     "to": "à",
     "of": "de",
-    "page": "Page"
+    "page": "Page",
+    "blank": "Vide",
+    "notBlank": "Pas vide"
   },
   "realTimeUsers": {
     "connected": "Connecté",

--- a/ui/main/src/assets/i18n/nl.json
+++ b/ui/main/src/assets/i18n/nl.json
@@ -407,7 +407,9 @@
     "orCondition": "OF",
     "to": "tot",
     "of": "van",
-    "page": "Pagina"
+    "page": "Pagina",
+    "blank": "Leeg",
+    "notBlank": "Niet leeg"
   },
   "realTimeUsers": {
     "connected": "Verbonden",


### PR DESCRIPTION
Fix #2593 #2585 

Release notes
In Bugs section:
#2593 : Monitoring: ag-grid filter is not localized
#2585 : Missing agrid translation in filter column feature 


Signed-off-by: Giovanni Ferrari <giovanni.ferrari@soft.it>