### PR TITLE
Add entity name in templates example instead of entityId (#2573)

### DIFF
--- a/src/test/resources/bundles/userCardExamples2/template/confirmation.handlebars
+++ b/src/test/resources/bundles/userCardExamples2/template/confirmation.handlebars
@@ -42,7 +42,7 @@
             responses += ' </tr>';
 
             templateGateway.childCards.forEach((c, i) => {
-                responses += `<tr> <td> ${c.publisher} </td>`
+                responses += `<tr> <td> ${templateGateway.getEntityName(c.publisher)} </td>`
                 responses += `<td> ${c.data.confirm} </td>`;
                 responses += `<td> ${c.data.message} </td>`;
                 responses += "</tr>";

--- a/src/test/resources/bundles/userCardExamples2/template/question.handlebars
+++ b/src/test/resources/bundles/userCardExamples2/template/question.handlebars
@@ -32,7 +32,7 @@
             responses += ' </tr>';
 
             templateGateway.childCards.forEach((c, i) => {
-                responses += `<tr> <td> ${c.publisher} </td>`
+                responses += `<tr> <td> ${templateGateway.getEntityName(c.publisher)} </td>`
                 responses += `<td> ${c.data.response} </td>`;
                 responses += "</tr>";
             });


### PR DESCRIPTION
Release notes : 

In Tasks section : 

#2573 : Add entity name in templates example instead of entityId