### PR TITLE
Enable to set temporarily startDate after endDate during userCard creation (#2584)

### DIFF
--- a/ui/main/src/app/modules/usercard/datesForm/usercard-dates-form.component.html
+++ b/ui/main/src/app/modules/usercard/datesForm/usercard-dates-form.component.html
@@ -10,7 +10,7 @@
     <div class="justify-content-center" style="display:flex;width:100%;align-content:center;flex-wrap: wrap;">
         <div *ngIf="datesFormInputData.startDate.isVisible" style="width:280px; margin-right: 30px; margin-left: 30px;" id="opfab-usercard-startdate-choice">
             <of-datetime-filter  filterPath="startDate" formControlName="startDate"
-                labelKey="userCard.filters."  [maxDate]="startDateMax"
+                labelKey="userCard.filters." 
                 (change)="onDateTimeChange($event)">
             </of-datetime-filter>
         </div>

--- a/ui/main/src/app/modules/usercard/datesForm/usercard-dates-form.component.ts
+++ b/ui/main/src/app/modules/usercard/datesForm/usercard-dates-form.component.ts
@@ -30,7 +30,6 @@ export class UserCardDatesFormComponent implements OnInit, OnDestroy, OnChanges 
     unsubscribe$: Subject<void> = new Subject<void>();
 
     endDateMin: {year: number, month: number, day: number} = null;
-    startDateMax: {year: number, month: number, day: number} = null;
 
     dateTimeFilterChange = new Subject();
 
@@ -82,16 +81,8 @@ export class UserCardDatesFormComponent implements OnInit, OnDestroy, OnChanges 
                 };
             } else {
                 this.endDateMin = null;
-            }
-            if (this.datesFormInputData.endDate.isVisible) {
-                this.startDateMax = {
-                    year: this.datesForm.value.endDate.date.year,
-                    month: this.datesForm.value.endDate.date.month,
-                    day: this.datesForm.value.endDate.date.day
-                };
-            } else {
-                this.startDateMax = null;
-            }
+            }          
+            
         }
     }
 


### PR DESCRIPTION
Signed-off-by: olivierPigeon-RTE <olivier.pigeon@rte-france.com>

In release notes, task section : 
#2584 : Enable to set temporarily startDate after endDate during userCard creation