### PR TITLE
Fix card publishing path in nginx-cors-permissive.conf (#2140)

### DIFF
--- a/config/docker/nginx-cors-permissive.conf
+++ b/config/docker/nginx-cors-permissive.conf
@@ -160,7 +160,7 @@ server {
     proxy_pass http://cards-consultation:8080/;
     proxy_set_header X-Forwarded-For $remote_addr;
   }
-  location /cardspub/cards/ {
+  location /cardspub/cards {
     # enables `ng serve` mode
     if ($request_method = 'OPTIONS') {
       add_header 'Access-Control-Allow-Origin' '*';
@@ -174,7 +174,7 @@ server {
       return 204;
     }
     proxy_set_header Host $http_host;
-    proxy_pass http://cards-publication:8080/cards/;
+    proxy_pass http://cards-publication:8080/cards;
     proxy_set_header X-Forwarded-For $remote_addr;
   }
   location /archives {


### PR DESCRIPTION
Fix #2140 

Release notes
In Bugs section:

#2140 :  Fix card publishing path in nginx-cors-permissive.conf


Signed-off-by: Giovanni Ferrari <giovanni.ferrari@soft.it>