### PR TITLE
In day mode , number in timeline are not always fully visible (#2582)

### DIFF
--- a/ui/main/src/app/modules/feed/components/time-line/custom-timeline-chart/custom-timeline-chart.component.html
+++ b/ui/main/src/app/modules/feed/components/time-line/custom-timeline-chart/custom-timeline-chart.component.html
@@ -118,8 +118,8 @@
         <svg:g *ngFor="let circle of circles" type="button">
 
         <svg:g *ngIf="(circle.count>1)" (mouseenter)="feedCircleHovered(circle, p1)" container="body" #p1="ngbPopover"   [ngbPopover]="tooltipTemplate"    triggers="mouseenter:mouseleave" closeDelay="3000" popoverClass="opfab-popover">
-            <svg:circle [attr.cx]="xScale(circle.date)"
-                [attr.cy]="yScale(circle.circleYPosition)" [attr.r]="'10'" [attr.fill]=circle.color [attr.stroke]="'stroke'"
+            <svg:ellipse [attr.cx]="xScale(circle.date)"
+                [attr.cy]="yScale(circle.circleYPosition)" [attr.ry]="'10'" [attr.rx]="circle.width" [attr.fill]=circle.color [attr.stroke]="'stroke'"
                 />
             <text  [attr.x]="xScale(circle.date)"
                 [attr.y]="yScale(circle.circleYPosition)" text-anchor="middle"  stroke-width="0px"

--- a/ui/main/src/app/modules/feed/components/time-line/custom-timeline-chart/custom-timeline-chart.component.ts
+++ b/ui/main/src/app/modules/feed/components/time-line/custom-timeline-chart/custom-timeline-chart.component.ts
@@ -44,7 +44,6 @@ import {LightCardsFeedFilterService} from '@ofServices/lightcards/lightcards-fee
 import {FilterService} from '@ofServices/lightcards/filter.service';
 
 
-
 @Component({
   selector: 'of-custom-timeline-chart',
   templateUrl: './custom-timeline-chart.component.html',
@@ -418,6 +417,7 @@ export class CustomTimelineChartComponent extends BaseChartComponent implements 
               date: moment(this.xTicks[tickIndex - 1].valueOf()),
               dateOrPeriod: '',
               count: 0,
+              width: 10,
               color: this.getCircleColor(cards[cardIndex].severity),
               circleYPosition: cards[cardIndex].circleYPosition,
               summary: []
@@ -435,6 +435,8 @@ export class CustomTimelineChartComponent extends BaseChartComponent implements 
               });
               cardIndex++;
             }
+            circle.width = 10 + 2 * this.getEllipseWidth(circle.count);
+
 
             //  add the circle to the list of circles to display
             if (circle.start.valueOf() === circle.end.valueOf()) {
@@ -449,6 +451,10 @@ export class CustomTimelineChartComponent extends BaseChartComponent implements 
         }
       }
     }
+  }
+
+  getEllipseWidth(count: number) {
+    return Math.log(count) * Math.LOG10E | 0;
   }
 
   getCircleYPosition(severity: string): number {


### PR DESCRIPTION
Fix #2582 

Release notes
In Bugs section:
#2582 : In day mode , number in timeline are not always fully visible 


Signed-off-by: Giovanni Ferrari <giovanni.ferrari@soft.it>