### PR TITLE
Display disabled buttons in gray in pagination (#2591)

### DIFF
--- a/ui/main/src/app/services/global-style.service.ts
+++ b/ui/main/src/app/services/global-style.service.ts
@@ -77,6 +77,8 @@ export class GlobalStyleService {
                                         --opfab-scrollbar-bar-border-color: #979797;
                                         --opfab-scrollbar-bgcolor-firefox: #dddddd;
                                         --opfab-scrollbar-bar-bgcolor-firefox: #bbbbbb;
+                                        --opfab-pagination-active-page-background: #909090;
+                                        --opfab-pagination-disabled-link: #808080;
                                         }`;
 
     private static NIGHT_STYLE = `:root {
@@ -137,6 +139,8 @@ export class GlobalStyleService {
                                         --opfab-scrollbar-bar-border-color: #979797;
                                         --opfab-scrollbar-bgcolor-firefox: #131D2B;
                                         --opfab-scrollbar-bar-bgcolor-firefox: #333D4B;
+                                        --opfab-pagination-active-page-background: #bababa;
+                                        --opfab-pagination-disabled-link: #606060
                                     }`;
 
 

--- a/ui/main/src/scss/styles.scss
+++ b/ui/main/src/scss/styles.scss
@@ -719,24 +719,31 @@ type-ahead > .badge-primary {
 
 
 // Pagination component config 
-
 ngb-pagination {
-  .page-link,.page-item.disabled .page-link {
+  .page-link {
       background-color: var(--opfab-bgcolor-darker);
       color : var(--opfab-text-color-stronger);
       border : 0px;
     }
     .page-item.active .page-link{
-      background-color: white;
-      color : black;
-      border: 0px;
+      background-color: var(--opfab-pagination-active-page-background);
+      color : var(--opfab-bgcolor-darker);
+    }
+
+    .page-item :hover{
+      background-color: var(--opfab-button-disable-bgcolor);
+      color : var(--opfab-text-color-stronger);
     }
 
     .page-link:focus {
       box-shadow: none;
     }
-}
 
+  .page-item.disabled .page-link {
+    background-color: var(--opfab-bgcolor-darker);
+    color: var(--opfab-pagination-disabled-link);
+  }
+}
 
 .archives-page .form-control {
   border-radius: 5px;


### PR DESCRIPTION
Signed-off-by: olivierPigeon-RTE <olivier.pigeon@rte-france.com>

In release notes, tasks section : 
#2591 : Pagination links to previous/next pages are displayed in grey when there is no previous/next page