### PR TITLE
Ensure version consistence by relying entirely on Gradle wrapper (#1305)

### DIFF
--- a/bin/load_environment_light.sh
+++ b/bin/load_environment_light.sh
@@ -11,8 +11,6 @@
 
 source ${BASH_SOURCE%/*}/load_variables.sh
 
-sdk install gradle 7.3
-sdk use gradle 7.3
 sdk install java 11.0.14-zulu
 sdk use java 11.0.14-zulu
 nvm install v14.15

--- a/src/docs/asciidoc/dev_env/launch_dev.adoc
+++ b/src/docs/asciidoc/dev_env/launch_dev.adoc
@@ -14,7 +14,7 @@
 WARNING: The steps below assume that you have installed and are using
 https://sdkman.io/[sdkman] and
 https://github.com/nvm-sh/nvm[nvm] to manage tool versions ( for java,
-gradle, node and npm).
+ node and npm).
 
 There are several ways to get started with `OperatorFabric`. Please look into
 the section that best fits your needs.
@@ -36,7 +36,7 @@ git clone https://github.com/opfab/operatorfabric-core.git
 cd operatorfabric-core
 ----
 
-== Set up your environment (environment variables & appropriate versions of gradle, maven, etc…)
+== Set up your environment (environment variables & appropriate versions of tools)
 [source,shell]
 ----
 source bin/load_environment_light.sh
@@ -76,7 +76,7 @@ To export the reports into the `SonarQube` docker instance, install and use link
 `OperatorFabric` development needs docker images of `MongoDB`, `RabbitMQ`, `web-ui` and `Keycloak` running.
 The `web-ui` configuration needs a `nginx.conf`.
 
-The `${OF_HOME}/config/dev/$docker-compose.sh` creates the `nginx.conf` file and then runs `docker-compose` in detached mode.
+The `${OF_HOME}/config/dev/docker-compose.sh` creates the `nginx.conf` file and then runs `docker-compose` in detached mode.
 For this, use:
 [source,shell]
 ----

--- a/src/docs/asciidoc/dev_env/misc.adoc
+++ b/src/docs/asciidoc/dev_env/misc.adoc
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2021 RTE (http://www.rte-france.com)
+// Copyright (c) 2018-2022 RTE (http://www.rte-france.com)
 // See AUTHORS.txt
 // This document is subject to the terms of the Creative Commons Attribution 4.0 International license.
 // If a copy of the license was not distributed with this
@@ -9,8 +9,7 @@
 
 == Running sub-project from jar file
 
-* gradle :[sub-projectPath]:bootJar
-* or java -jar [sub-projectPath]/build/libs/[sub-project].jar
+*  java -jar [sub-projectPath]/build/libs/[sub-project].jar
 
 == Overriding properties when running from jar file
 

--- a/src/docs/asciidoc/dev_env/requirements.adoc
+++ b/src/docs/asciidoc/dev_env/requirements.adoc
@@ -19,12 +19,11 @@ below for details on:
 
 == Tools and libraries
 
-* Gradle 7 +
 * Java 11.0 +
 * Docker
 * Docker Compose with 2.1+ file format support
 * Chrome (needed for UI tests in build)
-* Angular CLI
+* Node 14.15 (Npm 6.14)
 * https://stedolan.github.io/jq/[jq]
 
 NOTE: the current Jdk used for the project is Java 11.0.14-zulu.
@@ -33,8 +32,8 @@ IMPORTANT: It is highly recommended to use https://sdkman.io/[sdkman] and
 https://github.com/nvm-sh/nvm[nvm] to manage tools versions. The following steps rely on these tools.
 
 Once you have installed sdkman and nvm, you can **source** the following
-script to set up your development environment (appropriate versions of Gradle,
-Java, Maven and project variables set):
+script to set up your development environment (appropriate versions of Node 
+Java and project variables set):
 
 .Set up development environment (using sdkman and nvm)
 [source]

--- a/src/docs/asciidoc/dev_env/scripts.adoc
+++ b/src/docs/asciidoc/dev_env/scripts.adoc
@@ -12,7 +12,7 @@
 
 [horizontal]
 bin/load_environment_light.sh:: sets up environment when *sourced* (java
-version, gradle version, maven version, node version)
+version & node version)
 bin/run_all.sh:: runs all all services (see below)
 bin/setup_dockerized_environment.sh:: generate docker images for all services
 

--- a/src/docs/asciidoc/dev_env/troubleshooting.adoc
+++ b/src/docs/asciidoc/dev_env/troubleshooting.adoc
@@ -54,7 +54,7 @@ Metaspace
 ----
 
 .Possible causes & resolution
-Issue with the Gradle daemon. Stopping the daemon using `gradle --stop`
+Issue with the Gradle daemon. Stopping the daemon using `./gradlew --stop`
 and re-launching the build should solve this issue.
 
 +++ </div></details> +++

--- a/src/test/api/karate/README.adoc
+++ b/src/test/api/karate/README.adoc
@@ -18,7 +18,7 @@ Run the following command lines form this folder.
 
 ### Run a feature
 ....
-gradle karate --args=myfeature.feature
+$OF_HOME/gradlew karate --args=myfeature.feature
 ....
 
 The result will be available in the `target` repository.


### PR DESCRIPTION
In release note : 

Tasks : 

#1305 Ensure version consistence by relying entirely on Gradle wrapper for building