### PR TITLE
Transfert method getSpecificCardInformation from templateGateway to usercardTemplateGateway

### DIFF
--- a/src/docs/asciidoc/reference_doc/user_cards.adoc
+++ b/src/docs/asciidoc/reference_doc/user_cards.adoc
@@ -56,7 +56,7 @@ This template works the same as templates for card presentation. Here is an exam
 
 
 <script>
-    templateGateway.getSpecificCardInformation = function () {
+    usercardTemplateGateway.getSpecificCardInformation = function () {
         const message = document.getElementById('message').value;
         const card = {
           summary : {key : "message.summary"},
@@ -172,13 +172,13 @@ In this example the list of available recipients will contain: "ENTITY_FR" (leve
 To do that , you have to :
 
 * hide the recipient dropdown using the attribute `recipientVisible` in state definition in config.json 
-* provide the list of recipients when returning the card object in templateGateway.getSpecificCardInformation() in the field entityRecipients 
+* provide the list of recipients when returning the card object in usercardTemplateGateway.getSpecificCardInformation() in the field entityRecipients 
 
 
 Example:
 ....
 
-    templateGateway.getSpecificCardInformation = function () {
+    usercardTemplateGateway.getSpecificCardInformation = function () {
         const message = document.getElementById('message').value;
         const card = {
           summary : {key : "message.summary"},
@@ -242,7 +242,7 @@ To enable the automated response the template should add a `childCard` field to 
 
 ....
  <script>
-    templateGateway.getSpecificCardInformation = function () {
+    usercardTemplateGateway.getSpecificCardInformation = function () {
         const card = {...}
 
         childCard : { 

--- a/src/docs/asciidoc/resources/migration_guide_to_3.6.adoc
+++ b/src/docs/asciidoc/resources/migration_guide_to_3.6.adoc
@@ -30,11 +30,17 @@ db.archivedCards.updateMany(
 
 == Deprecated feature 
 
-Using "recipientList" in state definition (in config.json) is now deprecated 
+
+===  Method templateGateway.getSpecificInformation() 
+  
+Implementation of method templateGateway.getSpecificInformation() in usercard templates is now deprecated, replace it by usercardTemplateGateway.getSpecificInformation(). It is just a naming change, the behavior is the same.
+
 
 === Restrict recipient dropdown list for user 
 
-If you use  "recipientList" to restrict the list of recipient shown to user, replace it with code in template as in the following example : 
+Using "recipientList" in state definition (in config.json) is now deprecated 
+
+If you use  "recipientList" to restrict the list of recipients shown to user, replace it with code in template as in the following example : 
 
 ....
     usercardTemplateGateway.setDropdownEntityRecipientList([
@@ -45,14 +51,16 @@ If you use  "recipientList" to restrict the list of recipient shown to user, rep
 
 === Set the list of recipients  
 
-If you use  "recipientList" to set the list of recipient , provide now the list of recipients when returning the card object in templateGateway.getSpecificCardInformation() in the field entityRecipients.
+Using "recipientList" in state definition (in config.json) is now deprecated 
+
+If you use  "recipientList" to set the list of recipients, provide now the list of recipients when returning the card object in usercardTemplateGateway.getSpecificCardInformation() in the field entityRecipients.
 
 
 
 Example:
 ....
 
-    templateGateway.getSpecificCardInformation = function () {
+    usercardTemplateGateway.getSpecificCardInformation = function () {
         const message = document.getElementById('message').value;
         const card = {
           summary : {key : "message.summary"},

--- a/src/test/resources/bundles/defaultProcess_V1/template/usercard_message.handlebars
+++ b/src/test/resources/bundles/defaultProcess_V1/template/usercard_message.handlebars
@@ -38,6 +38,9 @@
     document.getElementById("hidden_process").value = usercardTemplateGateway.getCurrentProcess();
     document.getElementById("hidden_state").value = usercardTemplateGateway.getCurrentState();
 
+    // we keep here the deprecated templateGateway.getSpecificInformation (instead of usercardTemplateGateway.getSpecificInformation)
+    // to have the deprecated feature still covered by cypress tests
+    // DO NOT USE AS EXAMPLE 
     templateGateway.getSpecificCardInformation = function () {
         const message = document.getElementById('message').value;
         let summaryParameter = message.slice(0, 100);

--- a/src/test/resources/bundles/defaultProcess_V1/template/usercard_process.handlebars
+++ b/src/test/resources/bundles/defaultProcess_V1/template/usercard_process.handlebars
@@ -40,7 +40,7 @@
     selectedProcessStatus = "{{card.data.status}}";
     if (selectedProcessStatus.length >0) document.getElementById('status').value = selectedProcessStatus;
 
-    templateGateway.getSpecificCardInformation = function () {
+    usercardTemplateGateway.getSpecificCardInformation = function () {
         const state = document.getElementById('state').value;
         const status = document.getElementById('status').value;
         const card = {

--- a/src/test/resources/bundles/userCardExamples/template/usercard_conference.handlebars
+++ b/src/test/resources/bundles/userCardExamples/template/usercard_conference.handlebars
@@ -68,7 +68,7 @@
     document.getElementById("hidden_process").value = usercardTemplateGateway.getCurrentProcess();
     document.getElementById("hidden_state").value = usercardTemplateGateway.getCurrentState();
 
-    templateGateway.getSpecificCardInformation = function () {
+    usercardTemplateGateway.getSpecificCardInformation = function () {
         const message = document.getElementById('message').value;
         const conf_subject = document.getElementById('conf_subject').value;
         const conf_link = document.getElementById('conf_link').value;

--- a/src/test/resources/bundles/userCardExamples/template/usercard_incidentInProgress.handlebars
+++ b/src/test/resources/bundles/userCardExamples/template/usercard_incidentInProgress.handlebars
@@ -58,7 +58,7 @@
     document.getElementById("hidden_process").value = usercardTemplateGateway.getCurrentProcess();
     document.getElementById("hidden_state").value = usercardTemplateGateway.getCurrentState();
 
-    templateGateway.getSpecificCardInformation = function () {
+    usercardTemplateGateway.getSpecificCardInformation = function () {
         const message = document.getElementById('message').value;
         const SA = document.getElementById('SA').checked;
         const SB = document.getElementById('SB').checked;

--- a/src/test/resources/bundles/userCardExamples2/template/usercard_confirmation.handlebars
+++ b/src/test/resources/bundles/userCardExamples2/template/usercard_confirmation.handlebars
@@ -40,7 +40,7 @@
         document.getElementById('message').value=usercardTemplateGateway.getUserEntityChildCardFromCurrentCard().data.message;
     }
 
-    templateGateway.getSpecificCardInformation = function () {
+    usercardTemplateGateway.getSpecificCardInformation = function () {
         const question = document.getElementById('question').value;
         if (question.length <1) return {
             valid: false,

--- a/src/test/resources/bundles/userCardExamples2/template/usercard_message.handlebars
+++ b/src/test/resources/bundles/userCardExamples2/template/usercard_message.handlebars
@@ -16,7 +16,7 @@
 
 
 <script>
-    templateGateway.getSpecificCardInformation = function () {
+    usercardTemplateGateway.getSpecificCardInformation = function () {
         const message = document.getElementById('message').value;
         const card = {
         summary : {key : "message.summary"},

--- a/src/test/resources/bundles/userCardExamples2/template/usercard_question.handlebars
+++ b/src/test/resources/bundles/userCardExamples2/template/usercard_question.handlebars
@@ -29,7 +29,7 @@
     usercardTemplateGateway.setInitialLttd(mystartDate.getTime() + 4 * 3600000);
 
 
-    templateGateway.getSpecificCardInformation = function () {
+    usercardTemplateGateway.getSpecificCardInformation = function () {
         const question = document.getElementById('question').value;
 
         if (question.length <1) return {

--- a/src/test/resources/bundles/userCardExamples3/template/usercard_task.handlebars
+++ b/src/test/resources/bundles/userCardExamples3/template/usercard_task.handlebars
@@ -74,7 +74,7 @@
 
 
 <script>
-    templateGateway.getSpecificCardInformation = function () {
+    usercardTemplateGateway.getSpecificCardInformation = function () {
         const taskDescription = document.getElementById('taskDescription').value;
         
         const time = document.getElementById('time').value;

--- a/ui/main/src/app/modules/usercard/usercard.component.ts
+++ b/ui/main/src/app/modules/usercard/usercard.component.ts
@@ -265,7 +265,9 @@ export class UserCardComponent implements OnInit {
             const templateName = this.userCardConfiguration.template;
             usercardTemplateGateway.setEntityUsedForSendingCard = (entity) => {
                 // default method if not override by template
-            };  
+            };
+            templateGateway.getSpecificCardInformation = null;
+            usercardTemplateGateway.getSpecificCardInformation = null;
 
             this.handlebars.queryTemplate(this.selectedProcessId, selected.version, templateName)
                 .pipe(map(t => t(new DetailContext(card, null, null))))
@@ -302,8 +304,9 @@ export class UserCardComponent implements OnInit {
     }
 
     public prepareCard() {
+        this.dealWithDeprecatedUseOfTemplateGateway();
         if (!this.isSpecificInformationValid()) return;
-        this.specificInformation = templateGateway.getSpecificCardInformation();
+        this.specificInformation = usercardTemplateGateway.getSpecificCardInformation();
         const startDate = this.getStartDate();
         const endDate = this.getEndDate();
         const lttd = this.getLttd();
@@ -366,16 +369,25 @@ export class UserCardComponent implements OnInit {
             });
     }
 
+    private dealWithDeprecatedUseOfTemplateGateway(): void {
+        if (!usercardTemplateGateway.getSpecificCardInformation && templateGateway.getSpecificCardInformation) {
+            this.opfabLogger.info('Use of templateGateway.getSpecificCardInformation() is deprecated , use usercardTemplateGateway.getSpecificCardInformation instead');
+            usercardTemplateGateway.getSpecificCardInformation = templateGateway.getSpecificCardInformation;
+        }
+
+    }
+
     private isSpecificInformationValid(): boolean {
-        if (!templateGateway.getSpecificCardInformation) {
-            this.opfabLogger.error('ERROR : No getSpecificCardInformationMethod() in template, card cannot be send');
+
+        if (!usercardTemplateGateway.getSpecificCardInformation) {
+            this.opfabLogger.error('ERROR : No usercardTemplateGateway.getSpecificCardInformationMethod() in template, card cannot be send');
             this.displayMessage('userCard.error.templateError', null, MessageLevel.ERROR);
             return false;
         }
 
-        const specificInformation = templateGateway.getSpecificCardInformation();
+        const specificInformation = usercardTemplateGateway.getSpecificCardInformation();
         if (!specificInformation) {
-            this.opfabLogger.error('ERROR : getSpecificCardInformationMethod() in template return no information, card cannot be send');
+            this.opfabLogger.error('ERROR : usercardTemplateGateway.getSpecificCardInformationMethod() in template return no information, card cannot be send');
             this.displayMessage('userCard.error.templateError', null, MessageLevel.ERROR);
             return false;
         }
@@ -386,7 +398,7 @@ export class UserCardComponent implements OnInit {
         }
 
         if (!specificInformation.card) {
-            this.opfabLogger.error('ERROR : getSpecificCardInformationMethod() in template return specificInformation with no card field, card cannot be send');
+            this.opfabLogger.error('ERROR : usercardTemplateGateway.getSpecificCardInformationMethod() in template return specificInformation with no card field, card cannot be send');
             this.displayMessage('userCard.error.templateError', null, MessageLevel.ERROR);
             return false;
         }


### PR DESCRIPTION
Release note: 

In tasks : 

Transfert method getSpecificCardInformation from templateGateway to usercardTemplateGateway ( use of templateGateway.getSpecificCardInformation is now deprecated)