### PR TITLE
Archives/Logging screens : reset should disable timepicker arrows (#2710)

### DIFF
--- a/ui/main/src/app/modules/share/datetime-filter/datetime-filter.component.ts
+++ b/ui/main/src/app/modules/share/datetime-filter/datetime-filter.component.ts
@@ -111,14 +111,14 @@ export class DatetimeFilterComponent implements ControlValueAccessor,OnInit, OnD
 
     // Method call when archive-filter.component.ts set value to null
     writeValue(val: any): void {
- 
         this.disabled = true;
-
-        if (!!val) {
+        if (!val) {
+            this.resetDateAndTime();
+        }
+        else if (!!val.date) {
             this.disabled = false;
             this.datetimeForm.setValue(val, {emitEvent: false});
         }
-        else this.resetDateAndTime();
     }
 
     registerOnChange(fn: any): void {


### PR DESCRIPTION
Fix #2710 

Signed-off-by: Giovanni Ferrari <giovanni.ferrari@soft.it>

- In release note :
  -  In chapter :  Bugs 
  -  Text : #2710 : Archives/Logging screens: reset should disable timepicker arrows 