### PR TITLE
Update of resources/index.adoc to include migration guide to 3.6 + update documentation for release process (#2830)

### DIFF
--- a/src/docs/asciidoc/CICD/release_process.adoc
+++ b/src/docs/asciidoc/CICD/release_process.adoc
@@ -45,7 +45,8 @@ explanations if need be.
 
 . Based on the content of this version and the rules listed above, make sure that the version number is appropriate.
 
-. Check if there is a migration guide for this version, if so include a link to it at the top of the release notes.
+. Check if there is a migration guide for this version, if so, check if the corresponding file has been included in
+src/docs/asciidoc/resources/index.adoc and include a link to it at the top of the release notes.
 
 === Creating a release branch and preparing the release
 

--- a/src/docs/asciidoc/resources/index.adoc
+++ b/src/docs/asciidoc/resources/index.adoc
@@ -39,3 +39,5 @@ include::migration_guide_to_3.1.adoc[leveloffset=+1]
 include::migration_guide_to_3.2.adoc[leveloffset=+1]
 
 include::migration_guide_to_3.5.adoc[leveloffset=+1]
+
+include::migration_guide_to_3.6.adoc[leveloffset=+1]


### PR DESCRIPTION
I propose to add nothing in release notes.