### PR TITLE
Add box around the acknowledged footer of the card in day mode (#2808)

### DIFF
--- a/ui/main/src/app/modules/cards/components/detail/detail.component.scss
+++ b/ui/main/src/app/modules/cards/components/detail/detail.component.scss
@@ -26,6 +26,7 @@
 
 .opfab-card-response-header {
   background-color: var(--opfab-card-bgcolor);
+  box-shadow: var(--opfab-card-shadow);
   margin-bottom: 5px; 
 }
 


### PR DESCRIPTION
Signed-off-by: olivierPigeon-RTE <olivier.pigeon@rte-france.com>

- In release note :
  -  In chapter :  Bugs
  -  Text : #2808 Add box around the acknowledged footer of the card in day mode