### PR TITLE
External devices configuration screen : single-filters are no longer aligned #2822

### DIFF
--- a/ui/main/src/app/modules/externaldevicesconfiguration/editModal/externaldevicesconfiguration-modal.component.html
+++ b/ui/main/src/app/modules/externaldevicesconfiguration/editModal/externaldevicesconfiguration-modal.component.html
@@ -23,7 +23,7 @@
       <div class="container">
         <div class="col">
 
-          <div *ngIf="row" class="opfab-input row">
+          <div *ngIf="row" class="opfab-input" style="margin-bottom: 15px;">
             <label for="opfab-userLogin" translate>externalDevicesConfiguration.userLogin</label>
             <input type="text" disabled value="{{row.userLogin}}"/>
           </div>


### PR DESCRIPTION

- In release note :
  -  In chapter :  Bugs 
  -  Text : #2822 External devices configuration screen : single-filters are no longer aligned