### PR TITLE
Remove useless checks before setting card attributes in ExternalAppServiceImpl.java (#2845)

### DIFF
--- a/src/test/externalApp/src/main/java/org/opfab/externalapp/service/ExternalAppServiceImpl.java
+++ b/src/test/externalApp/src/main/java/org/opfab/externalapp/service/ExternalAppServiceImpl.java
@@ -73,14 +73,8 @@ public class ExternalAppServiceImpl implements ExternalAppService {
 		card.setSeverity(SeverityEnum.INFORMATION);
 		card.setStartDate(Instant.now());
 
-		if (!groupRecipients.isEmpty()) {
-			card.setGroupRecipients(groupRecipients);
-		}
-
-		if (!entitiesRecipients.isEmpty()) {
-			card.setEntityRecipients(entitiesRecipients);
-		}
-
+		card.setGroupRecipients(groupRecipients);
+		card.setEntityRecipients(entitiesRecipients);
 
 		I18n summary = new I18n();
 		summary.setKey("message.summary");


### PR DESCRIPTION
Signed-off-by: olivierPigeon-RTE <olivier.pigeon@rte-france.com>

Nothing to add in release notes, the bug was already corrected