### PR TITLE
Ag-grid: replace deprecated property localeTextFunc (#3054)

### DIFF
--- a/ui/main/src/app/modules/admin/components/table/admin-table.directive.ts
+++ b/ui/main/src/app/modules/admin/components/table/admin-table.directive.ts
@@ -171,10 +171,10 @@ export abstract class AdminTableDirective implements OnInit, OnDestroy {
           flex: 4,
         }
       },
-      localeTextFunc : function (key) {
+      getLocaleText : function (params) {
         // To avoid clashing with opfab assets, all keys defined by ag-grid are prefixed with "ag-grid."
         // e.g. key "to" defined by ag-grid for use with pagination can be found under "ag-grid.to" in assets
-        return translateService.instant('ag-grid.' + key);
+        return translateService.instant('ag-grid.' + params.key);
         // Not this.translateService otherwise "undefined" error
       },
       pagination : true,

--- a/ui/main/src/app/modules/externaldevicesconfiguration/externaldevicesconfiguration.component.ts
+++ b/ui/main/src/app/modules/externaldevicesconfiguration/externaldevicesconfiguration.component.ts
@@ -81,10 +81,10 @@ export class ExternaldevicesconfigurationComponent {
           cellRenderer: 'actionCellRenderer',
         },
       },
-      localeTextFunc : function (key) {
+      getLocaleText : function (params) {
         // To avoid clashing with opfab assets, all keys defined by ag-grid are prefixed with "ag-grid."
         // e.g. key "to" defined by ag-grid for use with pagination can be found under "ag-grid.to" in assets
-        return translateService.instant('ag-grid.' + key);
+        return translateService.instant('ag-grid.' + params.key);
         // Not this.translateService otherwise "undefined" error
       },
       popupParent: document.querySelector('body')

--- a/ui/main/src/app/modules/monitoring/components/monitoring-table/monitoring-table.component.ts
+++ b/ui/main/src/app/modules/monitoring/components/monitoring-table/monitoring-table.component.ts
@@ -122,10 +122,10 @@ export class MonitoringTableComponent implements OnChanges, OnDestroy {
             defaultColDef : {
                 editable: false
             },
-            localeTextFunc : function (key) {
+            getLocaleText : function (params) {
                 // To avoid clashing with opfab assets, all keys defined by ag-grid are prefixed with "ag-grid."
                 // e.g. key "to" defined by ag-grid for use with pagination can be found under "ag-grid.to" in assets
-                return translate.instant('ag-grid.' + key);
+                return translate.instant('ag-grid.' + params.key);
             },
             columnTypes: {
                 'timeColumn': {


### PR DESCRIPTION
Fix #3054

Signed-off-by: Giovanni Ferrari <giovanni.ferrari@soft.it>

- In release note :
  -  In chapter :  Tasks
  -  Text : #3054 : Ag-grid: replace deprecated property localeTextFunc