### PR TITLE
Remove 'You are not allowed to send cards'  text when editing cards with slow network (#2995)

### DIFF
--- a/ui/main/src/app/modules/usercard/usercard.component.html
+++ b/ui/main/src/app/modules/usercard/usercard.component.html
@@ -120,11 +120,25 @@
     </div>
 </div>
 
-<ng-container *ngIf="!displayForm()">
+<ng-container *ngIf="!displayForm() && !pageLoading">
     <div class="alert alert-info">
         <h1><label translate>userCard.error.notAvailable</label></h1>
     </div>
 </ng-container>
+
+
+<ng-container *ngIf="pageLoading">
+    <div class="opfab-card-loading-spinner">
+        <em  class="fas fa-spinner fa-spin opfab-slow-spinner" ></em>
+        </div>
+        <div style="text-align: center;font:16px;font-weight: bold;margin-top:10px" translate>
+            feed.cardLoadingInProgress
+    </div>
+    <br/>
+    <br/>
+</ng-container>
+
+
 
 
 


### PR DESCRIPTION
Signed-off-by: olivierPigeon-RTE <olivier.pigeon@rte-france.com>

- In release note :
  -  In chapter :  Bug
  -  Text : #2995 Remove 'You are not allowed to send cards'  text when editing cards with slow network