### PR TITLE
Sort alphabetically state rights in perimeter administration table (#3105)

### DIFF
--- a/ui/main/src/app/modules/admin/admin.module.ts
+++ b/ui/main/src/app/modules/admin/admin.module.ts
@@ -24,6 +24,7 @@ import {ArrayCellRendererComponent} from './components/cell-renderers/array-cell
 import {ActionCellRendererComponent} from './components/cell-renderers/action-cell-renderer.component';
 import {GroupCellRendererComponent} from './components/cell-renderers/group-cell-renderer.component';
 import {EntityCellRendererComponent} from './components/cell-renderers/entity-cell-renderer.component';
+import {PerimetersCellRendererComponent} from './components/cell-renderers/perimeters-cell-renderer.component';
 import {SharingService} from './services/sharing.service';
 import {PerimetersTableComponent} from './components/table/perimeters-table.component';
 import {StateRightsCellRendererComponent} from './components/cell-renderers/state-rights-cell-renderer.component';
@@ -52,6 +53,7 @@ import {MultiSelectModule} from '../share/multi-select/multi-select.module';
         ArrayCellRendererComponent,
         GroupCellRendererComponent,
         EntityCellRendererComponent,
+        PerimetersCellRendererComponent,
         ProcessCellRendererComponent,
         StateRightsCellRendererComponent
     ],
@@ -71,6 +73,7 @@ import {MultiSelectModule} from '../share/multi-select/multi-select.module';
                 ArrayCellRendererComponent,
                 GroupCellRendererComponent,
                 EntityCellRendererComponent,
+                PerimetersCellRendererComponent,
                 ProcessCellRendererComponent,
                 StateRightsCellRendererComponent
             ]

--- a/ui/main/src/app/modules/admin/components/cell-renderers/array-cell-renderer.component.ts
+++ b/ui/main/src/app/modules/admin/components/cell-renderers/array-cell-renderer.component.ts
@@ -37,7 +37,7 @@ export class ArrayCellRendererComponent implements ICellRendererAngularComp {
                 .getValue()
                 .map((code) => {
                     // This entails that the items that need to be rendered have an `id` and a `name` property.
-                    // I tried defining an interface to enforce that but it made the code very cumbersome so it didn't look worth the effort
+                    // I tried defining an interface to enforce that, but it made the code very cumbersome, so it didn't look worth the effort
                     // for now.
                     const lookedUpName = this.mapping
                         .filter((cachedItem) => code === cachedItem['id'])
@@ -48,6 +48,7 @@ export class ArrayCellRendererComponent implements ICellRendererAngularComp {
                         return code;
                     }
                 })
+                .sort()
                 .join(', ');
         } else {
             console.log('Admin table: id/name mapping was undefined for ' + this.itemType);

--- a/ui/main/src/app/modules/admin/components/cell-renderers/perimeters-cell-renderer.component.ts
+++ b/ui/main/src/app/modules/admin/components/cell-renderers/perimeters-cell-renderer.component.ts
@@ -1,0 +1,28 @@
+/* Copyright (c) 2022, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
+ */
+
+import {Component} from '@angular/core';
+import {ArrayCellRendererComponent} from './array-cell-renderer.component';
+import {AdminItemType} from '../../services/sharing.service';
+
+@Component({
+    selector: 'of-perimeters-cell-renderer',
+    templateUrl: './array-cell-renderer.component.html'
+})
+export class PerimetersCellRendererComponent extends ArrayCellRendererComponent {
+    /** Defining components extending ArrayCellComponent proved necessary rather than using generics or passing the type as a
+     * constructor parameter because ag-grid only accepts non-generic class names in column definitions.
+     * */
+
+    itemType = AdminItemType.PERIMETER;
+
+    agInit(params: any): void {
+        super.agInit(params);
+    }
+}

--- a/ui/main/src/app/modules/admin/components/cell-renderers/state-rights-cell-renderer.component.ts
+++ b/ui/main/src/app/modules/admin/components/cell-renderers/state-rights-cell-renderer.component.ts
@@ -13,6 +13,7 @@ import {ICellRendererParams} from 'ag-grid-community';
 import {StateRight} from '@ofModel/perimeter.model';
 import {Process} from '@ofModel/processes.model';
 import {ProcessesService} from '@ofServices/processes.service';
+import {Utilities} from '../../../../common/utilities';
 
 @Component({
     selector: 'of-state-rights-cell-renderer',
@@ -52,6 +53,7 @@ export class StateRightsCellRendererComponent implements ICellRendererAngularCom
                             ' does not exist anymore'
                     );
             });
+            this._stateRightsValues.sort((a, b) => Utilities.compareObj(a.stateName, b.stateName));
         } else console.log(new Date().toISOString(), 'The process ' + params.data.process + ' does not exist anymore');
     }
 

--- a/ui/main/src/app/modules/admin/components/table/admin-table.directive.ts
+++ b/ui/main/src/app/modules/admin/components/table/admin-table.directive.ts
@@ -28,6 +28,7 @@ import {GroupsService} from '@ofServices/groups.service';
 import {Group} from '@ofModel/group.model';
 import {Entity} from '@ofModel/entity.model';
 import {EntitiesService} from '@ofServices/entities.service';
+import {PerimetersCellRendererComponent} from '../cell-renderers/perimeters-cell-renderer.component';
 
 @Directive()
 @Injectable()
@@ -50,6 +51,7 @@ export abstract class AdminTableDirective implements OnInit, OnDestroy {
                 actionCellRenderer: ActionCellRendererComponent,
                 groupCellRenderer: GroupCellRendererComponent,
                 entityCellRenderer: EntityCellRendererComponent,
+                perimetersCellRenderer: PerimetersCellRendererComponent,
                 stateRightsCellRenderer: StateRightsCellRendererComponent
             },
             domLayout: 'autoHeight',
@@ -334,7 +336,7 @@ export abstract class AdminTableDirective implements OnInit, OnDestroy {
     }
 
     openActionModal(params) {
-        // This method might be flagged as "unused" by IDEs but it's actually called through the ActionCellRendererComponent
+        // This method might be flagged as "unused" by IDEs, but it's actually called through the ActionCellRendererComponent
         const columnId = params.colDef.colId;
         if (columnId === 'edit') {
             const modalRef = this.modalService.open(this.editModalComponent, this.modalOptions);

--- a/ui/main/src/app/modules/admin/components/table/groups-table.component.ts
+++ b/ui/main/src/app/modules/admin/components/table/groups-table.component.ts
@@ -23,7 +23,7 @@ export class GroupsTableComponent extends AdminTableDirective implements OnInit 
         new Field('id', 3),
         new Field('name', 3),
         new Field('description', 4),
-        new Field('perimeters', 6),
+        new Field('perimeters', 6, 'perimetersCellRenderer'),
         new Field('realtime', 4, null, this.translateValue)
     ];
     idField = 'id';


### PR DESCRIPTION
I've also sorted alphabetically the columns "groups" and "entities" (in users management), and "perimeters" column (in groups management).

- In release note :
  -  In chapter :  Features
  -  Text : #3105 : Sort alphabetically state rights in perimeter administration table