### PR TITLE
Force logins to be stored with lowercase letters when it comes from an init file (#2958)

### DIFF
--- a/services/users/src/main/java/org/opfab/users/configuration/DataInitComponent.java
+++ b/services/users/src/main/java/org/opfab/users/configuration/DataInitComponent.java
@@ -87,6 +87,7 @@ public class DataInitComponent {
      */
     private void safeInsertUserSettings(UserSettingsData u) {
         try {
+            u.setLogin(u.getLogin().toLowerCase());
             userSettingsRepository.insert(u);
         } catch (DuplicateKeyException ex) {
             log.warn("{} {} user settings: duplicate",FAILED_INIT_MSG, u.getLogin() );
@@ -102,6 +103,7 @@ public class DataInitComponent {
      */
     private void safeInsertUsers(UserData u) {
         try {
+            u.setLogin(u.getLogin().toLowerCase());
             userRepository.insert(u);
         } catch (DuplicateKeyException ex) {
             log.warn("{} {} user: duplicate", FAILED_INIT_MSG, u.getLogin());


### PR DESCRIPTION
I renamed the issue "Force logins to be stored with lowercase letters when it comes from an init file" because when a user is created via the admin interface, uppercase letters are already forbidden.
So the only way to have logins with uppercase letters in database is if the users come from an init file (or a properties file). 

- In release note :
  -  In chapter : Bugs
  -  Text : #2958 : Force logins to be stored with lowercase letters when it comes from an init file 