### PR TITLE
Archives/logging screens : set color gray for the cards (like monitoring) (#3168)

### DIFF
--- a/ui/main/src/scss/styles.scss
+++ b/ui/main/src/scss/styles.scss
@@ -633,7 +633,7 @@ type-ahead > .badge-primary {
     }
     tr {
         height: 42px;
-        color: var(--opfab-text-color-stronger);
+        color: var(--opfab-text-color);
     }
 
     tr:nth-child(even) {


### PR DESCRIPTION
- In release note :
  -  In chapter : Bugs
  -  Text : #3168 : Archives/logging screens : set color gray for the cards (like monitoring) 