### PR TITLE
Monitoring screen : "Export data" button displayed too in the bottom of the page (#3165)

### DIFF
--- a/ui/main/src/app/modules/monitoring/components/monitoring-table/monitoring-table.component.html
+++ b/ui/main/src/app/modules/monitoring/components/monitoring-table/monitoring-table.component.html
@@ -18,7 +18,7 @@
     </ag-grid-angular>
 
 
-    <div *ngIf="gridApi" class="opfab-pagination">
+    <div *ngIf="gridApi" class="opfab-pagination" style="padding-bottom: 5px">
         <div style="white-space: nowrap;margin-top:17px">
         <span translate> shared.resultsNumber </span> : {{gridApi.paginationGetRowCount()}}
         </div>


### PR DESCRIPTION
- In release note :
  -  In chapter : Bugs
  -  Text : #3165 :  Monitoring screen : "Export data" button displayed too in the bottom of the page 