### PR TITLE
Add administration endpoint for sending messages on subscription (#3128)

### DIFF
--- a/services/cards-consultation/src/main/java/org/opfab/cards/consultation/configuration/webflux/MessageToSubscriptionsRoutesConfig.java
+++ b/services/cards-consultation/src/main/java/org/opfab/cards/consultation/configuration/webflux/MessageToSubscriptionsRoutesConfig.java
@@ -1,0 +1,50 @@
+/* Copyright (c) 2022, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
+ */
+
+
+package org.opfab.cards.consultation.configuration.webflux;
+
+import lombok.extern.slf4j.Slf4j;
+import org.opfab.cards.consultation.controllers.CardOperationsController;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.MediaType;
+import org.springframework.web.reactive.function.server.*;
+import reactor.core.publisher.Mono;
+
+import static org.springframework.web.reactive.function.server.ServerResponse.ok;
+
+@Slf4j
+@Configuration
+public class MessageToSubscriptionsRoutesConfig {
+
+    private final CardOperationsController cardOperationsController;
+
+    @Autowired
+    public MessageToSubscriptionsRoutesConfig(CardOperationsController cardOperationsController){
+        this.cardOperationsController = cardOperationsController;
+    }
+
+    @Bean
+    public RouterFunction<ServerResponse> messageToSubscriptionsRoutes() {
+        return RouterFunctions
+                .route(RequestPredicates.POST("/messageToSubscriptions"), messageToSubscriptionsPostRoute());
+    }
+
+    private HandlerFunction<ServerResponse> messageToSubscriptionsPostRoute() {
+        return request -> {
+            Mono<String> messageToSend = request.bodyToMono(String.class);
+            ServerResponse.BodyBuilder builder = ok()
+                    .contentType(MediaType.APPLICATION_JSON);
+            return builder.body(cardOperationsController.postMessageToSubscriptions(messageToSend), String.class);
+        };
+    }
+}
+

--- a/services/cards-consultation/src/main/java/org/opfab/cards/consultation/configuration/webflux/WebSecurityConfiguration.java
+++ b/services/cards-consultation/src/main/java/org/opfab/cards/consultation/configuration/webflux/WebSecurityConfiguration.java
@@ -35,9 +35,10 @@ import reactor.core.publisher.Mono;
 public class WebSecurityConfiguration {
 
     public static final String PROMETHEUS_PATH = "/actuator/prometheus**";
-    public static final String LOGGERS_PATH ="/actuator/loggers/**";
-    public static final String CONNECTIONS ="/connections";
-    public static final String CONNECTIONS_PATH ="/connections**";
+    public static final String LOGGERS_PATH = "/actuator/loggers/**";
+    public static final String CONNECTIONS = "/connections";
+    public static final String CONNECTIONS_PATH = "/connections**";
+    public static final String MESSAGE_TO_SUBSCRIPTIONS = "/messageToSubscriptions";
     public static final String ADMIN_ROLE = "ADMIN";
 
 
@@ -73,6 +74,7 @@ public class WebSecurityConfiguration {
                 .pathMatchers(HttpMethod.GET, CONNECTIONS).authenticated()
                 .pathMatchers(CONNECTIONS_PATH).hasRole(ADMIN_ROLE)
                 .pathMatchers(LOGGERS_PATH).hasRole(ADMIN_ROLE)
+                .pathMatchers(MESSAGE_TO_SUBSCRIPTIONS).hasRole(ADMIN_ROLE)
                 .anyExchange().access(new IpAddressAuthorizationManager());
     }
 }

--- a/services/cards-consultation/src/main/java/org/opfab/cards/consultation/configuration/webflux/WillNewSubscriptionDisconnectAnExistingSubscriptionRoutesConfig.java
+++ b/services/cards-consultation/src/main/java/org/opfab/cards/consultation/configuration/webflux/WillNewSubscriptionDisconnectAnExistingSubscriptionRoutesConfig.java
@@ -24,11 +24,11 @@ import static org.springframework.web.reactive.function.server.ServerResponse.ok
 
 @Slf4j
 @Configuration
-public class WillNewSubscriptionDisconnectAnExistingSubscription implements UserExtractor {
+public class WillNewSubscriptionDisconnectAnExistingSubscriptionRoutesConfig implements UserExtractor {
 
     private final CardSubscriptionService cardSubscriptionService;
 
-    public WillNewSubscriptionDisconnectAnExistingSubscription(CardSubscriptionService cardSubscriptionService) {
+    public WillNewSubscriptionDisconnectAnExistingSubscriptionRoutesConfig(CardSubscriptionService cardSubscriptionService) {
         this.cardSubscriptionService = cardSubscriptionService;
     }
 

--- a/services/cards-consultation/src/main/java/org/opfab/cards/consultation/controllers/CardOperationsController.java
+++ b/services/cards-consultation/src/main/java/org/opfab/cards/consultation/controllers/CardOperationsController.java
@@ -149,6 +149,13 @@ public class CardOperationsController {
         });
     }
 
+    public Mono<String> postMessageToSubscriptions(Mono<String> messageToSend) {
+        return messageToSend.map(message -> {
+            cardSubscriptionService.postMessageToSubscriptions(message);
+            return "";
+        });
+    }
+
     private String writeValueAsString(CardOperation cardOperation) {
         try {
             return mapper.writeValueAsString(cardOperation);

--- a/services/cards-consultation/src/main/java/org/opfab/cards/consultation/services/CardSubscriptionService.java
+++ b/services/cards-consultation/src/main/java/org/opfab/cards/consultation/services/CardSubscriptionService.java
@@ -222,4 +222,11 @@ public class CardSubscriptionService {
         }
     }
 
+    public void postMessageToSubscriptions(String message) {
+        getSubscriptions().forEach(subscription -> {
+                log.info("message '{}' sent to subscription '{}'", message, subscription.getId());
+                subscription.publishDataIntoSubscription(message);
+        });
+    }
+
 }

--- a/services/cards-consultation/src/test/java/org/opfab/cards/consultation/routes/MessageToSubscriptionsRoutesShould.java
+++ b/services/cards-consultation/src/test/java/org/opfab/cards/consultation/routes/MessageToSubscriptionsRoutesShould.java
@@ -1,0 +1,81 @@
+/* Copyright (c) 2022, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
+ */
+
+package org.opfab.cards.consultation.routes;
+
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.opfab.cards.consultation.application.IntegrationTestApplication;
+import org.opfab.cards.consultation.configuration.webflux.MessageToSubscriptionsRoutesConfig;
+import org.opfab.cards.consultation.controllers.CardOperationsController;
+import org.opfab.cards.consultation.services.CardSubscriptionService;
+import org.opfab.springtools.configuration.test.UserServiceCacheTestApplication;
+import org.opfab.springtools.configuration.test.WithMockOpFabUserReactive;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import reactor.core.publisher.Mono;
+
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(classes = { IntegrationTestApplication.class,
+        CardSubscriptionService.class, MessageToSubscriptionsRoutesConfig.class, CardOperationsController.class,
+        UserServiceCacheTestApplication.class,  }, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureWebTestClient
+@ActiveProfiles(profiles = { "native", "test" })
+@Slf4j
+class MessageToSubscriptionsRoutesShould {
+
+    @Autowired
+    private WebTestClient webTestClient;
+    @Autowired
+    private CardSubscriptionService service;
+
+    public MessageToSubscriptionsRoutesShould() {}
+
+    @BeforeEach
+    public void clearSubscriptions() {
+        service.clearSubscriptions();
+    }
+
+    @Nested
+    @WithMockOpFabUserReactive(login = "userWithGroup", roles = { "ADMIN" })
+    class MessageToSubscriptionsRoutesForAdminShould {
+
+        @Test
+        void postMessageToSubscriptions() {
+            webTestClient.post()
+                    .uri("/messageToSubscriptions")
+                    .body(Mono.just("RELOAD"), String.class)
+                    .exchange()
+                    .expectStatus().isOk()
+                    .expectBody().isEmpty();
+        }
+    }
+
+    @Nested
+    @WithMockOpFabUserReactive(login = "userWithGroup", roles = { "TEST" })
+    class MessageToSubscriptionsRoutesForNonAdminShould {
+
+        @Test
+        void postMessageToSubscriptions() {
+            webTestClient.post()
+                    .uri("/messageToSubscriptions")
+                    .body(Mono.just("RELOAD"), String.class)
+                    .exchange()
+                    .expectStatus().isForbidden();
+        }
+    }
+}


### PR DESCRIPTION
Sonar complains about coverage, I've tried to add a test : 

```
@Test
void postMessageToSubscriptions() {
                  CardSubscription subscription = service.subscribe(currentUserWithPerimeters, "test");
                  subscription.getPublisher().subscribe(log::info);
                  webTestClient.post()
                          .uri("/messageToSubscriptions")
                          .body(Mono.just("RELOAD"), String.class)
                          .exchange()
                          .expectStatus().isOk()
                          .expectBody().isEmpty();      
          }
```
But the test always fails telling return code is 404 instead of 200.
And when I test with postman, the return code is 200.

- In release note :
  -  In chapter : Features
  -  Text : #3128 : Add administration endpoint for sending messages on subscription