### PR TITLE
Do not cache index.html to ease application update in production

### DIFF
--- a/config/dev/nginx.conf.template
+++ b/config/dev/nginx.conf.template
@@ -24,10 +24,12 @@ server {
   gzip_types application/javascript text/css;
 
   location / {
+    add_header Cache-Control "no-cache";
     alias /usr/share/nginx/html/;
     index index.html index.htm;
   }
   location /ui/ {
+    add_header Cache-Control "no-cache";
     alias /usr/share/nginx/html/;
     index index.html index.htm;
   }

--- a/config/docker/nginx.conf
+++ b/config/docker/nginx.conf
@@ -21,10 +21,12 @@ server {
   gzip_types application/javascript text/css;
 
   location / {
+    add_header Cache-Control "no-cache";
     alias /usr/share/nginx/html/;
     index index.html index.htm;
   }
   location /ui/ {
+    add_header Cache-Control "no-cache";
     alias /usr/share/nginx/html/;
     index index.html index.htm;
   }

--- a/ui/main/ngsw-config.json
+++ b/ui/main/ngsw-config.json
@@ -8,7 +8,6 @@
       "resources": {
         "files": [
           "/favicon.ico",
-          "/index.html",
           "/manifest.webmanifest",
           "/*.css",
           "/*.js"


### PR DESCRIPTION

- In release note :
  -  In chapter :  Tasks
  -  Text : #3251 Do not cache index.html to ease application update in production