### PR TITLE
Disable the button "Validate answer" as long as the answer is not saved (#3237)

### DIFF
--- a/src/test/cypress/cypress/integration/ResponseCard.spec.js
+++ b/src/test/cypress/cypress/integration/ResponseCard.spec.js
@@ -367,6 +367,7 @@ describe ('Response card tests',function () {
 
     });
 
+
     it ('Check responses in archived cards detail',function () {
         cy.loginOpFab('operator1_fr','test');
         // We move to archives screen
@@ -422,4 +423,28 @@ describe ('Response card tests',function () {
 
     });
 
+
+    it ('Check response button is disabled while sending response',function () {
+        cy.loginOpFab('operator1_fr','test');
+
+        // Click on the card
+        cy.get('of-light-card').eq(0).click(); 
+
+        // Delay send card response
+        cy.intercept('/cardspub/cards/userCard', (req) => {
+            req.reply((res) => {
+                res.delay = 2000;
+            });
+        });
+        cy.get('#opfab-card-details-btn-response').click(); // click to send the response
+
+        // send response button should be disabled
+        cy.get('#opfab-card-details-btn-response').should('have.text', 'SEND RESPONSE');
+        cy.get('#opfab-card-details-btn-response').should('be.disabled');
+
+        //  Modify response button should be enabled after response is sent,
+        cy.get('#opfab-card-details-btn-response').should('not.be.disabled');
+        cy.get('#opfab-card-details-btn-response').should('have.text', 'MODIFY RESPONSE');
+
+    });
 })

--- a/ui/main/src/app/modules/cards/components/detail/detail.component.html
+++ b/ui/main/src/app/modules/cards/components/detail/detail.component.html
@@ -131,7 +131,7 @@
 
             <div *ngIf="showButtons" style="text-align: right;">
               <button id="opfab-card-details-btn-response" class="opfab-btn"
-                *ngIf='showActionButton && isUserEnabledToRespond && !isResponseLocked' [disabled]='lttdExpiredIsTrue || !isUserEnabledToRespond'
+                *ngIf='showActionButton && isUserEnabledToRespond && !isResponseLocked' [disabled]='lttdExpiredIsTrue || !isUserEnabledToRespond || sendingResponse'
                 (click)='submitResponse()'>{{btnValidateLabel|translate}}</button>
 
               <button id="opfab-card-details-btn-response" class="opfab-btn"

--- a/ui/main/src/app/modules/cards/components/detail/detail.component.ts
+++ b/ui/main/src/app/modules/cards/components/detail/detail.component.ts
@@ -107,6 +107,7 @@ export class DetailComponent implements OnChanges, OnInit, OnDestroy, AfterViewC
     public isUserEnabledToRespond = false;
     public lttdExpiredIsTrue: boolean;
     public isResponseLocked = false;
+    public sendingResponse: boolean;
     public hrefsOfCssLink = new Array<SafeResourceUrl>();
     public fullscreen = false;
     public showButtons = false;
@@ -908,9 +909,10 @@ export class DetailComponent implements OnChanges, OnInit, OnDestroy, AfterViewC
                 parentCardId: this.card.id,
                 initialParentCardUid: this.card.uid
             };
-
+            this.sendingResponse = true;
             this.cardService.postCard(card).subscribe(
                 (rep) => {
+                    this.sendingResponse = false;
                     if (rep.status !== 201) {
                         this.displayMessage(ResponseI18nKeys.SUBMIT_ERROR_MSG, null, MessageLevel.ERROR);
                         console.error(rep);
@@ -921,6 +923,7 @@ export class DetailComponent implements OnChanges, OnInit, OnDestroy, AfterViewC
                     }
                 },
                 (err) => {
+                    this.sendingResponse = false;
                     this.displayMessage(ResponseI18nKeys.SUBMIT_ERROR_MSG, null, MessageLevel.ERROR);
                     console.error(err);
                 }


### PR DESCRIPTION
Fix #3237

Signed-off-by: Giovanni Ferrari <giovanni.ferrari@soft.it>

- In release note :
  -  In chapter :  Bugs 
  -  Text : #3237 : Disable the button "Validate answer" as long as the answer is not saved 