### PR TITLE
Adjust usercard cypress test

### DIFF
--- a/src/test/cypress/cypress/integration/UserCard.spec.js
+++ b/src/test/cypress/cypress/integration/UserCard.spec.js
@@ -379,6 +379,10 @@ describe('User Card ', function () {
       cy.get('of-light-card').eq(0).click();
       cy.get('#opfab-card-edit').click();
       cy.get("of-usercard").should('exist');
+
+      // check this to be sure template has been loaded
+      cy.get('#state-select');
+
       cy.usercardPrepareAndSendCard();
       // Check that the message indicating successful sending appears
       cy.get('.opfab-info-message').should('have.class', 'opfab-alert-info').contains("Your card is published");
@@ -458,6 +462,11 @@ describe('User Card ', function () {
         cy.get('of-light-card').eq(0).click();
         cy.get('#opfab-card-edit').click();
         cy.get("of-usercard").should('exist');
+
+        // check this to be sure template has been loaded
+        cy.get('#state-select');
+
+
         cy.usercardPrepareAndSendCard();
         // Check that the message indicating successful sending appears
         cy.get('.opfab-info-message').should('have.class','opfab-alert-info').contains("Your card is published");
@@ -479,6 +488,10 @@ describe('User Card ', function () {
       cy.usercardSelectService('User card examples');
       cy.usercardSelectProcess('Conference and IT incident');
       cy.usercardSelectState('IT Incident');
+
+      // check this to be sure template has been loaded
+      cy.get('#service-select');
+
       cy.usercardPrepareAndSendCard();
       // Check that the message indicating successful sending appears
       cy.get('.opfab-info-message').should('have.class', 'opfab-alert-info').contains("Your card is published");

--- a/ui/main/src/app/modules/usercard/selectStateForm/usercard-select-state-form.component.ts
+++ b/ui/main/src/app/modules/usercard/selectStateForm/usercard-select-state-form.component.ts
@@ -34,11 +34,11 @@ export class UserCardSelectStateFormComponent implements OnInit, OnDestroy {
 
     @ViewChild('processGroupSelect') set processGroup(processGroupSelect: MultiSelectComponent) {
         if (processGroupSelect && this.cardIdToEdit) processGroupSelect.disable();
-     }
+    }
 
     @ViewChild('processSelect') set process(processSelect: MultiSelectComponent) {
         if (processSelect && this.cardIdToEdit) processSelect.disable();
-     }
+    }
 
     processesDefinition: Process[];
     currentUserWithPerimeters: UserWithPerimeters;
@@ -49,10 +49,10 @@ export class UserCardSelectStateFormComponent implements OnInit, OnDestroy {
     processesWithoutProcessGroup = [];
 
     selectStateForm: FormGroup;
-    processOptions : Array<MultiSelectOption> = [];
+    processOptions: Array<MultiSelectOption> = [];
     processOptionsWhenSelectedProcessGroup = [];
-    processGroupOptions : Array<MultiSelectOption> = [];
-    selectedProcessGroupOption : any;
+    processGroupOptions: Array<MultiSelectOption> = [];
+    selectedProcessGroupOption: any;
     stateOptions: any[];
 
     selectedProcess: string;
@@ -105,7 +105,7 @@ export class UserCardSelectStateFormComponent implements OnInit, OnDestroy {
         if (!this.processOptions || this.processOptions.length < 1) this.emptyProcessList.emit(true);
     }
 
-    isProcessGroupFilterVisible() : boolean {
+    isProcessGroupFilterVisible(): boolean {
         return !!this.processGroupOptions && this.processGroupOptions.length > 1;
     }
 
@@ -144,7 +144,7 @@ export class UserCardSelectStateFormComponent implements OnInit, OnDestroy {
         this.statesPerProcesses.set(process.id, statesList);
     }
 
-    getStateFromProcessDefinition(process: Process, stateId: string) : {value: string, label: string}{
+    getStateFromProcessDefinition(process: Process, stateId: string): {value: string; label: string} {
         const stateFromProcessDefinition = process.states[stateId];
         if (!!stateFromProcessDefinition) {
             if (!!stateFromProcessDefinition.userCard) {
@@ -180,16 +180,19 @@ export class UserCardSelectStateFormComponent implements OnInit, OnDestroy {
         });
 
         for (const processGroupId of this.processesPerProcessGroups.keys())
-            this.processGroupOptions.push(new MultiSelectOption(processGroupId, this.processGroups.get(processGroupId).name));
+            this.processGroupOptions.push(
+                new MultiSelectOption(processGroupId, this.processGroups.get(processGroupId).name)
+            );
 
         this.processGroupOptions.sort((a, b) => Utilities.compareObj(a.label, b.label));
 
         if (this.processOptions.length > numberOfProcessesAttachedToAProcessGroup) {
             this.loadProcessesWithoutProcessGroup();
-            this.processGroupOptions.unshift(new MultiSelectOption( '--', 'processGroup.defaultLabel'));
+            this.processGroupOptions.unshift(new MultiSelectOption('--', 'processGroup.defaultLabel'));
         }
 
-        if (!this.cardIdToEdit && this.processGroupOptions.length > 0) this.selectedProcessGroupOption = this.processGroupOptions[0].value;
+        if (!this.cardIdToEdit && this.processGroupOptions.length > 0)
+            this.selectedProcessGroupOption = this.processGroupOptions[0].value;
     }
 
     private isProcessInProcessesGroup(idProcess: string, processesGroup: {name: string; processes: string[]}): boolean {
@@ -219,7 +222,7 @@ export class UserCardSelectStateFormComponent implements OnInit, OnDestroy {
 
     changeStatesWhenSelectProcess(): void {
         this.selectStateForm.get('usercardProcess').valueChanges.subscribe((process) => {
-            if (!!process ) {
+            if (!!process) {
                 this.stateOptions = this.statesPerProcesses.get(process);
                 if (!this.cardIdToEdit) {
                     this.selectedProcess = process;
@@ -232,18 +235,10 @@ export class UserCardSelectStateFormComponent implements OnInit, OnDestroy {
     private initProcessState() {
         if (this.cardIdToEdit) {
             const processGroupForCardToEdit = this.processGroupPerProcesses.get(this.initialProcess);
-
             if (processGroupForCardToEdit) this.selectedProcessGroupOption = processGroupForCardToEdit;
             else this.selectedProcessGroupOption = '--';
-
             this.selectedProcess = this.initialProcess;
-
             this.selectedState = this.initialState;
-
-            this.stateChange.emit({
-                selectedProcessId: this.initialProcess,
-                state: this.initialState
-            });
         }
     }
 


### PR DESCRIPTION
Nothing in release note

Cypress was right , there was really a pb in the code 

When editing the card the events of changing state in usercard was send twice leading to load template twice in a very  short time.


It does :

```
//First load 
Angular code : userCardTemplate.getSpecificCardInformation = null
Template  code : userCardTemplate.getSpecificCardInformation = templateCode
//Second Load 
Angular code : userCardTemplate.getSpecificCardInformation = null  
Template code : userCardTemplate.getSpecificCardInformation = templateCode 
```

But when we click on "prepare card" button in cypress code it may happen during the second load thus the getSpecificCardInformation() may be null 