### PR TITLE
Card detail: show action buttons only after template is loaded (#3279)

### DIFF
--- a/src/test/cypress/cypress/integration/ResponseCard.spec.js
+++ b/src/test/cypress/cypress/integration/ResponseCard.spec.js
@@ -423,7 +423,7 @@ describe ('Response card tests',function () {
 
     });
 
-/** 
+ 
     it ('Check response button is disabled while sending response',function () {
         cy.loginOpFab('operator1_fr','test');
 
@@ -436,10 +436,14 @@ describe ('Response card tests',function () {
                 res.delay = 2000;
             });
         });
+
+        // Check template is loaded
+        cy.get('#question-choice1');
+
+        cy.get('#opfab-card-details-btn-response').should('have.text', 'SEND RESPONSE');
         cy.get('#opfab-card-details-btn-response').click(); // click to send the response
 
         // send response button should be disabled
-        cy.get('#opfab-card-details-btn-response').should('have.text', 'SEND RESPONSE');
         cy.get('#opfab-card-details-btn-response').should('be.disabled');
 
         //  Modify response button should be enabled after response is sent,
@@ -447,5 +451,5 @@ describe ('Response card tests',function () {
         cy.get('#opfab-card-details-btn-response').should('have.text', 'MODIFY RESPONSE');
 
     });
-*/
+
 })

--- a/ui/main/src/app/modules/cards/components/detail/detail.component.ts
+++ b/ui/main/src/app/modules/cards/components/detail/detail.component.ts
@@ -223,7 +223,6 @@ export class DetailComponent implements OnChanges, OnInit, OnDestroy, AfterViewC
         this.initializeHrefsOfCssLink();
         this.initializeHandlebarsTemplates();
         this.markAsReadIfNecessary();
-        this.setButtonsVisibility();
         this.showDetailCardHeader =
             !this.cardState.showDetailCardHeader || this.cardState.showDetailCardHeader === true;
         this.computeFromEntityOrRepresentative();
@@ -341,6 +340,7 @@ export class DetailComponent implements OnChanges, OnInit, OnDestroy, AfterViewC
                                 }
                                 templateGateway.setScreenSize(this.screenSize);
                                 setTimeout(() => templateGateway.onTemplateRenderingComplete(), 10);
+                                this.setButtonsVisibility();
                             }, 10);
                         }, 10);
                     },


### PR DESCRIPTION
Fix #3279 

Signed-off-by: Giovanni Ferrari <giovanni.ferrari@soft.it>

- In release note :
  -  In chapter :  Bugs
  -  Text : #3279 : Card detail: show action buttons only after template is loaded 