### PR TITLE
Avoid null field in time input when user erases values (#3356,#3365,#3373)

### DIFF
--- a/ui/main/src/app/modules/share/datetime-filter/datetime-filter.component.ts
+++ b/ui/main/src/app/modules/share/datetime-filter/datetime-filter.component.ts
@@ -181,6 +181,10 @@ export class DatetimeFilterComponent implements ControlValueAccessor, OnInit, On
             if (val) {
                 this.disabled = false;
             }
+            // avoid having null value for time field
+            // when user erases values in input field
+            else this.timeInput.setValue({hour:0 ,minute:0,second:0});
+            
             this.change.emit();
         });
     }


### PR DESCRIPTION


- In release note :
  -  In chapter :  Bugs
  -  Text : 
   #3356 : Archives/Logging screens : error for control in hours/minutes fields
   #3365 : Usercard start/end dates : no error for wrong date
   #3373 : https://github.com/opfab/operatorfabric-core/issues/3373