### PR TITLE
Missing external devices on port 2105 in documentation (#3364)

### DIFF
--- a/src/docs/asciidoc/dev_env/scripts.adoc
+++ b/src/docs/asciidoc/dev_env/scripts.adoc
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2020 RTE (http://www.rte-france.com)
+// Copyright (c) 2018-2022 RTE (http://www.rte-france.com)
 // See AUTHORS.txt
 // This document is subject to the terms of the Creative Commons Attribution 4.0 International license.
 // If a copy of the license was not distributed with this
@@ -39,10 +39,12 @@ instance).
 |2102 |cards-publication |card publication service http (REST)
 |2103 |users |Users management service http (REST)
 |2104 |cards-consultation |card consultation service http (REST)
+|2105 |external-devices | External devices service http (REST)
 |4100 |businessconfig |java debug port
 |4102 |cards-publication |java debug port
 |4103 |users |java debug port
-|4103 |cards-consultation |java debug port
+|4104 |cards-consultation |java debug port
+|4105 |external-devices |java debug port
 |===
 
 +++ </div></details> +++


### PR DESCRIPTION
Fix #3364

Signed-off-by: Giovanni Ferrari <giovanni.ferrari@soft.it>

I propose to add nothing in release notes 