### PR TITLE
Cursor not valid in << and >> (monitoring screen and feed when timeline is hidden) (#3371)

### DIFF
--- a/ui/main/src/app/modules/share/timeline-buttons/timeline-buttons.component.html
+++ b/ui/main/src/app/modules/share/timeline-buttons/timeline-buttons.component.html
@@ -17,7 +17,7 @@
 
       <ul class="paddingTop">
         <li *ngIf='hideTimeLine || isMonitoringScreen'>
-          <a (click)="moveDomain(false)"> &lt;&lt;
+          <a (click)="moveDomain(false)" style="cursor: pointer"> &lt;&lt;
           </a>
         </li>
 
@@ -29,7 +29,7 @@
         </li>
 
         <li *ngIf='hideTimeLine || isMonitoringScreen'>
-          <a (click)="moveDomain(true)">
+          <a (click)="moveDomain(true)" style="cursor: pointer">
             &gt;&gt;
           </a>
         </li>


### PR DESCRIPTION
- In release note :
  -  In chapter : Bugs
  -  Text : #3371 : Cursor not valid in << and >> (monitoring screen and feed when timeline is hidden)