### PR TITLE
Cursor is not valid in monitoring table when going over the table rows (#3369)

### DIFF
--- a/ui/main/src/app/modules/monitoring/components/monitoring-table/monitoring-table.component.ts
+++ b/ui/main/src/app/modules/monitoring/components/monitoring-table/monitoring-table.component.ts
@@ -180,7 +180,8 @@ export class MonitoringTableComponent implements OnChanges, OnDestroy {
             suppressHorizontalScroll: true,
             columnDefs: this.columnDefs,
             rowHeight: 45,
-            popupParent: document.querySelector('body')
+            popupParent: document.querySelector('body'),
+            rowClass: 'opfab-monitoring-ag-grid-row',
         };
         this.rowData$ = this.rowDataSubject.asObservable();
     }

--- a/ui/main/src/scss/styles.scss
+++ b/ui/main/src/scss/styles.scss
@@ -991,6 +991,10 @@ body {
     }
 }
 
+.opfab-monitoring-ag-grid-row {
+    cursor: pointer;
+}
+
 .ag-popup {
     @extend .opfab-ag-grid-theme;
 }


### PR DESCRIPTION
It should affect only monitoring ag-grid, I've checked other ag-grid screens and it seems ok but please check also on your side.

- In release note :
  -  In chapter : Bugs
  -  Text : #3369 : Cursor is not valid in monitoring table when going over the table rows