### PR TITLE
Send HTTP error 500 when external application endpoint not found

### DIFF
--- a/services/cards-publication/src/main/java/org/opfab/cards/publication/services/clients/impl/ExternalAppClientImpl.java
+++ b/services/cards-publication/src/main/java/org/opfab/cards/publication/services/clients/impl/ExternalAppClientImpl.java
@@ -162,7 +162,7 @@ public class ExternalAppClientImpl implements ExternalAppClient {
 
     private void throwException(Exception e) {
         if (e instanceof HttpClientErrorException.NotFound) {
-            throw createApiError(HttpStatus.NOT_FOUND, REMOTE_404_MESSAGE);
+            throw createApiError(HttpStatus.INTERNAL_SERVER_ERROR, REMOTE_404_MESSAGE);
         } else if ( e instanceof HttpClientErrorException || e instanceof HttpServerErrorException ) {
             throw createApiError(((HttpStatusCodeException) e).getStatusCode(), UNEXPECTED_REMOTE_MESSAGE);
         } else if (e instanceof IllegalArgumentException) {

--- a/src/test/api/karate/cards/externalRecipentErrors.feature
+++ b/src/test/api/karate/cards/externalRecipentErrors.feature
@@ -135,7 +135,7 @@ Feature: External recipient application errors
     And header Authorization = 'Bearer ' + authTokenAsTSO
     And request card
     When method post
-    Then status 404
+    Then status 500
     And match response.message  ==  'External application endpoint not found (HTTP 404)'
 
 


### PR DESCRIPTION
Fix #3372 

Signed-off-by: Giovanni Ferrari <giovanni.ferrari@soft.it>

- In release note :
  -  In chapter :  Bugs 
  -  Text : #3372 : Send HTTP error 500 when external application endpoint is not found