### PR TITLE
Cleaning some log sentences

### DIFF
--- a/services/external-devices/src/main/java/org/opfab/externaldevices/services/ConfigService.java
+++ b/services/external-devices/src/main/java/org/opfab/externaldevices/services/ConfigService.java
@@ -43,7 +43,7 @@ import java.util.stream.Collectors;
 public class ConfigService {
 
     public static final String CONFIGURATION_NOT_FOUND = "Configuration not found for %1$s %2$s";
-    public static final String DEBUG_RETRIEVED_CONFIG = "Retrieved configuration for";
+    public static final String DEBUG_RETRIEVED_CONFIG = "Retrieved configuration";
     public static final String UNSUPPORTED_SIGNAL ="Signal %1$s is not supported in mapping %2$s";
     public static final String NULL_AFTER_DELETE = "Following deletion of {}, no {} is configured for {} {}";
     public static final String CANNOT_RETRIEVE_FOR_NULL_OR_EMPTY_ID = "Cannot retrieve %1$s with null or empty id.";

--- a/ui/main/src/app/services/card.service.ts
+++ b/ui/main/src/app/services/card.service.ts
@@ -108,7 +108,7 @@ export class CardService {
                             this.logger.info(
                                 'CardService - Receive card to add id=' +
                                     operation.card.id +
-                                    'with date=' +
+                                    ' with date=' +
                                     new Date(operation.card.publishDate).toISOString(),
                                 LogOption.LOCAL_AND_REMOTE
                             );


### PR DESCRIPTION
Nothing in release notes.

This PR corrects this for example : 
"Retrieved configuration for for user....
Retrieved configuration for for device ....
Retrieved configuration for for signal ....."