### PR TITLE
Permit to select more than one entity if possible when sending a response card (#3383)

### DIFF
--- a/src/test/cypress/cypress/integration/ResponseCard.spec.js
+++ b/src/test/cypress/cypress/integration/ResponseCard.spec.js
@@ -94,8 +94,6 @@ describe ('Response card tests',function () {
     });
 
 
-
-
     it('Check card response for operator2_fr ', function () {
 
         cy.loginOpFab('operator2_fr','test');
@@ -186,16 +184,15 @@ describe ('Response card tests',function () {
         cy.get('#question-choice3').click();
         cy.get('#opfab-card-details-btn-response').click(); // click again to send the response
 
-        // Check the popup for the entity choice is displayed
-        cy.get("#opfab-card-details-entity-choice-selector").should('exist');
-        cy.get('#opfab-card-details-entity-choice-selector').find('.vscomp-option-text').should("have.length", 3);
-        cy.get('#opfab-card-details-entity-choice-selector').find('.vscomp-option-text').eq(0).should("contain.text", "Control Center FR East");
-        cy.get('#opfab-card-details-entity-choice-selector').find('.vscomp-option-text').eq(1).should("contain.text", "Control Center FR North");
-        cy.get('#opfab-card-details-entity-choice-selector').find('.vscomp-option-text').eq(2).should("contain.text", "Control Center FR South");
+        // Check the popup for the entities choice is displayed
+        cy.get("#opfab-card-details-entities-choice-selector").should('exist');
+        cy.get('#opfab-card-details-entities-choice-selector').find('.vscomp-option-text').should("have.length", 3);
+        cy.get('#opfab-card-details-entities-choice-selector').find('.vscomp-option-text').eq(0).should("contain.text", "Control Center FR East");
+        cy.get('#opfab-card-details-entities-choice-selector').find('.vscomp-option-text').eq(1).should("contain.text", "Control Center FR North");
+        cy.get('#opfab-card-details-entities-choice-selector').find('.vscomp-option-text').eq(2).should("contain.text", "Control Center FR South");
 
-        // We choose ENTITY3_FR (East)
-        cy.get("#opfab-card-details-entity-choice-selector").find('.vscomp-option-text').eq(0).click({force: true});
-        cy.get("#opfab-card-details-entity-choice-selector").find('.vscomp-value').should('have.text', 'Control Center FR East');
+        // We choose ENTITY3_FR (East) which is already selected
+        cy.get("#opfab-card-details-entities-choice-selector").find('.vscomp-value').should('contain.text', 'Control Center FR East');
 
 
         cy.get('#opfab-card-details-entity-choice-btn-confirm').click();
@@ -211,28 +208,33 @@ describe ('Response card tests',function () {
                                            .next().should("have.text", ' NOK ')
                                            .next().should("have.text", ' OK ');
 
-        // operator4_fr updates the answer of ENTITY1_FR
+        // operator4_fr updates the answer of ENTITY1_FR and ENTITY2_FR
         cy.get('#opfab-card-details-btn-response').click(); // button "modify response"
         cy.get('#question-choice1').click();
         cy.get('#question-choice3').click(); //to uncheck the box
         cy.get('#opfab-card-details-btn-response').click(); // click again to send the response
-        cy.get("#opfab-card-details-entity-choice-selector").find('.vscomp-option-text').eq(1).click({force: true}); // We choose ENTITY1_FR (North)
-        cy.get("#opfab-card-details-entity-choice-selector").find('.vscomp-value').should('have.text', 'Control Center FR North');
+        cy.get("#opfab-card-details-entities-choice-selector").click();
+        cy.get("#opfab-card-details-entities-choice-selector").find('.vscomp-option-text').eq(0).click(); // We unselect ENTITY3_FR (East)
+        cy.get("#opfab-card-details-entities-choice-selector").find('.vscomp-option-text').eq(1).click(); // We select ENTITY1_FR (North)
+        cy.get("#opfab-card-details-entities-choice-selector").find('.vscomp-option-text').eq(2).click(); // We select ENTITY2_FR (South)
+        cy.get("#opfab-card-details-entities-choice-selector").click();
+        cy.get("#opfab-card-details-entities-choice-selector").find('.vscomp-value').should('contain.text', 'Control Center FR North');
+        cy.get("#opfab-card-details-entities-choice-selector").find('.vscomp-value').should('contain.text', 'Control Center FR South');
         cy.get('#opfab-card-details-entity-choice-btn-confirm').click();
 
         cy.waitDefaultTime();
-        // Check the response from ENTITY1_FR has been updated and the other responses are still the same
+        // Check the response from ENTITY1_FR and ENTITY2_FR have been updated and the other response is still the same
         cy.get('#response_from_ENTITY1_FR').next().should("have.text", ' OK ')
                                            .next().should("have.text", ' NOK ')
                                            .next().should("have.text", ' NOK ');
-        cy.get('#response_from_ENTITY2_FR').next().should("have.text", ' NOK ')
-                                           .next().should("have.text", ' OK ')
+        cy.get('#response_from_ENTITY2_FR').next().should("have.text", ' OK ')
+                                           .next().should("have.text", ' NOK ')
                                            .next().should("have.text", ' NOK ');
         cy.get('#response_from_ENTITY3_FR').next().should("have.text", ' NOK ')
                                            .next().should("have.text", ' NOK ')
                                            .next().should("have.text", ' OK ');
 
-        // operator4_fr disconnect from ENTITY_1_FR and ENTITY2_FR (the popup for entity choice must not be displayed)
+        // operator4_fr disconnect from ENTITY_1_FR and ENTITY2_FR (the popup for entities choice must not be displayed)
         // because the only one entity allowed to respond for him is now ENTITY3_FR
         cy.openActivityArea();
 
@@ -251,14 +253,14 @@ describe ('Response card tests',function () {
         cy.get('#opfab-card-details-btn-response').click(); // button "modify response"
         cy.get('#question-choice2').click(); // to check the box
         cy.get('#opfab-card-details-btn-response').click(); // click again to send the response
-        cy.get("#opfab-card-details-entity-choice-selector").should('not.exist'); // entity choice popup must not be displayed
+        cy.get("#opfab-card-details-entities-choice-selector").should('not.exist'); // entities choice popup must not be displayed
         cy.waitDefaultTime();
         // Check the response from ENTITY3_FR (East) has been updated and the other responses are still the same
         cy.get('#response_from_ENTITY1_FR').next().should("have.text", ' OK ')
                                            .next().should("have.text", ' NOK ')
                                            .next().should("have.text", ' NOK ');
-        cy.get('#response_from_ENTITY2_FR').next().should("have.text", ' NOK ')
-                                           .next().should("have.text", ' OK ')
+        cy.get('#response_from_ENTITY2_FR').next().should("have.text", ' OK ')
+                                           .next().should("have.text", ' NOK ')
                                            .next().should("have.text", ' NOK ');
         cy.get('#response_from_ENTITY3_FR').next().should("have.text", ' NOK ')
                                            .next().should("have.text", ' OK ')
@@ -292,8 +294,8 @@ describe ('Response card tests',function () {
         cy.get('#response_from_ENTITY1_FR').next().should("have.text", ' OK ')
                                            .next().should("have.text", ' NOK ')
                                            .next().should("have.text", ' NOK ');
-        cy.get('#response_from_ENTITY2_FR').next().should("have.text", ' NOK ')
-                                           .next().should("have.text", ' OK ')
+        cy.get('#response_from_ENTITY2_FR').next().should("have.text", ' OK ')
+                                           .next().should("have.text", ' NOK ')
                                            .next().should("have.text", ' NOK ');
         cy.get('#response_from_ENTITY3_FR').next().should("have.text", ' NOK ')
                                            .next().should("have.text", ' OK ')
@@ -305,8 +307,8 @@ describe ('Response card tests',function () {
         
         // Response button is not present 
         cy.get('#opfab-card-details-btn-response').should('not.exist');
-        
     })
+
 
     it ('Check response for operator1_fr is still present after update of card with keepChildCard=true re-logging',function () {
         cy.sendCard('defaultProcess/questionWithKeepChildCards.json');
@@ -325,8 +327,8 @@ describe ('Response card tests',function () {
         cy.get('#response_from_ENTITY1_FR').next().should("have.text", ' OK ')
                                            .next().should("have.text", ' NOK ')
                                            .next().should("have.text", ' NOK ');
-        cy.get('#response_from_ENTITY2_FR').next().should("have.text", ' NOK ')
-                                           .next().should("have.text", ' OK ')
+        cy.get('#response_from_ENTITY2_FR').next().should("have.text", ' OK ')
+                                           .next().should("have.text", ' NOK ')
                                            .next().should("have.text", ' NOK ');
         cy.get('#response_from_ENTITY3_FR').next().should("have.text", ' NOK ')
                                            .next().should("have.text", ' OK ')
@@ -335,10 +337,8 @@ describe ('Response card tests',function () {
         // check entities in card header 
         cy.get('#opfab-card-header-entity-ENTITY1_FR').should('have.css', 'color', 'rgb(0, 128, 0)'); // entity 1 color is green 
         cy.get('#opfab-card-header-entity-ENTITY2_FR').should('have.css', 'color', 'rgb(0, 128, 0)'); // entity 2 color is green
-
-       
-
     });
+
 
     it ('Check response for  operator1_fr  is not present after update of card with keepChildCard= false re-logging',function () {
         cy.sendCard('defaultProcess/question.json');
@@ -362,9 +362,6 @@ describe ('Response card tests',function () {
         // check entities in card header 
         cy.get('#opfab-card-header-entity-ENTITY1_FR').should('have.css', 'color', 'rgb(255, 102, 0)');// entity 1 color is orange 
         cy.get('#opfab-card-header-entity-ENTITY2_FR').should('have.css', 'color', 'rgb(255, 102, 0)');  // entity 2 color is orange
-    
-        
-
     });
 
 
@@ -401,8 +398,8 @@ describe ('Response card tests',function () {
         cy.get('#response_from_ENTITY1_FR').next().should("have.text", ' OK ')
                                             .next().should("have.text", ' NOK ')
                                             .next().should("have.text", ' NOK ');
-        cy.get('#response_from_ENTITY2_FR').next().should("have.text", ' NOK ')
-                                            .next().should("have.text", ' OK ')
+        cy.get('#response_from_ENTITY2_FR').next().should("have.text", ' OK ')
+                                            .next().should("have.text", ' NOK ')
                                             .next().should("have.text", ' NOK ');
         cy.get('#response_from_ENTITY3_FR').next().should("have.text", ' NOK ')
                                             .next().should("have.text", ' OK ')
@@ -420,7 +417,6 @@ describe ('Response card tests',function () {
         cy.get('#response_from_ENTITY1_FR').next().should("have.text", ' OK ')
                                             .next().should("have.text", ' NOK ')
                                             .next().should("have.text", ' NOK ');
-
     });
 
  
@@ -443,13 +439,12 @@ describe ('Response card tests',function () {
         cy.get('#opfab-card-details-btn-response').should('have.text', 'SEND RESPONSE');
         cy.get('#opfab-card-details-btn-response').click(); // click to send the response
 
-        // send response button should be disabled
+        // Send response button should be disabled
         cy.get('#opfab-card-details-btn-response').should('be.disabled');
 
-        //  Modify response button should be enabled after response is sent,
+        // Modify response button should be enabled after response is sent
         cy.get('#opfab-card-details-btn-response').should('not.be.disabled');
         cy.get('#opfab-card-details-btn-response').should('have.text', 'MODIFY RESPONSE');
-
     });
 
 })

--- a/ui/main/src/app/modules/cards/components/detail/detail.component.html
+++ b/ui/main/src/app/modules/cards/components/detail/detail.component.html
@@ -165,26 +165,26 @@
     </div>
   </ng-template>
 
-  <ng-template #chooseEntityForResponsePopup let-modal>
+  <ng-template #chooseEntitiesForResponsePopup let-modal>
     <div class="modal-header">
-      <div translate> response.entityChoice </div>
+      <div translate> response.entitiesChoice </div>
       <div class="opfab-close-modal-icon" aria-label="Close" (click)="modal.dismiss('Cross click')">
         <span aria-hidden="true">&times;</span>
       </div>
     </div>
     <div class="modal-body text-center">
-      <br/><p translate>response.chooseEntityForResponse</p><br/>
-      <form [formGroup]="selectEntityForm" class="opfab-form-lighter">
+      <br/><p translate>response.chooseEntitiesForResponse</p><br/>
+      <form [formGroup]="selectEntitiesForm" class="opfab-form-lighter">
         <div class="row">
-            <of-multi-select id="opfab-card-details-entity-choice-selector" multiSelectId="entity"
-                              [parentForm]="selectEntityForm" [config]="multiSelectConfig"
-                              [options]="userEntityOptionsDropdownList" [selectedOptions]="selectEntityForm.get('entity').value">
+            <of-multi-select id="opfab-card-details-entities-choice-selector" multiSelectId="entities"
+                              [parentForm]="selectEntitiesForm" [config]="multiSelectConfig"
+                              [options]="userEntityOptionsDropdownList" [selectedOptions]="selectEntitiesForm.get('entities').value">
             </of-multi-select>
         </div>
         <br/>
       </form>
-      <button id="opfab-card-details-entity-choice-btn-cancel" type="button" class="opfab-btn-cancel" (click)="cancelEntityChoice()" translate>button.cancel</button>
-      <button id="opfab-card-details-entity-choice-btn-confirm" type="button" class="opfab-btn" (click)="submitEntityChoice()" translate>button.ok</button>
+      <button id="opfab-card-details-entity-choice-btn-cancel" type="button" class="opfab-btn-cancel" (click)="cancelEntitiesChoice()" translate>button.cancel</button>
+      <button id="opfab-card-details-entity-choice-btn-confirm" type="button" class="opfab-btn" (click)="submitEntitiesChoice()" translate>button.ok</button>
     </div>
   </ng-template>
 

--- a/ui/main/src/app/modules/cards/components/detail/detail.component.ts
+++ b/ui/main/src/app/modules/cards/components/detail/detail.component.ts
@@ -26,7 +26,6 @@ import {DomSanitizer, SafeHtml} from '@angular/platform-browser';
 import {AcknowledgmentAllowedEnum, State, TypeOfStateEnum} from '@ofModel/processes.model';
 import {Store} from '@ngrx/store';
 import {AppState} from '@ofStore/index';
-import {UserContext} from '@ofModel/user-context.model';
 import {map, takeUntil} from 'rxjs/operators';
 import {CardService} from '@ofServices/card.service';
 import {Subject} from 'rxjs';
@@ -98,9 +97,9 @@ export class DetailComponent implements OnChanges, OnInit, OnDestroy, DoCheck {
     @ViewChild('cardDeletedWithNoErrorPopup') cardDeletedWithNoErrorPopupRef: TemplateRef<any>;
     @ViewChild('impossibleToDeleteCardPopup') impossibleToDeleteCardPopupRef: TemplateRef<any>;
     @ViewChild('userCard') userCardTemplate: TemplateRef<any>;
-    @ViewChild('chooseEntityForResponsePopup') chooseEntityForResponsePopupRef: TemplateRef<any>;
+    @ViewChild('chooseEntitiesForResponsePopup') chooseEntitiesForResponsePopupRef: TemplateRef<any>;
 
-    private selectEntityForm: UntypedFormGroup;
+    private selectEntitiesForm: UntypedFormGroup;
 
     public isUserEnabledToRespond = false;
     public lttdExpiredIsTrue: boolean;
@@ -138,7 +137,6 @@ export class DetailComponent implements OnChanges, OnInit, OnDestroy, DoCheck {
     private userEntityOptionsDropdownList = [];
     private userEntityIdToUseForResponse = '';
     private userMemberOfAnEntityRequiredToRespondAndAllowedToSendCards = false;
-    private userContext: UserContext;
     private unsubscribe$: Subject<void> = new Subject<void>();
     private modalRef: NgbModalRef;
     public ackOrUnackInProgress = false;
@@ -147,7 +145,7 @@ export class DetailComponent implements OnChanges, OnInit, OnDestroy, DoCheck {
     public user: User;
     public multiSelectConfig: MultiSelectConfig = {
         labelKey: 'shared.entity',
-        multiple: false,
+        multiple: true,
         search: true
     };
 
@@ -177,8 +175,8 @@ export class DetailComponent implements OnChanges, OnInit, OnDestroy, DoCheck {
     ngOnInit() {
         if (this._appService.pageType !== PageType.ARCHIVE) this.integrateChildCardsInRealTime();
 
-        this.selectEntityForm = new UntypedFormGroup({
-            entity: new UntypedFormControl('')
+        this.selectEntitiesForm = new UntypedFormGroup({
+            entities: new UntypedFormControl([])
         });
 
         this.cardService
@@ -751,7 +749,7 @@ export class DetailComponent implements OnChanges, OnInit, OnDestroy, DoCheck {
         templateGateway.unlockAnswer();
     }
 
-    public cancelEntityChoice(): void {
+    public cancelEntitiesChoice(): void {
         this.modalRef.dismiss();
     }
 
@@ -764,25 +762,28 @@ export class DetailComponent implements OnChanges, OnInit, OnDestroy, DoCheck {
         this.userEntityOptionsDropdownList.sort((a, b) => Utilities.compareObj(a.label, b.label));
     }
 
-    private displayEntityChoicePopup() {
+    private displayEntitiesChoicePopup() {
         this.userEntityIdToUseForResponse = '';
-        this.selectEntityForm.get('entity').setValue(this.userEntityOptionsDropdownList[0].value);
-        this.openModal(this.chooseEntityForResponsePopupRef);
+        this.selectEntitiesForm.get('entities').setValue(this.userEntityOptionsDropdownList[0].value);
+        this.openModal(this.chooseEntitiesForResponsePopupRef);
     }
 
     public submitResponse() {
-        if (this.userEntityIdsPossibleForResponse.length > 1) this.displayEntityChoicePopup();
+        if (this.userEntityIdsPossibleForResponse.length > 1) this.displayEntitiesChoicePopup();
         else this.submitResponse0();
     }
 
-    public getSelectedEntity() {
-        return this.selectEntityForm.value['entity'];
+    public getSelectedEntities() {
+        return this.selectEntitiesForm.value['entities'];
     }
 
-    public submitEntityChoice() {
+    public submitEntitiesChoice() {
         this.modalRef.dismiss();
-        this.userEntityIdToUseForResponse = this.getSelectedEntity();
-        this.submitResponse0();
+
+        this.getSelectedEntities().forEach(selectedEntity => {
+            this.userEntityIdToUseForResponse = selectedEntity;
+            this.submitResponse0();
+        });
     }
 
     public submitResponse0() {

--- a/ui/main/src/assets/i18n/en.json
+++ b/ui/main/src/assets/i18n/en.json
@@ -326,8 +326,8 @@
     "answered": "Answered",
     "unanswered": "Not answered yet",
     "status": "Process Status",
-    "chooseEntityForResponse": "Choose the entity you are responding for :",
-    "entityChoice": "Entity choice"
+    "chooseEntitiesForResponse": "Choose the entities you are responding for :",
+    "entitiesChoice": "Entities choice"
   },
   "cardAcknowledgment": {
     "button": {

--- a/ui/main/src/assets/i18n/fr.json
+++ b/ui/main/src/assets/i18n/fr.json
@@ -326,8 +326,8 @@
     "answered": "A répondu",
     "unanswered": "Pas encore répondu",
     "status": "Statut du processus",
-    "chooseEntityForResponse": "Choissisez l'entité pour laquelle vous répondez :",
-    "entityChoice": "Choix de l'entité"
+    "chooseEntitiesForResponse": "Choisissez les entités pour lesquelles vous répondez :",
+    "entitiesChoice": "Choix des entités"
   },
   "cardAcknowledgment": {
     "button": {

--- a/ui/main/src/assets/i18n/nl.json
+++ b/ui/main/src/assets/i18n/nl.json
@@ -326,8 +326,8 @@
     "answered": "Beantwoord",
     "unanswered": "Nog niet beantwoord",
     "status": "Proces Status",
-    "chooseEntityForResponse": "Kies de entiteit waarvoor u reageert :",
-    "entityChoice": "Entiteit keuze"
+    "chooseEntitiesForResponse": "Kies de entiteiten waarvoor u reageert :",
+    "entitiesChoice": "Entiteiten keuze"
   },
   "cardAcknowledgment": {
     "button": {


### PR DESCRIPTION
- In release note :
  -  In chapter :  Features
  -  Text : #3383 : Permit to select more than one entity if possible when sending a response card