### PR TITLE
Resource identifiers should only contain letters, digits, dashes or underscores (#1318)

### DIFF
--- a/services/users/src/main/java/org/opfab/users/controllers/EntitiesController.java
+++ b/services/users/src/main/java/org/opfab/users/controllers/EntitiesController.java
@@ -67,12 +67,13 @@ public class EntitiesController implements EntitiesApi {
         }
         userRepository.saveAll(foundUsers);
         return null;
-
     }
 
     @Override
     public Entity createEntity(HttpServletRequest request, HttpServletResponse response, Entity entity) throws Exception {
-        if(entityRepository.findById(entity.getId()).orElse(null) == null){
+        userService.checkFormatOfIdField(entity.getId());
+
+        if (entityRepository.findById(entity.getId()).orElse(null) == null) {
             response.addHeader("Location", request.getContextPath() + "/entities/" + entity.getId());
             response.setStatus(201);
         }
@@ -113,7 +114,7 @@ public class EntitiesController implements EntitiesApi {
                         .build()
         ));
 
-        if(foundUser!=null) {
+        if (foundUser != null) {
             foundUser.deleteEntity(id);
             userRepository.save(foundUser);
             userService.publishUpdatedUserMessage(foundUser.getLogin());
@@ -141,7 +142,7 @@ public class EntitiesController implements EntitiesApi {
     @Override
     public Entity updateEntity(HttpServletRequest request, HttpServletResponse response, String id, Entity entity) throws Exception {
         //id from entity body parameter should match id path parameter
-        if(!entity.getId().equals(id)){
+        if (!entity.getId().equals(id)) {
             throw new ApiErrorException(
                     ApiError.builder()
                             .status(HttpStatus.BAD_REQUEST)

--- a/services/users/src/main/java/org/opfab/users/controllers/GroupsController.java
+++ b/services/users/src/main/java/org/opfab/users/controllers/GroupsController.java
@@ -75,10 +75,12 @@ public class GroupsController implements GroupsApi {
 
     @Override
     public Group createGroup(HttpServletRequest request, HttpServletResponse response, Group group) throws Exception {
+        userService.checkFormatOfIdField(group.getId());
+
         if (group.getPerimeters() != null) {
             retrievePerimeters(group.getPerimeters());
         }
-        if(groupRepository.findById(group.getId()).orElse(null) == null){
+        if (groupRepository.findById(group.getId()).orElse(null) == null) {
             response.addHeader("Location", request.getContextPath() + "/groups/" + group.getId());
             response.setStatus(201);
         }

--- a/services/users/src/main/java/org/opfab/users/controllers/PerimetersController.java
+++ b/services/users/src/main/java/org/opfab/users/controllers/PerimetersController.java
@@ -1,4 +1,4 @@
-/* Copyright (c) 2018-2021, RTE (http://www.rte-france.com)
+/* Copyright (c) 2018-2022, RTE (http://www.rte-france.com)
  * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -69,9 +69,11 @@ public class PerimetersController implements PerimetersApi {
 
     @Override
     public Perimeter createPerimeter(HttpServletRequest request, HttpServletResponse response, Perimeter perimeter) throws Exception {
-        if(perimeterRepository.findById(perimeter.getId()).orElse(null) == null){
+        userService.checkFormatOfIdField(perimeter.getId());
 
-            if(! userService.isEachStateUniqueInPerimeter(perimeter)){
+        if (perimeterRepository.findById(perimeter.getId()).orElse(null) == null) {
+
+            if (! userService.isEachStateUniqueInPerimeter(perimeter)) {
                 throw new ApiErrorException(
                         ApiError.builder()
                                 .status(HttpStatus.BAD_REQUEST)

--- a/services/users/src/main/java/org/opfab/users/controllers/UsersController.java
+++ b/services/users/src/main/java/org/opfab/users/controllers/UsersController.java
@@ -84,8 +84,9 @@ public class UsersController implements UsersApi, UserExtractor {
     public User createUser(HttpServletRequest request, HttpServletResponse response, User user) {
 
         boolean created = false;
-        checkAndSetUserLogin(user);
+        userService.checkFormatOfLoginField(user.getLogin());
 
+        user.setLogin(user.getLogin().toLowerCase());
         String login = user.getLogin();
 
         if (userRepository.findById(login).orElse(null) == null){
@@ -102,7 +103,7 @@ public class UsersController implements UsersApi, UserExtractor {
 
         userService.createUser(user);
 
-        if(!created)
+        if (!created)
             userService.publishUpdatedUserMessage(login);
         
         return user;
@@ -208,8 +209,9 @@ public class UsersController implements UsersApi, UserExtractor {
     public User synchronizeWithToken(HttpServletRequest request, HttpServletResponse response) {
         User user = this.extractUserFromJwtToken(request);
 
-        checkAndSetUserLogin(user);
+        userService.checkFormatOfLoginField(user.getLogin());
 
+        user.setLogin(user.getLogin().toLowerCase());
         String login = user.getLogin();
 
         if (groupsProperties.getMode() == GroupsMode.JWT) {
@@ -261,15 +263,6 @@ public class UsersController implements UsersApi, UserExtractor {
     private UserData findUserOrThrow(String login) throws ApiErrorException {
         return userRepository.findById(login).orElseThrow(
                 ()-> buildApiException(HttpStatus.NOT_FOUND, String.format(USER_NOT_FOUND_MSG, login)));
-    }
-
-    private void checkAndSetUserLogin(User user) {
-        String login = user.getLogin();
-
-        if (login.length() == 0) {
-            throw buildApiException(HttpStatus.BAD_REQUEST, MANDATORY_LOGIN_MISSING);
-        }
-        user.setLogin(user.getLogin().toLowerCase());
     }
 
     private ApiErrorException buildApiException(HttpStatus httpStatus, String errorMessage) {

--- a/services/users/src/main/java/org/opfab/users/services/UserService.java
+++ b/services/users/src/main/java/org/opfab/users/services/UserService.java
@@ -8,6 +8,7 @@
  */
 package org.opfab.users.services;
 
+import org.opfab.springtools.error.model.ApiErrorException;
 import org.opfab.users.model.*;
 
 import java.util.List;
@@ -22,4 +23,6 @@ public interface UserService {
     boolean checkFilteringNotificationIsAllowedForAllProcessesStates(String login, UserSettings userSettings);
     void publishUpdatedUserMessage(String userLogin);
     void publishUpdatedConfigMessage();
+    void checkFormatOfIdField(String id) throws ApiErrorException;
+    void checkFormatOfLoginField(String login) throws ApiErrorException;
 }

--- a/services/users/src/main/java/org/opfab/users/services/UserServiceImp.java
+++ b/services/users/src/main/java/org/opfab/users/services/UserServiceImp.java
@@ -35,6 +35,16 @@ public class UserServiceImp implements UserService {
 
     public static final String PERIMETER_ID_IMPOSSIBLE_TO_FETCH_MSG = "Perimeter id impossible to fetch : %s";
 
+    public static final String ID_IS_REQUIRED_MSG = "Id is required.";
+    public static final String ID_FIELD_PATTERN_MSG = "Id should only contain the following characters: letters, _, - or digits (id=%s).";
+    public static final String ID_FIELD_MIN_LENGTH_MSG = "Id should be minimum 2 characters (id=%s).";
+    public static final String ID_FIELD_PATTERN = "^[A-Za-z0-9-_]+$";
+
+    public static final String MANDATORY_LOGIN_MISSING = "Mandatory 'login' field is missing.";
+    public static final String LOGIN_FIELD_PATTERN_MSG = "Login should only contain the following characters: letters, _, -, . or digits (login=%s).";
+    public static final String LOGIN_FIELD_MIN_LENGTH_MSG = "Login should be minimum 2 characters (login=%s).";
+    public static final String LOGIN_FIELD_PATTERN = "^[A-Za-z0-9-_.]+$";
+
     @Autowired
     private UserRepository userRepository;
     @Autowired
@@ -209,6 +219,48 @@ public class UserServiceImp implements UserService {
     public User createUser(User user) {
         userRepository.save(new UserData(user));
         return user;
+    }
+
+    public void checkFormatOfIdField(String id) throws ApiErrorException {
+        String errorMessage = "";
+
+        if (id.length() == 0)
+            errorMessage = ID_IS_REQUIRED_MSG;
+        else {
+            if (id.length() == 1)
+                errorMessage = String.format(ID_FIELD_MIN_LENGTH_MSG, id);
+
+            if (! id.matches(ID_FIELD_PATTERN))
+                errorMessage += String.format(ID_FIELD_PATTERN_MSG, id);
+        }
+
+        if (errorMessage.length() > 0)
+            throw new ApiErrorException(
+                    ApiError.builder()
+                            .status(HttpStatus.BAD_REQUEST)
+                            .message(errorMessage)
+                            .build());
+    }
+
+    public void checkFormatOfLoginField(String login) throws ApiErrorException {
+        String errorMessage = "";
+
+        if (login.length() == 0)
+            errorMessage = MANDATORY_LOGIN_MISSING;
+        else {
+            if (login.length() == 1)
+                errorMessage = String.format(LOGIN_FIELD_MIN_LENGTH_MSG, login);
+
+            if (! login.matches(LOGIN_FIELD_PATTERN))
+                errorMessage += String.format(LOGIN_FIELD_PATTERN_MSG, login);
+        }
+
+        if (errorMessage.length() > 0)
+            throw new ApiErrorException(
+                    ApiError.builder()
+                            .status(HttpStatus.BAD_REQUEST)
+                            .message(errorMessage)
+                            .build());
     }
 }
 

--- a/services/users/src/main/modeling/swagger.yaml
+++ b/services/users/src/main/modeling/swagger.yaml
@@ -30,6 +30,7 @@ definitions:
     properties:
       login:
         type: string
+        description: Login must be minimum 2 characters and must only contain lowercase letters, _, -, . or digits.
       firstName:
         type: string
       lastName:
@@ -75,6 +76,7 @@ definitions:
     properties:
       id:
         type: string
+        description: Id must be minimum 2 characters and must only contain letters, _, - or digits.
       name:
         type: string
       type:
@@ -99,6 +101,7 @@ definitions:
     properties:
       id:
         type: string
+        description: Id must be minimum 2 characters and must only contain letters, _, - or digits.
       name:
         type: string
       description:
@@ -149,6 +152,7 @@ definitions:
     properties:
       id:
         type: string
+        description: Id must be minimum 2 characters and must only contain letters, _, - or digits.
       process:
         type: string
       stateRights:
@@ -314,7 +318,7 @@ paths:
       tags:
         - users
       summary: Create a new user
-      description: Create a new user. If the user already exists, then an update of the user will be made. Be careful, user login must be lowercase. Otherwise, it will be converted to lowercase before saving to the database.
+      description: Create a new user. If the user already exists, then an update of the user will be made. Be careful, login must be minimum 2 characters and must only contain lowercase letters, _, -, . or digits.
       operationId: createUser
       consumes:
         - application/json

--- a/services/users/src/test/java/org/opfab/users/services/UserServiceShould.java
+++ b/services/users/src/test/java/org/opfab/users/services/UserServiceShould.java
@@ -14,6 +14,7 @@ package org.opfab.users.services;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.opfab.springtools.error.model.ApiErrorException;
 import org.opfab.users.application.UnitTestApplication;
 import org.opfab.users.model.PerimeterData;
 import org.opfab.users.model.RightsEnum;
@@ -57,5 +58,50 @@ class UserServiceShould {
         Assertions.assertThat(userService.isEachStateUniqueInPerimeter(p2)).isTrue();
         Assertions.assertThat(userService.isEachStateUniqueInPerimeter(p3)).isFalse();
         Assertions.assertThat(userService.isEachStateUniqueInPerimeter(p4)).isFalse();
+    }
+
+    @Test
+    void checkFormatOfIdField() {
+        Assertions.assertThatExceptionOfType(ApiErrorException.class).isThrownBy(() ->
+                userService.checkFormatOfIdField("")).withMessage("Id is required.");
+
+        Assertions.assertThatExceptionOfType(ApiErrorException.class).isThrownBy(() ->
+                userService.checkFormatOfIdField("a")).withMessage("Id should be minimum 2 characters (id=a).");
+
+        Assertions.assertThatExceptionOfType(ApiErrorException.class).isThrownBy(() ->
+                userService.checkFormatOfIdField("aé"))
+            .withMessage("Id should only contain the following characters: letters, _, - or digits (id=aé).");
+
+        Assertions.assertThatExceptionOfType(ApiErrorException.class).isThrownBy(() ->
+                userService.checkFormatOfIdField("é"))
+            .withMessage("Id should be minimum 2 characters (id=é).Id should only contain the following characters: letters, _, - or digits (id=é).");
+
+        Assertions.assertThatNoException().isThrownBy(() -> userService.checkFormatOfIdField("validId"));
+        Assertions.assertThatNoException().isThrownBy(() -> userService.checkFormatOfIdField("valid_id"));
+        Assertions.assertThatNoException().isThrownBy(() -> userService.checkFormatOfIdField("valid-id"));
+        Assertions.assertThatNoException().isThrownBy(() -> userService.checkFormatOfIdField("validId_with-digit_0"));
+    }
+
+    @Test
+    void checkFormatOfLoginField() {
+        Assertions.assertThatExceptionOfType(ApiErrorException.class).isThrownBy(() ->
+                userService.checkFormatOfLoginField("")).withMessage("Mandatory 'login' field is missing.");
+
+        Assertions.assertThatExceptionOfType(ApiErrorException.class).isThrownBy(() ->
+                userService.checkFormatOfLoginField("a")).withMessage("Login should be minimum 2 characters (login=a).");
+
+        Assertions.assertThatExceptionOfType(ApiErrorException.class).isThrownBy(() ->
+                userService.checkFormatOfLoginField("aé"))
+            .withMessage("Login should only contain the following characters: letters, _, -, . or digits (login=aé).");
+
+        Assertions.assertThatExceptionOfType(ApiErrorException.class).isThrownBy(() ->
+                userService.checkFormatOfLoginField("é"))
+            .withMessage("Login should be minimum 2 characters (login=é).Login should only contain the following characters: letters, _, -, . or digits (login=é).");
+
+        Assertions.assertThatNoException().isThrownBy(() -> userService.checkFormatOfLoginField("validLoginConvertedToLowerCase"));
+        Assertions.assertThatNoException().isThrownBy(() -> userService.checkFormatOfLoginField("valid_login"));
+        Assertions.assertThatNoException().isThrownBy(() -> userService.checkFormatOfLoginField("valid-login"));
+        Assertions.assertThatNoException().isThrownBy(() -> userService.checkFormatOfLoginField("valid.login"));
+        Assertions.assertThatNoException().isThrownBy(() -> userService.checkFormatOfLoginField("valid.login_with-digit_0"));
     }
 }

--- a/src/test/api/karate/externaldevices/deleteUserConfig.feature
+++ b/src/test/api/karate/externaldevices/deleteUserConfig.feature
@@ -17,7 +17,7 @@ Feature: User Configuration Management (Delete)
     * def userSettings =
 """
 {
-  "login" : "loginKarate1",
+  "login" : "loginkarate1",
   "playSoundOnExternalDevice" : true
 }
 """

--- a/src/test/api/karate/users/createUsers.feature
+++ b/src/test/api/karate/users/createUsers.feature
@@ -11,8 +11,7 @@ Feature: CreateUsers
     * def userKarate =
 """
 {
-
-   "login" : "loginKarate1",
+   "login" : "loginkarate1",
    "firstName" : "name",
    "lastName" : "familyName"
 }
@@ -21,8 +20,7 @@ Feature: CreateUsers
     * def userUpdate =
 """
 {
-
-   "login" : "loginKarate1",
+   "login" : "loginkarate1",
    "firstName" : "nameUpdate",
    "lastName" : "familyNameUpdate"
 }
@@ -31,7 +29,7 @@ Feature: CreateUsers
   * def adminUser =
 """
   {
-  
+
      "login" : "admin",
      "groups": []
   }
@@ -40,8 +38,89 @@ Feature: CreateUsers
     * def wrongUser =
 """
 {
-
    "random" : "login"
+}
+"""
+
+    * def userToTestBadRequest0 =
+"""
+{
+   "login" : "",
+   "firstName" : "first name",
+   "lastName" : "last name"
+}
+"""
+
+    * def userToTestBadRequest1 =
+"""
+{
+   "login" : "a",
+   "firstName" : "first name",
+   "lastName" : "last name"
+}
+"""
+
+    * def userToTestBadRequest2 =
+"""
+{
+   "login" : "aé",
+   "firstName" : "first name",
+   "lastName" : "last name"
+}
+"""
+
+    * def userToTestBadRequest3 =
+"""
+{
+   "login" : "é",
+   "firstName" : "first name",
+   "lastName" : "last name"
+}
+"""
+
+    * def userWithValidLoginFormat0 =
+"""
+{
+   "login" : "validLoginConvertedToLowercaseLetters",
+   "firstName" : "first name",
+   "lastName" : "last name"
+}
+"""
+
+
+    * def userWithValidLoginFormat1 =
+"""
+{
+   "login" : "valid_login",
+   "firstName" : "first name",
+   "lastName" : "last name"
+}
+"""
+
+    * def userWithValidLoginFormat2 =
+"""
+{
+   "login" : "valid-login",
+   "firstName" : "first name",
+   "lastName" : "last name"
+}
+"""
+
+    * def userWithValidLoginFormat3 =
+"""
+{
+   "login" : "valid.login",
+   "firstName" : "first name",
+   "lastName" : "last name"
+}
+"""
+
+    * def userWithValidLoginFormat4 =
+"""
+{
+   "login" : "valid.login_with-digit_0",
+   "firstName" : "first name",
+   "lastName" : "last name"
 }
 """
 
@@ -53,7 +132,7 @@ Feature: CreateUsers
     And request userKarate
     When method post
     Then status 201
-    And match response.login == karate.lowerCase(userKarate.login)
+    And match response.login == userKarate.login
     And match response.firstName == userKarate.firstName
     And match response.lastName == userKarate.lastName
 
@@ -65,7 +144,7 @@ Feature: CreateUsers
     And request userUpdate
     When method post
     Then status 200
-    And match response.login == karate.lowerCase(userUpdate.login)
+    And match response.login == userUpdate.login
     And match response.firstName == userUpdate.firstName
     And match response.lastName == userUpdate.lastName
 
@@ -84,15 +163,6 @@ Feature: CreateUsers
     When method post
     Then status 403
 
-   Scenario: bad request
-        #expected response 400
-    Given url opfabUrl + 'users/users'
-   And header Authorization = 'Bearer ' + authToken
-   And request wrongUser
-    When method post
-    Then status 400
-
-    
   Scenario: Try to remove the admin user from the ADMIN group
     #post /users
     #update user, expected response 403
@@ -102,3 +172,60 @@ Feature: CreateUsers
     When method post
     Then status 403
     And match response.message == 'Removing group ADMIN from user admin is not allowed'
+
+  Scenario: bad request
+   #expected response 400
+    Given url opfabUrl + 'users/users'
+    And header Authorization = 'Bearer ' + authToken
+    And request wrongUser
+    When method post
+    Then status 400
+
+
+  Scenario Outline: bad request
+    Given url opfabUrl + 'users/users'
+    And header Authorization = 'Bearer ' + authToken
+    And request <userToTestBadRequest>
+    When method post
+    Then status 400
+    And match response.status == "BAD_REQUEST"
+    And match response.message == <expectedMessage>
+
+    Examples:
+      | userToTestBadRequest  | expectedMessage                                                                                                                            |
+      | userToTestBadRequest0 | "Mandatory 'login' field is missing."                                                                                                      |
+      | userToTestBadRequest1 | "Login should be minimum 2 characters (login=a)."                                                                                          |
+      | userToTestBadRequest2 | "Login should only contain the following characters: letters, _, -, . or digits (login=aé)."                                               |
+      | userToTestBadRequest3 | "Login should be minimum 2 characters (login=é).Login should only contain the following characters: letters, _, -, . or digits (login=é)." |
+
+
+  Scenario Outline: request successful
+    Given url opfabUrl + 'users/users'
+    And header Authorization = 'Bearer ' + authToken
+    And request <userWithValidLoginFormat>
+    When method post
+    Then status 201
+    And match response.login == <expectedLogin>
+
+    Examples:
+      | userWithValidLoginFormat  | expectedLogin                                     |
+      | userWithValidLoginFormat0 | karate.lowerCase(userWithValidLoginFormat0.login) |
+      | userWithValidLoginFormat1 | userWithValidLoginFormat1.login                   |
+      | userWithValidLoginFormat2 | userWithValidLoginFormat2.login                   |
+      | userWithValidLoginFormat3 | userWithValidLoginFormat3.login                   |
+      | userWithValidLoginFormat4 | userWithValidLoginFormat4.login                   |
+
+
+  Scenario Outline: we delete the users previously created
+    Given url opfabUrl + 'users/users/' + <login>
+    And header Authorization = 'Bearer ' + authToken
+    When method delete
+    Then status 200
+
+    Examples:
+      | login  |
+      | karate.lowerCase(userWithValidLoginFormat0.login) |
+      | userWithValidLoginFormat1.login |
+      | userWithValidLoginFormat2.login |
+      | userWithValidLoginFormat3.login |
+      | userWithValidLoginFormat4.login |

--- a/src/test/api/karate/users/deleteUser.feature
+++ b/src/test/api/karate/users/deleteUser.feature
@@ -9,12 +9,12 @@ Feature: deleteUser
 
 
     # defining user to create
-    * def userForEndpointDeleteUser =
+    * def user_for_endpoint_delete_user =
 """
 {
-   "login" : "userForEndpointDeleteUser",
-   "firstName" : "userForEndpointDeleteUser firstname",
-   "lastName" : "userForEndpointDeleteUser lastname"
+   "login" : "user_for_endpoint_delete_user",
+   "firstName" : "user_for_endpoint_delete_user firstname",
+   "lastName" : "user_for_endpoint_delete_user lastname"
 }
 """
 
@@ -30,29 +30,29 @@ Feature: deleteUser
   Scenario: create a new user
     Given url opfabUrl + 'users/users'
     And header Authorization = 'Bearer ' + authToken
-    And request userForEndpointDeleteUser
+    And request user_for_endpoint_delete_user
     When method post
     Then status 201
-    And match response.login == karate.lowerCase(userForEndpointDeleteUser.login)
-    And match response.firstName == userForEndpointDeleteUser.firstName
-    And match response.lastName == userForEndpointDeleteUser.lastName
+    And match response.login == user_for_endpoint_delete_user.login
+    And match response.firstName == user_for_endpoint_delete_user.firstName
+    And match response.lastName == user_for_endpoint_delete_user.lastName
 
 
   Scenario: we check that the user created previously exists
-    Given url opfabUrl + 'users/users/' + karate.lowerCase(userForEndpointDeleteUser.login)
+    Given url opfabUrl + 'users/users/' + user_for_endpoint_delete_user.login
     And header Authorization = 'Bearer ' + authToken
     When method get
     Then status 200
 
 
   Scenario: delete user with no authentication, expected response 401
-    Given url opfabUrl + 'users/users/' + karate.lowerCase(userForEndpointDeleteUser.login)
+    Given url opfabUrl + 'users/users/' + user_for_endpoint_delete_user.login
     When method delete
     Then status 401
 
 
   Scenario: delete user with no admin authentication (with operator1_fr authentication), expected response 403
-    Given url opfabUrl + 'users/users/' + karate.lowerCase(userForEndpointDeleteUser.login)
+    Given url opfabUrl + 'users/users/' + user_for_endpoint_delete_user.login
     And header Authorization = 'Bearer ' + authTokenAsTSO
     When method delete
     Then status 403
@@ -66,14 +66,14 @@ Feature: deleteUser
 
 
   Scenario: delete user (with admin authentication), expected response 200
-    Given url opfabUrl + 'users/users/' + karate.lowerCase(userForEndpointDeleteUser.login)
+    Given url opfabUrl + 'users/users/' + user_for_endpoint_delete_user.login
     And header Authorization = 'Bearer ' + authToken
     When method delete
     Then status 200
 
 
   Scenario: we check that the user doesn't exist anymore, expected response 404
-    Given url opfabUrl + 'users/users/' + karate.lowerCase(userForEndpointDeleteUser.login)
+    Given url opfabUrl + 'users/users/' + user_for_endpoint_delete_user.login
     And header Authorization = 'Bearer ' + authToken
     When method get
     Then status 404

--- a/src/test/api/karate/users/entities/checkEntityGroupManagement.feature
+++ b/src/test/api/karate/users/entities/checkEntityGroupManagement.feature
@@ -95,7 +95,7 @@ Feature: CheckEntityGroupManagement
     | entity2_RefToEntity4          | 201       |
     | entity3_RefToEntity2          | 201       |
 
-        # Chech the correct detection of cycle
+        # Check the correct detection of cycle
     Scenario Outline: Adding entities with parents declaration results to a cycle detection
 
         Given url opfabUrl + 'users/entities'

--- a/src/test/api/karate/users/entities/deleteUserFromEntity.feature
+++ b/src/test/api/karate/users/entities/deleteUserFromEntity.feature
@@ -22,7 +22,7 @@ Feature: deleteUserFromEntity
     * def userKarate2 =
 """
 {
-   "login" : "loginKarate2",
+   "login" : "loginkarate2",
    "firstName" : "name2",
    "lastName" : "familyname2"
 }
@@ -51,7 +51,7 @@ Feature: deleteUserFromEntity
     And request userKarate2
     When method post
     Then status 200
-    And match response.login == karate.lowerCase(userKarate2.login)
+    And match response.login == userKarate2.login
     And match response.firstName == userKarate2.firstName
     And match response.lastName == userKarate2.lastName
 
@@ -67,14 +67,14 @@ Feature: deleteUserFromEntity
 
   Scenario: Delete user from an entity (with operator1_fr authentication)
     #Given url opfabUrl + 'users/entities/' + entityDeletedFrom + '/users/' + userToDelete
-    Given url opfabUrl + 'users/entities/' + entityKarate2.id  + '/users/' + karate.lowerCase(userKarate2.login)
+    Given url opfabUrl + 'users/entities/' + entityKarate2.id  + '/users/' + userKarate2.login
     And header Authorization = 'Bearer ' + authTokenAsTSO
     When method delete
     Then status 403
 
 
   Scenario: No authentication, expected response 401
-    Given url opfabUrl + 'users/entities/' + entityKarate2.id  + '/users/' + karate.lowerCase(userKarate2.login)
+    Given url opfabUrl + 'users/entities/' + entityKarate2.id  + '/users/' + userKarate2.login
     When method delete
     Then status 401
 
@@ -82,7 +82,7 @@ Feature: deleteUserFromEntity
   Scenario: Delete user from a non-existent entity
   #  non-existent entity, expected response 404
     Given def userToDelete = 'operator3_fr'
-    Given url opfabUrl + 'users/entities/' + 'entityNonExistent'  + '/users/' + karate.lowerCase(userKarate2.login)
+    Given url opfabUrl + 'users/entities/' + 'entityNonExistent'  + '/users/' + userKarate2.login
     And header Authorization = 'Bearer ' + authToken
     When method delete
     Then status 404
@@ -90,7 +90,7 @@ Feature: deleteUserFromEntity
 
   #delete /entities/{id}/users/{login}
   Scenario: Delete user from an entity (with admin authentication)
-    Given url opfabUrl + 'users/entities/' + entityKarate2.id  + '/users/' + karate.lowerCase(userKarate2.login)
+    Given url opfabUrl + 'users/entities/' + entityKarate2.id  + '/users/' + userKarate2.login
     And header Authorization = 'Bearer ' + authToken
     When method delete
     Then status 200

--- a/src/test/api/karate/users/entities/updateListOfEntityUsers.feature
+++ b/src/test/api/karate/users/entities/updateListOfEntityUsers.feature
@@ -16,7 +16,7 @@ Feature: Update list of entity users
     * def userKarate3 =
 """
 {
-   "login" : "loginKarate3",
+   "login" : "loginkarate3",
    "firstName" : "name3",
    "lastName" : "familyName3"
 }
@@ -25,7 +25,7 @@ Feature: Update list of entity users
     * def userKarate4 =
 """
 {
-   "login" : "loginKarate4",
+   "login" : "loginkarate4",
    "firstName" : "name4",
    "lastName" : "familyName4"
 }
@@ -34,7 +34,7 @@ Feature: Update list of entity users
     * def userKarate6 =
 """
 {
-   "login" : "loginKarate6",
+   "login" : "loginkarate6",
    "firstName" : "name6",
    "lastName" : "familyName6"
 }
@@ -62,7 +62,7 @@ Feature: Update list of entity users
     And request userKarate3
     When method post
     Then status 200
-    And match response.login == karate.lowerCase(userKarate3.login)
+    And match response.login == userKarate3.login
     And match response.firstName == userKarate3.firstName
     And match response.lastName == userKarate3.lastName
 
@@ -75,7 +75,7 @@ Feature: Update list of entity users
     And request userKarate4
     When method post
     Then status 200
-    And match response.login == karate.lowerCase(userKarate4.login)
+    And match response.login == userKarate4.login
     And match response.firstName == userKarate4.firstName
     And match response.lastName == userKarate4.lastName
 
@@ -88,7 +88,7 @@ Feature: Update list of entity users
     And request userKarate6
     When method post
     Then status 200
-    And match response.login == karate.lowerCase(userKarate6.login)
+    And match response.login == userKarate6.login
     And match response.firstName == userKarate6.firstName
     And match response.lastName == userKarate6.lastName
 
@@ -102,7 +102,7 @@ Feature: Update list of entity users
 
 
   Scenario: Check that userKarate6 belongs to the entity
-    Given url opfabUrl + 'users/users/' + karate.lowerCase(userKarate6.login)
+    Given url opfabUrl + 'users/users/' + userKarate6.login
     And header Authorization = 'Bearer ' + authToken
     When method get
     Then status 200
@@ -142,7 +142,7 @@ Feature: Update list of entity users
 
 
   Scenario: Check that userKarate3 belongs to the entity
-    Given url opfabUrl + 'users/users/' + karate.lowerCase(userKarate3.login)
+    Given url opfabUrl + 'users/users/' + userKarate3.login
     And header Authorization = 'Bearer ' + authToken
     When method get
     Then status 200
@@ -150,7 +150,7 @@ Feature: Update list of entity users
 
 
   Scenario: Check that userKarate4 belongs to the entity
-    Given url opfabUrl + 'users/users/' + karate.lowerCase(userKarate4.login)
+    Given url opfabUrl + 'users/users/' + userKarate4.login
     And header Authorization = 'Bearer ' + authToken
     When method get
     Then status 200
@@ -158,7 +158,7 @@ Feature: Update list of entity users
 
 
   Scenario: Check that userKarate6 no longer belongs to the entity
-    Given url opfabUrl + 'users/users/' + karate.lowerCase(userKarate6.login)
+    Given url opfabUrl + 'users/users/' + userKarate6.login
     And header Authorization = 'Bearer ' + authToken
     When method get
     Then status 200

--- a/src/test/api/karate/users/fetchUserSettings.feature
+++ b/src/test/api/karate/users/fetchUserSettings.feature
@@ -6,7 +6,7 @@ Feature: fetch user settings
     * def authToken = signIn.authToken
     * def signInAsTSO = callonce read('../common/getToken.feature') { username: 'operator1_fr'}
     * def authTokenAsTSO = signInAsTSO.authToken
-    * def userToFetch = 'loginKarate1'
+    * def userToFetch = 'loginkarate1'
 
 
   Scenario: Fetch user settings

--- a/src/test/api/karate/users/groups/createGroups.feature
+++ b/src/test/api/karate/users/groups/createGroups.feature
@@ -43,6 +43,78 @@ Feature: CreateGroups
   }
   """
 
+    * def groupToTestBadRequest0 =
+"""
+{
+   "id" : "",
+   "name" : "group name",
+   "description" : "group description"
+}
+"""
+
+    * def groupToTestBadRequest1 =
+"""
+{
+   "id" : "a",
+   "name" : "group name",
+   "description" : "group description"
+}
+"""
+
+    * def groupToTestBadRequest2 =
+"""
+{
+   "id" : "aé",
+   "name" : "group name",
+   "description" : "group description"
+}
+"""
+
+    * def groupToTestBadRequest3 =
+"""
+{
+   "id" : "é",
+   "name" : "group name",
+   "description" : "group description"
+}
+"""
+
+    * def groupWithValidIdFormat0 =
+"""
+{
+   "id" : "validId",
+   "name" : "group name",
+   "description" : "group description"
+}
+"""
+
+    * def groupWithValidIdFormat1 =
+"""
+{
+   "id" : "valid_id",
+   "name" : "group name",
+   "description" : "group description"
+}
+"""
+
+    * def groupWithValidIdFormat2 =
+"""
+{
+   "id" : "valid-id",
+   "name" : "group name",
+   "description" : "group description"
+}
+"""
+
+    * def groupWithValidIdFormat3 =
+"""
+{
+   "id" : "validId_with-digit_0",
+   "name" : "group name",
+   "description" : "group description"
+}
+"""
+
   Scenario: Create Groups
 
 #Create new group (check if the group already exists otherwise it will return 200)
@@ -103,3 +175,50 @@ Feature: CreateGroups
     And request wrongPerimeterGroup
     When method post
     Then status 400
+
+
+  Scenario Outline: Bad request
+    Given url opfabUrl + 'users/groups'
+    And header Authorization = 'Bearer ' + authToken
+    And request <groupToTestBadRequest>
+    When method post
+    Then status 400
+    And match response.status == "BAD_REQUEST"
+    And match response.message == <expectedMessage>
+
+    Examples:
+      | groupToTestBadRequest  | expectedMessage                                                                                                            |
+      | groupToTestBadRequest0 | "Id is required."                                                                                                           |
+      | groupToTestBadRequest1 | "Id should be minimum 2 characters (id=a)."                                                                                 |
+      | groupToTestBadRequest2 | "Id should only contain the following characters: letters, _, - or digits (id=aé)."                                         |
+      | groupToTestBadRequest3 | "Id should be minimum 2 characters (id=é).Id should only contain the following characters: letters, _, - or digits (id=é)." |
+
+
+  Scenario Outline: Create group with valid id format
+    Given url opfabUrl + 'users/groups'
+    And header Authorization = 'Bearer ' + authToken
+    And request <groupWithValidIdFormat>
+    When method post
+    Then status 201
+    And match response.id == <expectedGroupId>
+
+    Examples:
+      | groupWithValidIdFormat  | expectedGroupId            |
+      | groupWithValidIdFormat0 | groupWithValidIdFormat0.id |
+      | groupWithValidIdFormat1 | groupWithValidIdFormat1.id |
+      | groupWithValidIdFormat2 | groupWithValidIdFormat2.id |
+      | groupWithValidIdFormat3 | groupWithValidIdFormat3.id |
+
+
+  Scenario Outline: we delete the groups previously created
+    Given url opfabUrl + 'users/groups/' + <groupId>
+    And header Authorization = 'Bearer ' + authToken
+    When method delete
+    Then status 200
+
+    Examples:
+      | groupId  |
+      | groupWithValidIdFormat0.id |
+      | groupWithValidIdFormat1.id |
+      | groupWithValidIdFormat2.id |
+      | groupWithValidIdFormat3.id |

--- a/src/test/api/karate/users/groups/deleteUserFromGroup.feature
+++ b/src/test/api/karate/users/groups/deleteUserFromGroup.feature
@@ -21,7 +21,7 @@ Feature: deleteUserFromGroup
     * def userKarate2 =
 """
 {
-   "login" : "loginKarate2",
+   "login" : "loginkarate2",
    "firstName" : "name2",
    "lastName" : "familyname2"
 }
@@ -50,7 +50,7 @@ Feature: deleteUserFromGroup
     And request userKarate2
     When method post
     Then status 201
-    And match response.login == karate.lowerCase(userKarate2.login)
+    And match response.login == userKarate2.login
     And match response.firstName == userKarate2.firstName
     And match response.lastName == userKarate2.lastName
 
@@ -66,14 +66,14 @@ Feature: deleteUserFromGroup
 
   Scenario: Delete user from a group (with operator1_fr authentication)
     #Given url opfabUrl + 'users/groups/' + groupDeletedFrom + '/users/' + userToDelete
-    Given url opfabUrl + 'users/groups/' + groupKarate2.id  + '/users/' + karate.lowerCase(userKarate2.login)
+    Given url opfabUrl + 'users/groups/' + groupKarate2.id  + '/users/' + userKarate2.login
     And header Authorization = 'Bearer ' + authTokenAsTSO
     When method delete
     Then status 403
 
 
   Scenario: No authentication, expected response 401
-    Given url opfabUrl + 'users/groups/' + groupKarate2.id  + '/users/' + karate.lowerCase(userKarate2.login)
+    Given url opfabUrl + 'users/groups/' + groupKarate2.id  + '/users/' + userKarate2.login
     When method delete
     Then status 401
 
@@ -81,7 +81,7 @@ Feature: deleteUserFromGroup
   Scenario: Delete user from a non-existent group
   #  non-existent group, expected response 404
     Given def userToDelete = 'operator3_fr'
-    Given url opfabUrl + 'users/groups/' + 'groupNonExistent'  + '/users/' + karate.lowerCase(userKarate2.login)
+    Given url opfabUrl + 'users/groups/' + 'groupNonExistent'  + '/users/' + userKarate2.login
     And header Authorization = 'Bearer ' + authToken
     When method delete
     Then status 404
@@ -89,7 +89,7 @@ Feature: deleteUserFromGroup
 
   #delete /groups/{name}/users/{login}
   Scenario: Delete user from a group (with admin authentication)
-    Given url opfabUrl + 'users/groups/' + groupKarate2.id  + '/users/' + karate.lowerCase(userKarate2.login)
+    Given url opfabUrl + 'users/groups/' + groupKarate2.id  + '/users/' + userKarate2.login
     And header Authorization = 'Bearer ' + authToken
     When method delete
     Then status 200

--- a/src/test/api/karate/users/groups/updateListOfGroupUsers.feature
+++ b/src/test/api/karate/users/groups/updateListOfGroupUsers.feature
@@ -16,7 +16,7 @@ Feature: Update list of group users
     * def userKarate3 =
 """
 {
-   "login" : "loginKarate3",
+   "login" : "loginkarate3",
    "firstName" : "name3",
    "lastName" : "familyName3"
 }
@@ -25,7 +25,7 @@ Feature: Update list of group users
     * def userKarate4 =
 """
 {
-   "login" : "loginKarate4",
+   "login" : "loginkarate4",
    "firstName" : "name4",
    "lastName" : "familyName4"
 }
@@ -34,7 +34,7 @@ Feature: Update list of group users
     * def userKarate6 =
 """
 {
-   "login" : "loginKarate6",
+   "login" : "loginkarate6",
    "firstName" : "name6",
    "lastName" : "familyName6"
 }
@@ -62,7 +62,7 @@ Feature: Update list of group users
     And request userKarate3
     When method post
     Then status 201
-    And match response.login == karate.lowerCase(userKarate3.login)
+    And match response.login == userKarate3.login
     And match response.firstName == userKarate3.firstName
     And match response.lastName == userKarate3.lastName
 
@@ -75,7 +75,7 @@ Feature: Update list of group users
     And request userKarate4
     When method post
     Then status 201
-    And match response.login == karate.lowerCase(userKarate4.login)
+    And match response.login == userKarate4.login
     And match response.firstName == userKarate4.firstName
     And match response.lastName == userKarate4.lastName
 
@@ -88,7 +88,7 @@ Feature: Update list of group users
     And request userKarate6
     When method post
     Then status 201
-    And match response.login == karate.lowerCase(userKarate6.login)
+    And match response.login == userKarate6.login
     And match response.firstName == userKarate6.firstName
     And match response.lastName == userKarate6.lastName
 
@@ -102,7 +102,7 @@ Feature: Update list of group users
 
 
   Scenario: Check that userKarate6 belongs to the group
-    Given url opfabUrl + 'users/users/' + karate.lowerCase(userKarate6.login)
+    Given url opfabUrl + 'users/users/' + userKarate6.login
     And header Authorization = 'Bearer ' + authToken
     When method get
     Then status 200
@@ -142,7 +142,7 @@ Feature: Update list of group users
 
 
   Scenario: Check that userKarate3 belongs to the group
-    Given url opfabUrl + 'users/users/' + karate.lowerCase(userKarate3.login)
+    Given url opfabUrl + 'users/users/' + userKarate3.login
     And header Authorization = 'Bearer ' + authToken
     When method get
     Then status 200
@@ -150,7 +150,7 @@ Feature: Update list of group users
 
 
   Scenario: Check that userKarate4 belongs to the group
-    Given url opfabUrl + 'users/users/' + karate.lowerCase(userKarate4.login)
+    Given url opfabUrl + 'users/users/' + userKarate4.login
     And header Authorization = 'Bearer ' + authToken
     When method get
     Then status 200
@@ -158,7 +158,7 @@ Feature: Update list of group users
 
 
   Scenario: Check that userKarate6 no longer belongs to the group
-    Given url opfabUrl + 'users/users/' + karate.lowerCase(userKarate6.login)
+    Given url opfabUrl + 'users/users/' + userKarate6.login
     And header Authorization = 'Bearer ' + authToken
     When method get
     Then status 200

--- a/src/test/api/karate/users/ipControl.feature
+++ b/src/test/api/karate/users/ipControl.feature
@@ -113,7 +113,7 @@ Feature: Client ip control
     And request userAuthorizedIPAddressesUpdate
     When method put
     Then assert responseStatus == 200 || responseStatus == 201
-    And match response.login == karate.lowerCase(userAuthorizedIPAddressesUpdate.login)
+    And match response.login == userAuthorizedIPAddressesUpdate.login
     And match response.authorizedIPAddresses contains '10.0.2.2'
     And match response.authorizedIPAddresses contains '10.0.3.3'
 
@@ -214,7 +214,7 @@ Scenario Outline: Check direct calls from authorized ip are accepted
     And request userEmptyAuthorizedIPAddressesUpdate
     When method put
     Then status 200
-    And match response.login == karate.lowerCase(userAuthorizedIPAddressesUpdate.login)
+    And match response.login == userAuthorizedIPAddressesUpdate.login
     And match response.authorizedIPAddresses == []
 
 

--- a/src/test/api/karate/users/patchUserSettings.feature
+++ b/src/test/api/karate/users/patchUserSettings.feature
@@ -13,7 +13,7 @@ Feature: patch user settings
     * def userSettings =
 """
 {
-  "login" : "loginKarate1",
+  "login" : "loginkarate1",
   "description" : "my dummy user",
   "locale" : "en",
   "processesStatesNotNotified": {"processA": ["state1", "state2"], "processB": ["state3", "state4"]},

--- a/src/test/api/karate/users/perimeters/createPerimeters.feature
+++ b/src/test/api/karate/users/perimeters/createPerimeters.feature
@@ -52,6 +52,77 @@ Feature: CreatePerimeters (endpoint tested : POST /perimeters)
 }
 """
 
+    * def perimeterToTestBadRequest0 =
+"""
+{
+   "id" : "",
+   "name" : "perimeter name",
+   "description" : "perimeter description"
+}
+"""
+
+    * def perimeterToTestBadRequest1 =
+"""
+{
+   "id" : "a",
+   "name" : "perimeter name",
+   "description" : "perimeter description"
+}
+"""
+
+    * def perimeterToTestBadRequest2 =
+"""
+{
+   "id" : "aé",
+   "name" : "perimeter name",
+   "description" : "perimeter description"
+}
+"""
+
+    * def perimeterToTestBadRequest3 =
+"""
+{
+   "id" : "é",
+   "name" : "perimeter name",
+   "description" : "perimeter description"
+}
+"""
+
+    * def perimeterWithValidIdFormat0 =
+"""
+{
+   "id" : "validId",
+   "name" : "perimeter name",
+   "description" : "perimeter description"
+}
+"""
+
+    * def perimeterWithValidIdFormat1 =
+"""
+{
+   "id" : "valid_id",
+   "name" : "perimeter name",
+   "description" : "perimeter description"
+}
+"""
+
+    * def perimeterWithValidIdFormat2 =
+"""
+{
+   "id" : "valid-id",
+   "name" : "perimeter name",
+   "description" : "perimeter description"
+}
+"""
+
+    * def perimeterWithValidIdFormat3 =
+"""
+{
+   "id" : "validId_with-digit_0",
+   "name" : "perimeter name",
+   "description" : "perimeter description"
+}
+"""
 
   Scenario: Create Perimeters
   #Create new perimeter (check if the perimeter already exists otherwise it will return 200)
@@ -104,3 +175,50 @@ Feature: CreatePerimeters (endpoint tested : POST /perimeters)
     And request wrongPerimeter
     When method post
     Then status 400
+
+
+  Scenario Outline: Bad request
+    Given url opfabUrl + 'users/perimeters'
+    And header Authorization = 'Bearer ' + authToken
+    And request <perimeterToTestBadRequest>
+    When method post
+    Then status 400
+    And match response.status == "BAD_REQUEST"
+    And match response.message == <expectedMessage>
+
+    Examples:
+      | perimeterToTestBadRequest  | expectedMessage                                                                                                             |
+      | perimeterToTestBadRequest0 | "Id is required."                                                                                                           |
+      | perimeterToTestBadRequest1 | "Id should be minimum 2 characters (id=a)."                                                                                 |
+      | perimeterToTestBadRequest2 | "Id should only contain the following characters: letters, _, - or digits (id=aé)."                                         |
+      | perimeterToTestBadRequest3 | "Id should be minimum 2 characters (id=é).Id should only contain the following characters: letters, _, - or digits (id=é)." |
+
+
+  Scenario Outline: Create perimeter with valid id format
+    Given url opfabUrl + 'users/perimeters'
+    And header Authorization = 'Bearer ' + authToken
+    And request <perimeterWithValidIdFormat>
+    When method post
+    Then status 201
+    And match response.id == <expectedPerimeterId>
+
+    Examples:
+      | perimeterWithValidIdFormat  | expectedPerimeterId            |
+      | perimeterWithValidIdFormat0 | perimeterWithValidIdFormat0.id |
+      | perimeterWithValidIdFormat1 | perimeterWithValidIdFormat1.id |
+      | perimeterWithValidIdFormat2 | perimeterWithValidIdFormat2.id |
+      | perimeterWithValidIdFormat3 | perimeterWithValidIdFormat3.id |
+
+
+  Scenario Outline: we delete the perimeters previously created
+    Given url opfabUrl + 'users/perimeters/' + <perimeterId>
+    And header Authorization = 'Bearer ' + authToken
+    When method delete
+    Then status 200
+
+    Examples:
+      | perimeterId  |
+      | perimeterWithValidIdFormat0.id |
+      | perimeterWithValidIdFormat1.id |
+      | perimeterWithValidIdFormat2.id |
+      | perimeterWithValidIdFormat3.id |

--- a/src/test/api/karate/users/perimeters/getPerimetersForAUser.feature
+++ b/src/test/api/karate/users/perimeters/getPerimetersForAUser.feature
@@ -10,9 +10,9 @@ Feature: Get perimeters for a user (endpoint tested : GET /users/{login}/perimet
     * def user10 =
 """
 {
-   "login" : "loginKarate10",
-   "firstName" : "loginKarate10 firstName",
-   "lastName" : "loginKarate10 lastName"
+   "login" : "loginkarate10",
+   "firstName" : "loginkarate10 firstName",
+   "lastName" : "loginkarate10 lastName"
 }
 """
 
@@ -95,7 +95,7 @@ Feature: Get perimeters for a user (endpoint tested : GET /users/{login}/perimet
     And request user10
     When method post
     Then status 201
-    And match response.login == karate.lowerCase(user10.login)
+    And match response.login == user10.login
     And match response.firstName == user10.firstName
     And match response.lastName == user10.lastName
 
@@ -177,14 +177,14 @@ Feature: Get perimeters for a user (endpoint tested : GET /users/{login}/perimet
 
 
   Scenario: get all perimeters for user10 without authentication
-    Given url opfabUrl + 'users/users/' + karate.lowerCase(user10.login) + '/perimeters'
+    Given url opfabUrl + 'users/users/' + user10.login + '/perimeters'
     When method get
     Then status 401
 
 
   Scenario: get all perimeters for user10 with simple user
     #   Using TSO user,  expected response 403
-    Given url opfabUrl + 'users/users/' + karate.lowerCase(user10.login) + '/perimeters'
+    Given url opfabUrl + 'users/users/' + user10.login + '/perimeters'
     And header Authorization = 'Bearer ' + authTokenAsTSO
     When method get
     Then status 403
@@ -200,7 +200,7 @@ Feature: Get perimeters for a user (endpoint tested : GET /users/{login}/perimet
 
 
   Scenario: get all perimeters for user10
-    Given url opfabUrl + 'users/users/' + karate.lowerCase(user10.login) + '/perimeters'
+    Given url opfabUrl + 'users/users/' + user10.login + '/perimeters'
     And header Authorization = 'Bearer ' + authToken
     When method get
     Then status 200

--- a/src/test/api/karate/users/updateExistingUser.feature
+++ b/src/test/api/karate/users/updateExistingUser.feature
@@ -12,7 +12,7 @@ Feature: Update existing user
     * def userNew =
 """
 {
-  "login" : "loginKarate5",
+  "login" : "loginkarate5",
   "firstName" : "name",
   "lastName" : "last name"
 }
@@ -21,7 +21,7 @@ Feature: Update existing user
     * def userUpdate =
 """
 {
-  "login" : "loginKarate5",
+  "login" : "loginkarate5",
   "firstName" : "name update Karate5",
   "lastName" : "last name update Karate5",
   "authorizedIPAddresses" : ['127.0.0.1','192.168.0.1']
@@ -31,7 +31,7 @@ Feature: Update existing user
     * def fakeUser =
 """
 {
-  "fake" : "NewUser"
+  "fake" : "newuser"
 }
 """
     #Endpoint tested put /users/{login}
@@ -69,7 +69,7 @@ Feature: Update existing user
     And request userNew
     When method put
     Then status 201
-    And match response.login == karate.lowerCase(userNew.login)
+    And match response.login == userNew.login
     And match response.firstName == userNew.firstName
     And match response.lastName == userNew.lastName
 
@@ -81,7 +81,7 @@ Feature: Update existing user
     And request userUpdate
     When method put
     Then status 200
-    And match response.login == karate.lowerCase(userUpdate.login)
+    And match response.login == userUpdate.login
     And match response.firstName == userUpdate.firstName
     And match response.lastName == userUpdate.lastName
     And match response.authorizedIPAddresses contains '127.0.0.1'


### PR DESCRIPTION
I've chosen to forbid uppercase letters in login and so, to delete calls to toLowerCase() functions to convert login. 
To be discussed maybe ?

- In release note :
  -  In chapter :  Features
  -  Text : #1318 : Resource identifiers should only contain letters, digits, dashes or underscores