### PR TITLE
Add option to not refuse sending card if process or state does not exists (#3543)

### DIFF
--- a/config/dev/cards-publication-dev.yml
+++ b/config/dev/cards-publication-dev.yml
@@ -58,3 +58,5 @@ external-recipients:
 
 
 checkAuthenticationForCardSending: true
+
+authorizeToSendCardWithInvalidProcessState: false

--- a/services/cards-publication/src/main/java/org/opfab/cards/publication/services/CardProcessingService.java
+++ b/services/cards-publication/src/main/java/org/opfab/cards/publication/services/CardProcessingService.java
@@ -70,6 +70,8 @@ public class CardProcessingService {
 
     @Value("${checkAuthenticationForCardSending:true}") boolean checkAuthenticationForCardSending;
 
+    @Value("${authorizeToSendCardWithInvalidProcessState:false}") boolean authorizeToSendCardWithInvalidProcessState;
+
     public static final String UNEXISTING_PROCESS_STATE = "Impossible to publish card because process and/or state does not exist (process=%1$s, state=%2$s, processVersion=%3$s, processInstanceId=%4$s)";
    
 
@@ -100,7 +102,7 @@ public class CardProcessingService {
 
     private void processOneCard(CardPublicationData card, Optional<CurrentUserWithPerimeters> user, Optional<Jwt> jwt) {
         validate(card);
-        checkProcessStateExistsInBundles(card);
+        if (!authorizeToSendCardWithInvalidProcessState) checkProcessStateExistsInBundles(card);
         card.prepare(Instant.ofEpochMilli(Instant.now().toEpochMilli()));
         cardTranslationService.translate(card);
 

--- a/src/docs/asciidoc/deployment/configuration/configuration.adoc
+++ b/src/docs/asciidoc/deployment/configuration/configuration.adoc
@@ -112,6 +112,7 @@ The cards-publication service has these specific properties :
 |name|default|mandatory?|Description
 
 |checkAuthenticationForCardSending|true|no|If false, OperatorFabric will not require user authentication to send or delete a card via endpoint /cards (it does not concern user cards which always need authentication). Be careful when setting the value to false, nginx conf must be adapted for security reasons (see security warning in link:https://github.com/opfab/operatorfabric-core/blob/master/config/docker/nginx.conf[the reference nginx.conf])
+|authorizeToSendCardWithInvalidProcessState|false|no|If true, OperatorFabric will allow to publish a card referring a not existent process or state 
 |spring.kafka.consumer.group-id |null|no| If set, support for receiving cards via Kafka is enabled
 |spring.deserializer.value.delegate.class|io.confluent.kafka.serializers.
 KafkaAvroDeserializer|yes| Deserializer used to convert the received bytes into objects

--- a/src/docs/asciidoc/resources/migration_guide_to_3.10.adoc
+++ b/src/docs/asciidoc/resources/migration_guide_to_3.10.adoc
@@ -7,6 +7,10 @@
 
 = Migration Guide from release 3.9.x to release 3.10.0
 
+== Card publication with not existent process or state
+OperatorFabric will refuse the publication of cards referring a not existent process or state.
+To allow the publication of cards with not existent proces or state you should set the `authorizeToSendCardWithInvalidProcessState` property to `true` in `cards-publication.yml` configuration file 
+
 == `web-ui.json` config file 
 
 === `settings.about` section


### PR DESCRIPTION
Fix #3543 

Signed-off-by: Giovanni Ferrari <giovanni.ferrari@soft.it>

- In release note :
  -  In chapter :  Features
  -  Text : #3543 : Add option to not refuse sending card if process or state does not exists 