### PR TITLE
Add card sorting by start and end date (#3565)

### DIFF
--- a/ui/main/src/app/modules/feed/components/card-list/filters/feed-sort/feed-sort.component.html
+++ b/ui/main/src/app/modules/feed/components/card-list/filters/feed-sort/feed-sort.component.html
@@ -1,4 +1,4 @@
-<!-- Copyright (c) 2018-2021, RTE (http://www.rte-france.com)              -->
+<!-- Copyright (c) 2018-2022, RTE (http://www.rte-france.com)              -->
 <!-- See AUTHORS.txt                                                       -->
 <!-- This Source Code Form is subject to the terms of the Mozilla Public   -->
 <!-- License, v. 2.0. If a copy of the MPL was not distributed with this   -->
@@ -25,6 +25,16 @@
 
         <label *ngIf="!hideSeveritySort" class="opfab-radio-button"> <span  translate> feed.sort.severity</span>
             <input type="radio"  id="opfab-feed-filter-severity" formControlName="sortControl" value="severity">
+            <span class="opfab-radio-button-checkmark"></span>
+        </label>
+
+        <label class="opfab-radio-button"> <span  translate> feed.sort.startDate</span>
+            <input type="radio"  id="opfab-feed-filter-start-date" formControlName="sortControl" value="startDate">
+            <span class="opfab-radio-button-checkmark"></span>
+        </label>
+
+        <label class="opfab-radio-button"> <span  translate> feed.sort.endDate</span>
+            <input type="radio"  id="opfab-feed-filter-end-date" formControlName="sortControl" value="endDate">
             <span class="opfab-radio-button-checkmark"></span>
         </label>
     </form>

--- a/ui/main/src/app/services/lightcards/sort.service.ts
+++ b/ui/main/src/app/services/lightcards/sort.service.ts
@@ -33,6 +33,10 @@ export class SortService {
                 return compareByReadPublishDate;
             case 'severity':
                 return compareBySeverityPublishDate;
+            case 'startDate':
+                return compareByStartDate;
+            case 'endDate':
+                return compareByEndDate;
             default:
                 return compareByPublishDate;
         }
@@ -92,4 +96,14 @@ export function compareByReadPublishDate(card1: LightCard, card2: LightCard) {
         result = compareByPublishDate(card1, card2);
     }
     return result;
+}
+
+export function compareByStartDate(card1: LightCard, card2: LightCard) {
+    return card1.startDate - card2.startDate;
+}
+
+export function compareByEndDate(card1: LightCard, card2: LightCard) {
+    const date1 = !!card1.endDate ? card1.endDate: card1.startDate;
+    const date2 = !!card2.endDate ? card2.endDate: card2.startDate;
+    return date1 - date2;
 }

--- a/ui/main/src/assets/i18n/en.json
+++ b/ui/main/src/assets/i18n/en.json
@@ -171,9 +171,11 @@
     },
     "sort": {
       "title": "Sort by",
-      "severity": "Criticality then date",
-      "publish": "Date",
-      "unread": "Unread then date"
+      "severity": "Criticality then reception date",
+      "publish": "Reception date",
+      "unread": "Unread then reception date",
+      "startDate": "Start date",
+      "endDate": "End date"
     },
     "tips": {
       "acknowledged": "Acknowledged",

--- a/ui/main/src/assets/i18n/fr.json
+++ b/ui/main/src/assets/i18n/fr.json
@@ -171,9 +171,11 @@
     },
     "sort": {
       "title": "Triées par",
-      "severity": "Criticité puis date ",
-      "publish": "Date",
-      "unread": "Non lu puis date"
+      "severity": "Criticité puis date de réception",
+      "publish": "Date de réception",
+      "unread": "Non lu puis date de réception",
+      "startDate": "Date de début",
+      "endDate": "Date de fin"
     },
     "tips": {
       "acknowledged": "Acquittée",

--- a/ui/main/src/assets/i18n/nl.json
+++ b/ui/main/src/assets/i18n/nl.json
@@ -171,9 +171,11 @@
     },
     "sort": {
       "title": "Sorteer op",
-      "severity": "Ernst en dan datum",
-      "publish": "Datum",
-      "unread": "Ongelezen en dan datum"
+      "severity": "Ernst en dan ontvangstdatum",
+      "publish": "Ontvangstdatum",
+      "unread": "Ongelezen en dan ontvangstdatum",
+      "startDate": "Startdatum",
+      "endDate": "Einddatum"
     },
     "tips": {
       "acknowledged": "Bevestigd",


### PR DESCRIPTION
Fix #3565

Signed-off-by: Giovanni Ferrari <giovanni.ferrari@soft.it>

- In release note :
  -  In chapter :  Features
  -  Text : #3565 Add option to sort cards by start and end date