### PR TITLE
Set eslint control to ecma script version 2017

### DIFF
--- a/ui/main/.eslintrc.json
+++ b/ui/main/.eslintrc.json
@@ -3,12 +3,16 @@
   "ignorePatterns": [
     "projects/**/*"
   ],
+  "env": {
+    "es6":true
+  },
   "overrides": [
     {
       "files": [
         "*.ts"
       ],
       "parserOptions": {
+        "ecmaVersion": 2017,
         "project": [
           "tsconfig.json"
         ],


### PR DESCRIPTION
This will in particular avoid having error when using keyword const in js scripts

Nothing in release note 