### PR TITLE
Ag-grid tables : cursor not the good one on the left part of columns titles (#3635)

### DIFF
--- a/ui/main/src/scss/styles.scss
+++ b/ui/main/src/scss/styles.scss
@@ -517,6 +517,17 @@ body {
     .ag-cell-wrap-text {
         word-break: normal;
     }
+
+    .ag-header-cell-sortable {
+        cursor: default;
+        .ag-header-cell-label {
+            cursor: pointer;
+        }
+    }
+
+    .ag-header-cell-menu-button {
+        cursor: pointer;
+    }
 }
 
 .opfab-monitoring-ag-grid-row {


### PR DESCRIPTION
- In release note :
  -  In chapter : Bugs
  -  Text : #3635 : Ag-grid tables : cursor not the good one on the left part of columns titles