### PR TITLE
When process name is long, it overlaps the following process name in notification configuration screen (#3665)

### DIFF
--- a/ui/main/src/app/modules/feedconfiguration/feedconfiguration.component.html
+++ b/ui/main/src/app/modules/feedconfiguration/feedconfiguration.component.html
@@ -1,4 +1,4 @@
-<!-- Copyright (c) 2020-2021, RTE (http://www.rte-france.com)              -->
+<!-- Copyright (c) 2020-2022, RTE (http://www.rte-france.com)              -->
 <!-- See AUTHORS.txt                                                       -->
 <!-- This Source Code Form is subject to the terms of the Mozilla Public   -->
 <!-- License, v. 2.0. If a copy of the MPL was not distributed with this   -->
@@ -23,7 +23,7 @@
                 <div  class="opfab-feedconfiguration-process" *ngFor="let processIdAndLabel of processGroup.processes; ">
                     <div *ngIf="processesStatesLabels.get(processIdAndLabel.processId) as processData">
                         <p class="font-weight-bold">
-                            <label style="font-weight: bold" class="opfab-checkbox">{{processData.processLabel}}
+                            <label style="font-weight: bold;width: auto" class="opfab-checkbox">{{processData.processLabel}}
                                 <input type="checkbox" (click)="toggleSelectAllStates(processIdAndLabel.processId)" [checked]="isAllStatesSelectedPerProcess.get(processIdAndLabel.processId)">
                                 <span class="opfab-checkbox-checkmark"></span>
                             </label>
@@ -47,7 +47,7 @@
         <div class="row opfab-feedconfiguration-processlist opfab-feedconfiguration-processgrid" *ngIf="!! processesWithoutGroup && processesWithoutGroup.length">
             <div class="opfab-feedconfiguration-process" *ngFor="let process of processesWithoutGroup; ">
                 <p class="font-weight-bold">
-                    <label style="font-weight: bold" class="opfab-checkbox">{{process.processLabel}}
+                    <label style="font-weight: bold;width: auto" class="opfab-checkbox">{{process.processLabel}}
                         <input type="checkbox" (click)="toggleSelectAllStates(process.idProcess)" [checked]="isAllStatesSelectedPerProcess.get(process.idProcess)">
                         <span class="opfab-checkbox-checkmark"></span>
                     </label>


### PR DESCRIPTION
- In release note :
  -  In chapter : Bugs
  -  Text : #3665 : When process name is long, it overlaps the following process name in notification configuration screen