### PR TITLE
Chekboxes in external configuration screen lose state when changing page (#3664)

### DIFF
--- a/ui/main/src/app/modules/externaldevicesconfiguration/table/externaldevicesconfiguration-directive.ts
+++ b/ui/main/src/app/modules/externaldevicesconfiguration/table/externaldevicesconfiguration-directive.ts
@@ -147,6 +147,7 @@ export abstract class ExternalDevicesConfigurationDirective {
     }
 
     updateResultPage(currentPage): void {
+        this.refreshData();
         this.gridApi.paginationGoToPage(currentPage - 1);
         this.page = currentPage;
     }


### PR DESCRIPTION
- In release note :
  -  In chapter : Bugs
  -  Text : #3664 : Chekboxes in external configuration screen lose state when changing page