### PR TITLE
In confirmation example, show response input only after user clicks on modify answer (#3613)

### DIFF
--- a/src/test/resources/bundles/messageOrQuestionExample/template/confirmation.handlebars
+++ b/src/test/resources/bundles/messageOrQuestionExample/template/confirmation.handlebars
@@ -10,7 +10,7 @@
 <h2 style="text-align: center;"> {{card.data.question}} </h2>
 
 <br />
-<div style="width:100%;display:flex;flex-wrap:wrap">  
+<div id="confirmation-response" style="width:100%;display:flex;flex-wrap:wrap">  
     <div class="opfab-select" style="flex-basis:0;width:20%;position:relative;flex-grow:1;">
         <label for="confirm" style="z-index: 100;"> Confirm </label>
         <select id="resp_confirm" name="confirm">
@@ -94,6 +94,14 @@
                 };
 
             }
+
+            templateGateway.lockAnswer = function() {
+                document.getElementById('confirmation-response').style['visibility'] = 'hidden';
+            };
+
+            templateGateway.unlockAnswer = function() {
+                document.getElementById('confirmation-response').style['visibility'] = 'visible';
+            };
         },
 
         loadEntitiesList: function() {


### PR DESCRIPTION
Fix #3613

Signed-off-by: Giovanni Ferrari <giovanni.ferrari@soft.it>

- In release note :
  -  In chapter :  Features 
  -  Text : #3613 : In confirmation example , show response input only after user click on modify answer