### PR TITLE
Use less space for edit/delete columns in admin screens (#3720)

### DIFF
--- a/ui/main/src/app/modules/admin/components/table/admin-table.directive.ts
+++ b/ui/main/src/app/modules/admin/components/table/admin-table.directive.ts
@@ -320,14 +320,18 @@ export abstract class AdminTableDirective implements OnInit, OnDestroy {
 
         // Add action columns
         columnDefs[fields.length] = {
-            headerName: 'edit',
             colId: 'edit',
-            type: 'actionColumn'
+            type: 'actionColumn',
+            headerClass:'action-cell-column-header',
+            cellStyle: {'padding-left': '0'},
+            maxWidth: 50,
         };
         columnDefs[fields.length + 1] = {
-            headerName: 'delete',
             colId: 'delete',
             type: 'actionColumn',
+            headerClass:'action-cell-column-header',
+            cellStyle: {'padding-left': '0'},
+            maxWidth: 50,
             cellClassRules: deleteActionCellClassRules
         };
 

--- a/ui/main/src/scss/styles.scss
+++ b/ui/main/src/scss/styles.scss
@@ -493,6 +493,11 @@ body {
     .action-cell-delete-admin {
         display: none;
     }
+
+    .action-cell-column-header {
+        display: none;
+    }
+
     .opfab-sev-alarm {
         background-color: $sev-alarm;
         font-size: 0px;


### PR DESCRIPTION
- In release note :
  -  In chapter :  Features
  -  Text : #3720 : Use less space for edit/delete columns in admin screens