### PR TITLE
Monitoring : message when no result should be like the one for archives and logging pages (#3800)

### DIFF
--- a/ui/main/src/app/modules/monitoring/monitoring.component.html
+++ b/ui/main/src/app/modules/monitoring/monitoring.component.html
@@ -41,6 +41,6 @@
 </div>
 
 <ng-template #noResult>
-    <div id="opfab-monitoring-noResult" class="alert alert-info"  translate>shared.noResult</div>
+    <div id="opfab-monitoring-noResult" style="text-align: center;font-size: 20px;" translate>shared.noResult</div>
 </ng-template>
 </div>


### PR DESCRIPTION
- In release note :
  -  In chapter : Bugs
  -  Text : #3800 : Monitoring : message when no result should be like the one for archives and logging pages