### PR TITLE
Fix runSomeCypressTests gradle task

### DIFF
--- a/src/test/cypress/cypressTests.gradle
+++ b/src/test/cypress/cypressTests.gradle
@@ -11,5 +11,5 @@ tasks.register('runSomeCypressTests', NpxTask)  {
     description 'runs some Cypress tests for the project'
     dependsOn npmInstall
     command = 'cypress'
-    args = ['run','-scypress/integration/' + specFiles + '.spec.js', '--config', 'video=false', '--browser', 'chrome', '--headless' ]
+    args = ['run','-scypress/integration/' + project.properties["specFiles"] + '.spec.js', '--config', 'video=false', '--browser', 'chrome', '--headless' ]
 }


### PR DESCRIPTION
Changed runSomeCypressTests  task declaration to avoid build error on VSCode 

Signed-off-by: Giovanni Ferrari <giovanni.ferrari@soft.it>

- In release note :
  -  In chapter :  Features Bugs Tasks
  -  Text : #xxx ... 