### PR TITLE
Solve deprecated usage of ~ in import (#3855)

### DIFF
--- a/ui/main/src/app/modules/admin/components/cell-renderers/state-rights-cell-renderer.component.scss
+++ b/ui/main/src/app/modules/admin/components/cell-renderers/state-rights-cell-renderer.component.scss
@@ -7,7 +7,7 @@
  * This file is part of the OperatorFabric project.
  */
 
-@import '~scss/_variables.scss';
+@import 'src/scss/_variables.scss';
 
 /* import bootstrap*/
 @import '../../../../../../node_modules/bootstrap/scss/bootstrap.scss';

--- a/ui/main/src/app/modules/archives/archives.component.scss
+++ b/ui/main/src/app/modules/archives/archives.component.scss
@@ -7,7 +7,7 @@
  * This file is part of the OperatorFabric project.
  */
 
-@import '~scss/_variables.scss';
+@import 'src/scss/_variables.scss';
 
 .opfab-archive-sev {
     width: 15px;

--- a/ui/main/src/app/modules/calendar/calendar.component.scss
+++ b/ui/main/src/app/modules/calendar/calendar.component.scss
@@ -7,7 +7,7 @@
  * This file is part of the OperatorFabric project.
  */
 
-@import '~scss/_variables.scss';
+@import 'src/scss/_variables.scss';
 
 ::ng-deep .opfab-app-calendar {
     // GLOBAL SETTINGS

--- a/ui/main/src/app/modules/feed/components/card-list/filters/feed-filter/feed-filter.component.scss
+++ b/ui/main/src/app/modules/feed/components/card-list/filters/feed-filter/feed-filter.component.scss
@@ -7,7 +7,7 @@
  * This file is part of the OperatorFabric project.
  */
 
-@import '~scss/_variables.scss';
+@import 'src/scss/_variables.scss';
 
 .opfab-filter-header {
     margin-left: 2px;

--- a/ui/main/src/app/modules/feed/components/pinned-cards/pinned-cards.component.scss
+++ b/ui/main/src/app/modules/feed/components/pinned-cards/pinned-cards.component.scss
@@ -7,7 +7,7 @@
  * This file is part of the OperatorFabric project.
  */
 
-@import '~scss/_variables.scss';
+@import 'src/scss/_variables.scss';
 
 .opfab-pinned-cards {
     display: flex;

--- a/ui/main/src/app/modules/logging/logging.component.scss
+++ b/ui/main/src/app/modules/logging/logging.component.scss
@@ -7,7 +7,7 @@
  * This file is part of the OperatorFabric project.
  */
 
-@import '~scss/_variables.scss';
+@import 'src/scss/_variables.scss';
 
 .opfab-logging-sev {
     width: 15px;

--- a/ui/main/src/app/modules/monitoring/components/monitoring-table/monitoring-table.component.scss
+++ b/ui/main/src/app/modules/monitoring/components/monitoring-table/monitoring-table.component.scss
@@ -7,7 +7,7 @@
  * SPDX-License-Identifier: MPL-2.0
  * This file is part of the OperatorFabric project.
  */
-@import '~scss/_variables.scss';
+@import 'src/scss/_variables.scss';
 
 .opfab-monitoring-export-div {
     width: 50%;

--- a/ui/main/src/app/modules/settings/components/settings/checkbox-setting/checkbox-setting.component.scss
+++ b/ui/main/src/app/modules/settings/components/settings/checkbox-setting/checkbox-setting.component.scss
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: MPL-2.0
  * This file is part of the OperatorFabric project.
  */
-@import '~scss/_variables.scss';
+@import 'src/scss/_variables.scss';
 
 label {
     padding-right: 10px;

--- a/ui/main/src/app/modules/share/countdown/countdown.component.scss
+++ b/ui/main/src/app/modules/share/countdown/countdown.component.scss
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: MPL-2.0
  * This file is part of the OperatorFabric project.
  */
-@import '~scss/_variables.scss';
+@import 'src/scss/_variables.scss';
 
 .lttd-timeleft {
     font-size: small;

--- a/ui/main/src/app/modules/share/light-card/light-card.component.scss
+++ b/ui/main/src/app/modules/share/light-card/light-card.component.scss
@@ -7,7 +7,7 @@
  * This file is part of the OperatorFabric project.
  */
 
-@import '~scss/_variables.scss';
+@import 'src/scss/_variables.scss';
 
 .light-card-detail {
     color: var(--opfab-lightcard-detail-textcolor);

--- a/ui/main/src/app/modules/share/timeline-buttons/timeline-buttons.component.scss
+++ b/ui/main/src/app/modules/share/timeline-buttons/timeline-buttons.component.scss
@@ -7,7 +7,7 @@
  * This file is part of the OperatorFabric project.
  */
 
-@import '~scss/_variables.scss';
+@import 'src/scss/_variables.scss';
 
 .opfab-menu-timeline {
     position: relative;

--- a/ui/main/src/app/modules/usercard/usercard.component.scss
+++ b/ui/main/src/app/modules/usercard/usercard.component.scss
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: MPL-2.0
  * This file is part of the OperatorFabric project.
  */
-@import '~scss/_variables.scss';
+@import 'src/scss/_variables.scss';
 
 .opfab-usercard-radio-button {
     margin-top: 20px;


### PR DESCRIPTION
I propose to add nothing in release notes or maybe in Tasks section ?
  -  In chapter : Tasks
  -  Text : #3855 : Solve deprecated usage of ~ in import