### PR TITLE
Fixed grouped card icon (#8325)

### DIFF
--- a/ui/main/src/app/modules/share/light-card/light-card.component.ts
+++ b/ui/main/src/app/modules/share/light-card/light-card.component.ts
@@ -81,10 +81,12 @@ export class LightCardComponent implements OnInit, OnDestroy {
                     this.currentPath = urlParts[1];
                 }
             });
+        this.groupedCardsService.computeEvent
+            .pipe(takeUntil(this.ngUnsubscribe))
+            .subscribe((x) => this.computeGroupedCardsIcon());
         this.computeFromEntity();
         this.computeDisplayedDate();
         this.computeLttdParams();
-        this.computeGroupedCardsIcon();
         this.hasGeoLocation =
             this.lightCard.wktGeometry === undefined ||
             this.lightCard.wktGeometry == null ||

--- a/ui/main/src/app/services/grouped-cards.service.ts
+++ b/ui/main/src/app/services/grouped-cards.service.ts
@@ -9,6 +9,7 @@
 
 import {Injectable} from '@angular/core';
 import {LightCard} from '@ofModel/light-card.model';
+import {BehaviorSubject} from 'rxjs';
 
 @Injectable({
     providedIn: 'root'
@@ -16,6 +17,8 @@ import {LightCard} from '@ofModel/light-card.model';
 export class GroupedCardsService {
     private groupedChildCards: LightCard[] = [];
     private parentsOfGroupedCards: LightCard[] = [];
+
+    computeEvent = new BehaviorSubject(null);
 
     static tagsAsString(tags: string[]): string {
         return tags ? JSON.stringify([...tags].sort()) : '';
@@ -43,6 +46,7 @@ export class GroupedCardsService {
                 }
             }
         });
+        this.computeEvent.next(null);
     }
 
     filterGroupedChilds(lightCards: LightCard[]): LightCard[] {


### PR DESCRIPTION
Signed-off-by: Jeroen Gommans <jeroen@anjersoftwaredesign.nl>

- In release note :
  -  In chapter :  Bugs
  -  Text : The arrow from the grouped cards symbol would appear even though there are no grouped cards due to the filter settings.