### PR TITLE
Fix reset button does not clear tags filter in Archives page (#3950)

### DIFF
--- a/ui/main/src/app/modules/share/archives-logging-filters/archives-logging-filters.component.html
+++ b/ui/main/src/app/modules/share/archives-logging-filters/archives-logging-filters.component.html
@@ -27,12 +27,12 @@
                     [options]="processGroupMultiSelectOptions" [selectedOptions]="processGroupSelected">
                     </of-multi-select>
                     <of-multi-select *ngIf="! isProcessGroupFilterVisible() && tags" id="opfab-tags" multiSelectId="tags" [parentForm]="this.parentForm" [config]="tagsMultiSelectConfig"
-                    [options]="tagsMultiSelectOptions" [selectedOptions]="tagSelected">
+                    [options]="tagsMultiSelectOptions" [selectedOptions]="tagsSelected">
                     </of-multi-select>
                 </div>
                 <div *ngIf="isProcessGroupFilterVisible() && tags" style="min-width:300px;max-width:400px;max-height: 48px">
                     <of-multi-select id="opfab-tags" multiSelectId="tags" [parentForm]="this.parentForm" [config]="tagsMultiSelectConfig"
-                    [options]="tagsMultiSelectOptions" [selectedOptions]="tagSelected">
+                    [options]="tagsMultiSelectOptions" [selectedOptions]="tagsSelected">
                     </of-multi-select>
                 </div>
             </div>


### PR DESCRIPTION
Fix #3950 

Signed-off-by: Giovanni Ferrari <giovanni.ferrari@soft.it>

- In release note :
  -  In chapter :  Bugs
  -  Text : #3950 : Fix reset button does not clear tags filter in Archives page