### PR TITLE
Remove deprecated method templateGateway.getSpecificCardInformation() (#2730)

### DIFF
--- a/src/docs/asciidoc/resources/migration_guide_to_3.12.adoc
+++ b/src/docs/asciidoc/resources/migration_guide_to_3.12.adoc
@@ -45,3 +45,7 @@ usercard configuration in the config.json of your bundle.
         "expirationDateVisible" : true,
         "recipientList" : [{"id": "ENTITY_FR", "levels": [0,1]}, {"id": "IT_SUPERVISOR_ENTITY"}]
       },
+
+=== Remove deprecated method templateGateway.getSpecificCardInformation() 
+  
+The deprecated method 'templateGateway.getSpecificCardInformation()' in usercard templates has been removed, use 'usercardTemplateGateway.getSpecificCardInformation()' method instead.

--- a/src/test/resources/bundles/defaultProcess_V1/template/usercard_message.handlebars
+++ b/src/test/resources/bundles/defaultProcess_V1/template/usercard_message.handlebars
@@ -38,10 +38,7 @@
     document.getElementById("hidden_process").value = usercardTemplateGateway.getCurrentProcess();
     document.getElementById("hidden_state").value = usercardTemplateGateway.getCurrentState();
 
-    // we keep here the deprecated templateGateway.getSpecificInformation (instead of usercardTemplateGateway.getSpecificInformation)
-    // to have the deprecated feature still covered by cypress tests
-    // DO NOT USE AS EXAMPLE 
-    templateGateway.getSpecificCardInformation = function () {
+    usercardTemplateGateway.getSpecificCardInformation = function () {
         const message = document.getElementById('message').value;
         let summaryParameter = message.slice(0, 100);
         if (message.length > summaryParameter.length)

--- a/ui/main/src/app/modules/usercard/usercard.component.ts
+++ b/ui/main/src/app/modules/usercard/usercard.component.ts
@@ -385,7 +385,6 @@ export class UserCardComponent implements OnInit {
             usercardTemplateGateway.setEntityUsedForSendingCard = () => {
                 // default method if not override by template
             };
-            templateGateway.getSpecificCardInformation = null;
             usercardTemplateGateway.getSpecificCardInformation = null;
             if (!this.cardToEdit) this.setDefaultDateFormValues();
 
@@ -457,7 +456,6 @@ export class UserCardComponent implements OnInit {
     }
 
     public prepareCard() {
-        this.dealWithDeprecatedUseOfTemplateGateway();
         if (!this.isSpecificInformationValid()) return;
         this.specificInformation = usercardTemplateGateway.getSpecificCardInformation();
         const startDate = this.getStartDate();
@@ -540,15 +538,6 @@ export class UserCardComponent implements OnInit {
                 }
                 this.displayPreview = true;
             });
-    }
-
-    private dealWithDeprecatedUseOfTemplateGateway(): void {
-        if (!usercardTemplateGateway.getSpecificCardInformation && templateGateway.getSpecificCardInformation) {
-            this.opfabLogger.info(
-                'Use of templateGateway.getSpecificCardInformation() is deprecated , use usercardTemplateGateway.getSpecificCardInformation instead'
-            );
-            usercardTemplateGateway.getSpecificCardInformation = templateGateway.getSpecificCardInformation;
-        }
     }
 
     private isSpecificInformationValid(): boolean {
@@ -658,7 +647,7 @@ export class UserCardComponent implements OnInit {
             const recipientListFromStateConfig = this.getRecipientListFromState_Deprecated();
             if (recipientListFromStateConfig !== undefined) {
                 this.opfabLogger.info(
-                    'Use of state configuration to define list of recipient is deprecated, provide  it via  templateGateway.getSpecificCardInformation() '
+                    'Use of state configuration to define list of recipient is deprecated, provide it via usercardTemplateGateway.getSpecificCardInformation() '
                 );
                 recipientListFromStateConfig.forEach((entity) => {if (!recipients.includes(entity.id)) recipients.push(entity.id)});
             }


### PR DESCRIPTION
Fix #2730

Signed-off-by: Giovanni Ferrari <giovanni.ferrari@soft.it>

- In release note :
  -  In chapter :  Tasks
  -  Text : #2730 : Remove deprecated method templateGateway.getSpecificCardInformation()