### PR TITLE
Refacto UI : modify http error management in server classes

### DIFF
--- a/ui/main/src/app/business/server/config.server.ts
+++ b/ui/main/src/app/business/server/config.server.ts
@@ -10,10 +10,11 @@
 
 import {MonitoringConfig} from "@ofModel/monitoringConfig.model";
 import {Observable} from "rxjs";
+import {ServerResponse} from "./serverResponse";
 
 export abstract class ConfigServer {
 
-    abstract getWebUiConfiguration():Observable<any>;
-    abstract getMenuConfiguration():Observable<any>;
-    abstract getMonitoringConfiguration(): Observable<MonitoringConfig>;
+    abstract getWebUiConfiguration():Observable<ServerResponse<any>>;
+    abstract getMenuConfiguration():Observable<ServerResponse<any>>;
+    abstract getMonitoringConfiguration(): Observable<ServerResponse<MonitoringConfig>>;
 }

--- a/ui/main/src/app/business/server/process.server.ts
+++ b/ui/main/src/app/business/server/process.server.ts
@@ -10,12 +10,12 @@
 
 import {Process} from '@ofModel/processes.model';
 import {Observable} from 'rxjs';
+import {ServerResponse} from './serverResponse';
 
 export abstract class ProcessServer {
-    abstract getProcessDefinition(processId:string,processVersion:string): Observable<Process>;
-    abstract getAllProcessesDefinition(): Observable<Process[]>;
-    abstract getI18N(processId: string, locale: string,version: string): Observable<any>;
-    abstract getProcessGroups() : Observable<any>;
-    abstract getTemplate(processid:string,processVersion:string,templateName:string) : Observable<string>;
-    abstract getCss(processId:string,version:string,cssName:string) : Observable<string>;
+    abstract getProcessDefinition(processId:string,processVersion:string): Observable<ServerResponse<Process>>;
+    abstract getAllProcessesDefinition(): Observable<ServerResponse<Process[]>>;
+    abstract getProcessGroups() : Observable<ServerResponse<any>>;
+    abstract getTemplate(processid:string,processVersion:string,templateName:string) : Observable<ServerResponse<string>>;
+    abstract getCss(processId:string,version:string,cssName:string) : Observable<ServerResponse<string>>;
 }

--- a/ui/main/src/app/business/server/serverResponse.ts
+++ b/ui/main/src/app/business/server/serverResponse.ts
@@ -1,0 +1,28 @@
+
+/* Copyright (c) 2023, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
+ */
+
+
+
+export class ServerResponse<responseDataType>{
+
+    public constructor(
+        readonly data: responseDataType,
+        readonly status: ServerResponseStatus,
+        readonly statusMessage: string
+    ){}
+}
+
+
+export enum ServerResponseStatus {
+    OK,
+    NOT_FOUND,
+    UNKNOWN_ERROR,
+    FORBIDDEN
+}

--- a/ui/main/src/app/business/services/config.service.spec.ts
+++ b/ui/main/src/app/business/services/config.service.spec.ts
@@ -10,6 +10,7 @@
 import {ConfigServerMock} from '@tests/mocks/configServer.mock';
 import {ConfigService} from './config.service';
 import {firstValueFrom, timeout} from 'rxjs';
+import {ServerResponse, ServerResponseStatus} from '../server/serverResponse';
 
 describe('ConfigService', () => {
     let configService: ConfigService;
@@ -21,14 +22,14 @@ describe('ConfigService', () => {
     });
     describe('Web-ui config', () => {
         it('GIVEN_A_Web-ui_Configuration_File_WHEN_Loading_THEN_Configuration_Is_Loaded', async () => {
-            configServerMock.setWebUIConfiguration({field: 'value'});
+            configServerMock.setResponseForWebUIConfiguration(new ServerResponse({field: 'value'},ServerResponseStatus.OK,null));
             const conf = await firstValueFrom(configService.loadWebUIConfiguration().pipe(timeout(100)));
             expect(conf).toEqual({field: 'value'});
         });
 
         it('GIVEN_A_Loaded_Configuration_WHEN_Get_Config_Value_THEN_Obtain_Config_Value', async () => {
             const conf = {field1: 'value1', nested: {field2: 'value2'}};
-            configServerMock.setWebUIConfiguration(conf);
+            configServerMock.setResponseForWebUIConfiguration(new ServerResponse(conf,ServerResponseStatus.OK,null));
             await firstValueFrom(configService.loadWebUIConfiguration().pipe(timeout(100)));
             expect(configService.getConfigValue('field1')).toEqual('value1');
             expect(configService.getConfigValue('nested.field2')).toEqual('value2');
@@ -36,14 +37,14 @@ describe('ConfigService', () => {
 
         it('GIVEN_A_Loaded_Configuration_WHEN_Get_Non_Existing_Config_Value_THEN_Obtain_FallBack_Config_Value', async () => {
             const conf = {field1: 'value1', nested: {field2: 'value2'}};
-            configServerMock.setWebUIConfiguration(conf);
+            configServerMock.setResponseForWebUIConfiguration(new ServerResponse(conf,ServerResponseStatus.OK,null));
             await firstValueFrom(configService.loadWebUIConfiguration().pipe(timeout(100)));
             expect(configService.getConfigValue('unexisting', 'myfallback')).toEqual('myfallback');
         });
 
         it('GIVEN_A_Loaded_Configuration_WHEN_Set_Config_Value_THEN_Initial_Config_Value_Change', async () => {
             const conf = {field1: 'value1', nested: {field2: 'value2'}};
-            configServerMock.setWebUIConfiguration(conf);
+            configServerMock.setResponseForWebUIConfiguration(new ServerResponse(conf,ServerResponseStatus.OK,null));
             await firstValueFrom(configService.loadWebUIConfiguration().pipe(timeout(100)));
             configService.setConfigValue('nested.field2', 'newValue2');
             expect(configService.getConfigValue('nested.field2')).toEqual('newValue2');
@@ -63,7 +64,7 @@ describe('ConfigService', () => {
                 settings3: 'newS3'
             };
 
-            configServerMock.setWebUIConfiguration(conf);
+            configServerMock.setResponseForWebUIConfiguration(new ServerResponse(conf,ServerResponseStatus.OK,null));
             await firstValueFrom(configService.loadWebUIConfiguration());
             configService.overrideConfigSettingsWithUserSettings(settings);
             expect(configService.getConfigValue('settings.settings1')).toEqual('newS1');
@@ -73,7 +74,7 @@ describe('ConfigService', () => {
 
         it('GIVEN_A_Loaded_Configuration_WHEN_Change_Config_Value_THEN_Change_Is_Received_Via_Observable', async () => {
             const conf = {field1: 'value1', nested: {field2: 'value2'}};
-            configServerMock.setWebUIConfiguration(conf);
+            configServerMock.setResponseForWebUIConfiguration(new ServerResponse(conf,ServerResponseStatus.OK,null));
             await firstValueFrom(configService.loadWebUIConfiguration().pipe(timeout(100)));
 
             let observableEmissionNb = 1;
@@ -123,23 +124,24 @@ describe('ConfigService', () => {
         };
 
         it('GIVEN_A_Menu_Configuration_File_WHEN_Loading_Core_Menu_THEN_Core_Menu_Configuration_Is_Available', async () => {
-            configServerMock.setMenuConfiguration(menuConf);
+            configServerMock.setResponseForMenuConfiguration(new ServerResponse(menuConf,ServerResponseStatus.OK,null));
             await firstValueFrom(configService.loadCoreMenuConfigurations().pipe(timeout(100)));
             expect(configService.getCoreMenuConfiguration()[0].id).toEqual("feed");
         });
 
 
         it('GIVEN_A_Menu_Configuration_File_WHEN_Fetch_Custom_Menu_Translation_THEN_Translation_Is_Available', async () => {
-            configServerMock.setMenuConfiguration(menuConf);
+            configServerMock.setResponseForMenuConfiguration(new ServerResponse(menuConf,ServerResponseStatus.OK,null));
             const translation = await firstValueFrom(configService.fetchMenuTranslations().pipe(timeout(100)));
             expect(translation[0].language).toEqual("en");
             expect(translation[0].i18n["menu1"]["title"]).toEqual("First menu");
         });
 
         it('GIVEN_A_Menu_Configuration_File_WHEN_Getting_Url_For_Custom_Menu_THEN_Url_Is_Provided', async () => {
-            configServerMock.setMenuConfiguration(menuConf);
+            configServerMock.setResponseForMenuConfiguration(new ServerResponse(menuConf,ServerResponseStatus.OK,null));
             const url = await firstValueFrom(configService.queryMenuEntryURL("menu1","entry1").pipe(timeout(100)));
             expect(url).toEqual("https://test");
         });
     });
+
 });

--- a/ui/main/src/app/business/services/config.service.ts
+++ b/ui/main/src/app/business/services/config.service.ts
@@ -29,7 +29,7 @@ export class ConfigService {
     }
 
     public loadWebUIConfiguration(): Observable<any> {
-        return this.configServer.getWebUiConfiguration().pipe(( map((config) => {this.config = config; return config})));
+        return this.configServer.getWebUiConfiguration().pipe(( map((serverResponse) => {this.config = serverResponse.data; return this.config})));
     }
 
     public overrideConfigSettingsWithUserSettings(settings: any) {
@@ -63,10 +63,10 @@ export class ConfigService {
 
     public loadCoreMenuConfigurations(): Observable<CoreMenuConfig[]> {
         return this.configServer.getMenuConfiguration()
-            .pipe(map((config) => {
-                this.coreMenuConfigurations = config.coreMenusConfiguration;
-                this.processMenuConfig(config);
-                return config.coreMenuConfiguration;
+            .pipe(map((serverResponse) => {
+                this.coreMenuConfigurations = serverResponse.data.coreMenusConfiguration;
+                this.processMenuConfig(serverResponse.data);
+                return this.coreMenuConfigurations;
             }));
     }
 
@@ -81,12 +81,12 @@ export class ConfigService {
     /* Configuration for custom menus */
 
     public fetchMenuTranslations(): Observable<Locale[]> {
-        return this.configServer.getMenuConfiguration().pipe(map((config) => config.locales));
+        return this.configServer.getMenuConfiguration().pipe(map((serverResponse) => serverResponse.data?.locales));
     }
 
     public computeMenu(): Observable<Menu[]> {
         return this.configServer.getMenuConfiguration()
-            .pipe(map((config) => this.processMenuConfig(config)));
+            .pipe(map((serverResponse) => this.processMenuConfig(serverResponse.data)));
     }
 
     public queryMenuEntryURL(id: string, menuEntryId: string): Observable<string> {

--- a/ui/main/src/app/business/services/processes.service.spec.ts
+++ b/ui/main/src/app/business/services/processes.service.spec.ts
@@ -7,19 +7,18 @@
  * This file is part of the OperatorFabric project.
  */
 
-
 import {ProcessesService} from './processes.service';
 import {getRandomAlphanumericValue} from '@tests/helpers';
 import {Process} from '@ofModel/processes.model';
 import {ConfigServerMock} from '@tests/mocks/configServer.mock';
 import {ProcessServerMock} from '@tests/mocks/processServer.mock';
+import {ServerResponse, ServerResponseStatus} from '../server/serverResponse';
 
 describe('Processes Services', () => {
-
     let processesService: ProcessesService;
     let processServerMock: ProcessServerMock;
     let configServerMock: ConfigServerMock;
-    
+
     beforeEach(() => {
         processServerMock = new ProcessServerMock();
         configServerMock = new ConfigServerMock();
@@ -81,13 +80,22 @@ describe('Processes Services', () => {
         });
     });
 
-    describe('#queryProcess', () => {
-        const processDefinition = new Process('testPublisher', '0', 'businessconfig.label');
-        it('should load businessconfig from remote server', () => {
-            processServerMock.setProcessDefinition(processDefinition);
+    describe('Query a process', () => {
+        it('GIVEN an existing process WHEN query the process THEN process is returned', () => {
+            const processDefinition = new Process('testPublisher', '0', 'businessconfig.label');
+            const serverResponse = new ServerResponse<Process>(processDefinition, null, null);
+            processServerMock.setResponseForProcessDefinition(serverResponse);
             processesService
                 .queryProcess('testPublisher', '0')
                 .subscribe((result) => expect(result).toEqual(processDefinition));
+        });
+
+        it('GIVEN a non-existing process WHEN query the process THEN null is returned', () => {
+            const serverResponse = new ServerResponse<Process>(null, ServerResponseStatus.NOT_FOUND, null);
+            processServerMock.setResponseForProcessDefinition(serverResponse);
+            processesService
+                .queryProcess('testPublisher', '0')
+                .subscribe((result) => expect(result).toEqual(null));
         });
     });
 });

--- a/ui/main/src/app/modules/card/card.component.ts
+++ b/ui/main/src/app/modules/card/card.component.ts
@@ -72,25 +72,8 @@ export class CardComponent implements OnInit, OnDestroy {
                                         this.cardState = new State();
                                     }
                                 } else {
-                                    console.log(
-                                        new Date().toISOString(),
-                                        `WARNING process ` +
-                                            ` ${card.process} with version ${card.processVersion} does not exist.`
-                                    );
                                     this.cardState = new State();
                                 }
-                            },
-                            error: () => {
-                                card = card as Card;
-                                console.log(
-                                    new Date().toISOString(),
-                                    `WARNING process ` +
-                                        ` ${card.process} with version ${card.processVersion} does not exist.`
-                                );
-                                this.card = card;
-                                this.childCards = childCards;
-                                this.cardLoadingInProgress = false;
-                                this.cardState = new State();
                             }
                         });
                     } else {

--- a/ui/main/src/app/modules/card/services/handlebars.service.spec.ts
+++ b/ui/main/src/app/modules/card/services/handlebars.service.spec.ts
@@ -19,6 +19,7 @@ import {ConfigServerMock} from '@tests/mocks/configServer.mock';
 import {ProcessServerMock} from '@tests/mocks/processServer.mock';
 import {ProcessesService} from 'app/business/services/processes.service';
 import {ConfigService} from 'app/business/services/config.service';
+import {ServerResponse, ServerResponseStatus} from 'app/business/server/serverResponse';
 
 describe('Handlebars Services', () => {
     let processesService: ProcessesService;
@@ -69,7 +70,7 @@ describe('Handlebars Services', () => {
         });
 
         function testTemplate(template, expectedResult, done, contextMessage?) {
-            processServer.setTemplate(template);
+            processServer.setResponseForTemplate(new ServerResponse(template,ServerResponseStatus.OK,null));
             handlebarsService
                 .executeTemplate("test", new DetailContext(card, userContext, null))
                 .subscribe((result) => {
@@ -328,7 +329,7 @@ describe('Handlebars Services', () => {
         });
 
         it('compile  now ', (done) => {
-            processServer.setTemplate('{{now}}');
+            processServer.setResponseForTemplate(new ServerResponse('{{now}}',ServerResponseStatus.OK,null));
             handlebarsService
                 .executeTemplate("test", new DetailContext(card, userContext, null))
                 .subscribe((result) => {

--- a/ui/main/src/app/server/angular.server.ts
+++ b/ui/main/src/app/server/angular.server.ts
@@ -1,0 +1,28 @@
+/* Copyright (c) 2023, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
+ */
+
+import {ServerResponse, ServerResponseStatus} from 'app/business/server/serverResponse';
+import {catchError, map, Observable, of} from 'rxjs';
+
+export class AngularServer {
+    protected processHttpResponse<dataType>(httpResponse: Observable<dataType>): Observable<ServerResponse<dataType>> {
+        return httpResponse.pipe(
+            map((data) => {
+                return new ServerResponse(data, ServerResponseStatus.OK, '');
+            }),
+            catchError((error) => {
+                let serverStatus = ServerResponseStatus.UNKNOWN_ERROR;
+                if (error.status === 404) serverStatus = ServerResponseStatus.NOT_FOUND;
+                else if (error.status === 403) serverStatus = ServerResponseStatus.FORBIDDEN;
+
+                return of(new ServerResponse(null, serverStatus, ''));
+            })
+        );
+    }
+}

--- a/ui/main/src/app/server/angularConfig.server.ts
+++ b/ui/main/src/app/server/angularConfig.server.ts
@@ -12,23 +12,26 @@ import {Injectable} from '@angular/core';
 import {environment} from '@env/environment';
 import {UIMenuFile} from '@ofModel/menu.model';
 import {MonitoringConfig} from '@ofModel/monitoringConfig.model';
+import {ServerResponse} from 'app/business/server/serverResponse';
 import {map, Observable} from 'rxjs';
 import {ConfigServer} from '../business/server/config.server';
+import {AngularServer} from './angular.server';
 
 @Injectable({
     providedIn: 'root'
 })
-export class AngularConfigServer implements ConfigServer {
+export class AngularConfigServer extends AngularServer implements ConfigServer {
     private configUrl: string;
     private monitoringConfigUrl: string;
 
     constructor(private httpClient: HttpClient) {
+        super();
         this.configUrl = `${environment.urls.config}`;
         this.monitoringConfigUrl = `${environment.urls.monitoringConfig}`;
     }
 
-    getWebUiConfiguration(): Observable<any> {
-        return this.httpClient.get(`${this.configUrl}`, {responseType: 'text'}).pipe(
+    getWebUiConfiguration(): Observable<ServerResponse<any>> {
+        return  this.processHttpResponse(this.httpClient.get(`${this.configUrl}`, {responseType: 'text'}).pipe(
             map((config) => {
                 try {
                     config = JSON.parse(config);
@@ -37,15 +40,15 @@ export class AngularConfigServer implements ConfigServer {
                 }
                 return config;
             })
-        );
+        ));
     }
 
-    getMenuConfiguration(): Observable<any> {
-        return this.httpClient
-            .get<UIMenuFile>(`${environment.urls.menuConfig}`)
+    getMenuConfiguration(): Observable<ServerResponse<any>> {
+        return this.processHttpResponse(this.httpClient
+            .get<UIMenuFile>(`${environment.urls.menuConfig}`));
     }
 
-    getMonitoringConfiguration():Observable<MonitoringConfig> {
-        return this.httpClient.get<MonitoringConfig>(this.monitoringConfigUrl)
+    getMonitoringConfiguration():Observable<ServerResponse<MonitoringConfig>> {
+        return this.processHttpResponse(this.httpClient.get<MonitoringConfig>(this.monitoringConfigUrl));
     }
 }

--- a/ui/main/src/app/server/angularProcess.server.ts
+++ b/ui/main/src/app/server/angularProcess.server.ts
@@ -12,59 +12,49 @@ import {Injectable} from '@angular/core';
 import {environment} from '@env/environment';
 import {Process} from '@ofModel/processes.model';
 import {ProcessServer} from 'app/business/server/process.server';
+import {ServerResponse} from 'app/business/server/serverResponse';
 import {Observable} from 'rxjs';
+import {AngularServer} from './angular.server';
 
 @Injectable({
     providedIn: 'root'
 })
-export class AngularProcessServer implements ProcessServer {
+export class AngularProcessServer extends AngularServer implements ProcessServer {
     private processesUrl: string;
     private processGroupsUrl: string;
-    private monitoringConfigUrl: string;
 
     constructor(private httpClient: HttpClient) {
+        super();
         this.processesUrl = `${environment.urls.processes}`;
         this.processGroupsUrl = `${environment.urls.processGroups}`;
-        this.monitoringConfigUrl = `${environment.urls.monitoringConfig}`;
     }
 
-    getProcessDefinition(processId: string, processVersion: string):Observable<Process> {
+    getProcessDefinition(processId: string, processVersion: string): Observable<ServerResponse<Process>> {
         const params = new HttpParams().set('version', processVersion);
-        return this.httpClient.get<Process>(`${this.processesUrl}/${processId}/`, {
-            params
-        });
+        return this.processHttpResponse(
+            this.httpClient.get<Process>(`${this.processesUrl}/${processId}/`, {
+                params
+            })
+        );
     }
 
-    getAllProcessesDefinition(): Observable<Process[]> {
-        return this.httpClient.get<Process[]>(this.processesUrl);
+    getAllProcessesDefinition(): Observable<ServerResponse<Process[]>> {
+        return this.processHttpResponse(this.httpClient.get<Process[]>(this.processesUrl));
     }
 
-    getI18N(processId: string, locale: string,version: string): Observable<any> {
-        let params = new HttpParams().set('locale', locale);
-        if (version) {
-            /*
-            `params` override needed otherwise only locale is use in the request.
-            It's so because HttpParams.set(...) return a new HttpParams,
-            and basically that's why HttpParams can be set with fluent API...
-             */
-            params = params.set('version', version);
-        }
-        return this.httpClient.get(`${this.processesUrl}/${processId}/i18n`, {params});
+    getProcessGroups(): Observable<ServerResponse<any>> {
+        return this.processHttpResponse(this.httpClient.get(this.processGroupsUrl));
     }
 
-    getProcessGroups(): Observable<any> {
-        return this.httpClient.get(this.processGroupsUrl);
-    }
-
-    getTemplate(processId: string, processVersion: string, templateName: string) : Observable<string> {
+    getTemplate(processId: string, processVersion: string, templateName: string): Observable<ServerResponse<string>> {
         const params = new HttpParams().set('version', processVersion);
-        return this.httpClient.get(`${this.processesUrl}/${processId}/templates/${templateName}`, {
+        return this.processHttpResponse(this.httpClient.get(`${this.processesUrl}/${processId}/templates/${templateName}`, {
             params,
             responseType: 'text'
-        });
+        }));
     }
 
-    getCss(processId: string, version: string, cssName: string) : Observable<string> {
+    getCss(processId: string, version: string, cssName: string): Observable<ServerResponse<string>> {
         return null;
     }
 }

--- a/ui/main/src/tests/mocks/configServer.mock.ts
+++ b/ui/main/src/tests/mocks/configServer.mock.ts
@@ -10,34 +10,35 @@
 import {Observable, ReplaySubject} from 'rxjs';
 import {ConfigServer} from 'app/business/server/config.server';
 import {MonitoringConfig} from '@ofModel/monitoringConfig.model';
+import {ServerResponse} from 'app/business/server/serverResponse';
 
 export class ConfigServerMock implements ConfigServer {
 
-    private webUiConf = new ReplaySubject<any>();
-    private menuConf = new ReplaySubject<any>();
-    private monitoringConf = new ReplaySubject<MonitoringConfig>;
+    private webUiConf = new ReplaySubject<ServerResponse<any>>();
+    private menuConf = new ReplaySubject<ServerResponse<any>>();
+    private monitoringConf = new ReplaySubject<ServerResponse<MonitoringConfig>>;
 
-    getWebUiConfiguration(): Observable<any> {
+    getWebUiConfiguration(): Observable<ServerResponse<any>> {
         return this.webUiConf.asObservable();
     }
 
-    getMenuConfiguration(): Observable<any> {
+    getMenuConfiguration(): Observable<ServerResponse<any>> {
         return this.menuConf.asObservable();
     }
 
-    getMonitoringConfiguration(): Observable<MonitoringConfig> {
+    getMonitoringConfiguration(): Observable<ServerResponse<MonitoringConfig>> {
         return this.monitoringConf.asObservable();
     }
 
-    setWebUIConfiguration(webuiConf:any) {
+    setResponseForWebUIConfiguration(webuiConf:ServerResponse<any>) {
         this.webUiConf.next(webuiConf);
     }
 
-    setMenuConfiguration(menuConf:any) {
+    setResponseForMenuConfiguration(menuConf:ServerResponse<any>) {
         this.menuConf.next(menuConf);
     }
 
-    setMonitoringConfiguration(monitoringConf: MonitoringConfig) {
+    setResponseForMonitoringConfiguration(monitoringConf: ServerResponse<MonitoringConfig>) {
         this.monitoringConf.next(monitoringConf);
     }
 }

--- a/ui/main/src/tests/mocks/processServer.mock.ts
+++ b/ui/main/src/tests/mocks/processServer.mock.ts
@@ -9,53 +9,48 @@
 
 import {Process} from '@ofModel/processes.model';
 import {ProcessServer} from 'app/business/server/process.server';
+import {ServerResponse} from 'app/business/server/serverResponse';
 import {Observable, ReplaySubject} from 'rxjs';
 
 export class ProcessServerMock implements ProcessServer {
-    private processSubject = new ReplaySubject<Process>();
-    private allProcessSubject = new ReplaySubject<Process[]>();
-    private i18nSubject = new ReplaySubject<any>();
-    private processGroupsSubject = new ReplaySubject<any>();
-    private templateSubject = new ReplaySubject<string>();
-    private cssSubject = new ReplaySubject<string>();
+    private processSubject = new ReplaySubject<ServerResponse<Process>>();
+    private allProcessSubject = new ReplaySubject<ServerResponse<Process[]>>();
+    private processGroupsSubject = new ReplaySubject<ServerResponse<any>>();
+    private templateSubject = new ReplaySubject<ServerResponse<string>>();
+    private cssSubject = new ReplaySubject<ServerResponse<string>>();
 
-    setProcessDefinition(process: Process) {
+    setResponseForProcessDefinition(process: ServerResponse<Process>) {
         this.processSubject.next(process);
     }
-    setAllProcessDefinition(processes: Process[]) {
+    setResponseForAllProcessDefinition(processes: ServerResponse<Process[]>) {
         this.allProcessSubject.next(processes);
     }
-    setI18N(i18n: any) {
-        this.i18nSubject.next(i18n);
-    }
-    setProcessGroups(processGroups: any) {
+
+    setResponseForProcessGroups(processGroups: ServerResponse<any>) {
         this.processGroupsSubject.next(processGroups);
     }
 
-    setTemplate(template: string) {
+    setResponseForTemplate(template: ServerResponse<string>) {
         this.templateSubject.next(template);
     }
 
-    setCss(css: string) {
+    setResponseForCss(css: ServerResponse<string>) {
         this.cssSubject.next(css);
     }
 
-    getProcessDefinition(processId: string, processVersion: string): Observable<Process> {
+    getProcessDefinition(processId: string, processVersion: string): Observable<ServerResponse<Process>> {
         return this.processSubject.asObservable();
     }
-    getAllProcessesDefinition(): Observable<Process[]> {
+    getAllProcessesDefinition(): Observable<ServerResponse<Process[]>> {
         return this.allProcessSubject.asObservable();
     }
-    getI18N(processId: string, version: string): Observable<any> {
-        return this.i18nSubject.asObservable();
-    }
-    getProcessGroups(): Observable<any> {
+    getProcessGroups(): Observable<ServerResponse<any>> {
         return this.processGroupsSubject.asObservable();
     }
-    getTemplate(processid: string, processVersion: string, templateName: string): Observable<string> {
+    getTemplate(processid: string, processVersion: string, templateName: string): Observable<ServerResponse<string>> {
         return this.templateSubject.asObservable();
     }
-    getCss(processId: string, version: string, cssName: string): Observable<string> {
+    getCss(processId: string, version: string, cssName: string): Observable<ServerResponse<string>> {
         return this.cssSubject.asObservable();
     }
 }


### PR DESCRIPTION

Add a ServerResponse class to manage error in business services without having to be coupled with angular HttpClient 

Nothing in release note