### PR TITLE
Fix error when opening card with no childs from Archives screen (#4062)

### DIFF
--- a/ui/main/src/app/modules/share/simplified-card-view/simplified-card-view.component.ts
+++ b/ui/main/src/app/modules/share/simplified-card-view/simplified-card-view.component.ts
@@ -91,7 +91,7 @@ export class SimplifiedCardViewComponent implements OnInit, OnDestroy {
     public beforeTemplateRendering() {
         templateGateway.userMemberOfAnEntityRequiredToRespond =
             this.userMemberOfAnEntityRequiredToRespondAndAllowedToSendCards;
-        templateGateway.childCards = this.childCards;
+        templateGateway.childCards = !!this.childCards ? this.childCards : [];
     }
 
     ngOnDestroy() {


### PR DESCRIPTION
Fix #4062 

Signed-off-by: Giovanni Ferrari <giovanni.ferrari@soft.it>

- In release note :
  -  In chapter :  Bugs 
  -  Text : #4062 : Fix error when opening card with no childs from Archives screen