### PR TITLE
Refacto event stream management

### DIFF
--- a/ui/main/src/app/app.component.ts
+++ b/ui/main/src/app/app.component.ts
@@ -1,4 +1,4 @@
-/* Copyright (c) 2018-2022, RTE (http://www.rte-france.com)
+/* Copyright (c) 2018-2023, RTE (http://www.rte-france.com)
  * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -8,13 +8,11 @@
  */
 
 import {Component, HostListener, TemplateRef, ViewChild} from '@angular/core';
-import {AppState} from '@ofStore/index';
-import {CardService} from '@ofServices/card.service';
-import {NgbModal, NgbModalRef} from '@ng-bootstrap/ng-bootstrap';
+import {NgbModalRef} from '@ng-bootstrap/ng-bootstrap';
 import {LogOption, OpfabLoggerService} from '@ofServices/logs/opfab-logger.service';
 import {RemoteLoggerService} from '@ofServices/logs/remote-logger.service';
-import {Store} from '@ngrx/store';
 import {SoundNotificationService} from '@ofServices/sound-notification.service';
+import {OpfabEventStreamService} from './business/services/opfabEventStream.service';
 
 @Component({
     selector: 'of-root',
@@ -46,7 +44,7 @@ export class AppComponent {
     @HostListener('window:beforeunload')
     onBeforeUnload() {
         this.logger.info('Unload opfab', LogOption.LOCAL_AND_REMOTE);
-        this.cardService.closeSubscription();
+        this.opfabEventStreamService.closeEventStream();
         this.remoteLogger.flush(); // flush log before exiting opfab
         return null;
     }
@@ -70,11 +68,9 @@ export class AppComponent {
     }
 
     constructor(
-        private store: Store<AppState>,
-        private cardService: CardService,
-        private modalService: NgbModal,
         private soundNotificationService: SoundNotificationService,
         private logger: OpfabLoggerService,
+        private opfabEventStreamService: OpfabEventStreamService,
         private remoteLogger: RemoteLoggerService
     ) {}
 

--- a/ui/main/src/app/app.module.ts
+++ b/ui/main/src/app/app.module.ts
@@ -47,6 +47,8 @@ import {ConfigServer} from './business/server/config.server';
 import {AngularConfigServer} from './server/angularConfig.server';
 import {ProcessServer} from './business/server/process.server';
 import {AngularProcessServer} from './server/angularProcess.server';
+import {AngularOpfabEventStreamServer} from './server/angularOpfabEventStream.server';
+import {OpfabEventStreamServer} from './business/server/opfabEventStream.server';
 
 @NgModule({
     imports: [
@@ -100,7 +102,8 @@ import {AngularProcessServer} from './server/angularProcess.server';
             multi: true
         },
         {provide: ConfigServer, useClass: AngularConfigServer},
-        {provide: ProcessServer, useClass: AngularProcessServer}
+        {provide: ProcessServer, useClass: AngularProcessServer},
+        {provide: OpfabEventStreamServer, useClass: AngularOpfabEventStreamServer}
     ],
     bootstrap: [AppComponent]
 })

--- a/ui/main/src/app/business/server/opfabEventStream.server.ts
+++ b/ui/main/src/app/business/server/opfabEventStream.server.ts
@@ -1,0 +1,20 @@
+/* Copyright (c) 2023, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
+ */
+
+import {Observable} from 'rxjs';
+import {ServerResponse} from './serverResponse';
+
+export abstract class OpfabEventStreamServer {
+    abstract initStream();
+    abstract getStreamInitDone():Observable<void>;
+    abstract closeStream();
+    abstract getEvents(): Observable<any>;
+    abstract getStreamStatus(): Observable<any>;
+    abstract setBusinessPeriod(StartDate:number,EndDate: number): Observable<ServerResponse<any>>;
+}

--- a/ui/main/src/app/business/services/opfabEventStream.service.ts
+++ b/ui/main/src/app/business/services/opfabEventStream.service.ts
@@ -1,0 +1,152 @@
+/* Copyright (c) 2023, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
+ */
+
+import {Injectable} from '@angular/core';
+import {Store} from '@ngrx/store';
+import {CardOperation} from '@ofModel/card-operation.model';
+import {FilterService} from '@ofServices/lightcards/filter.service';
+import {LogOption, OpfabLoggerService} from '@ofServices/logs/opfab-logger.service';
+import {
+    CardSubscriptionOpenAction,
+    CardSubscriptionClosedAction,
+    UIReloadRequestedAction
+} from '@ofStore/actions/cards-subscription.actions';
+import {BusinessConfigChangeAction} from '@ofStore/actions/processes.actions';
+import {UserConfigChangeAction} from '@ofStore/actions/user.actions';
+import {AppState} from '@ofStore/index';
+import {filter, map, Observable, Subject} from 'rxjs';
+import {OpfabEventStreamServer} from '../server/opfabEventStream.server';
+
+@Injectable({
+    providedIn: 'root'
+})
+export class OpfabEventStreamService {
+    public initSubscription = new Subject<void>();
+
+    private startOfAlreadyLoadedPeriod: number;
+    private endOfAlreadyLoadedPeriod: number;
+
+    private receivedDisconnectedSubject = new Subject<boolean>();
+
+    private eventStreamClosed = false;
+
+    constructor(
+        private opfabEventStreamServer: OpfabEventStreamServer,
+        private store: Store<AppState>,
+        private filterService: FilterService,
+        private logger: OpfabLoggerService
+    ) {}
+
+    public initEventStream() {
+        this.opfabEventStreamServer.getStreamStatus().subscribe((status) => {
+            if (status === 'open') this.store.dispatch(new CardSubscriptionOpenAction());
+            else this.store.dispatch(new CardSubscriptionClosedAction());
+        });
+        this.opfabEventStreamServer.initStream();
+        this.listenForFilterChange();
+    }
+
+    private listenForFilterChange() {
+        this.filterService.getBusinessDateFilterChanges().subscribe((filter) => {
+            this.setSubscriptionDates(filter.status.start, filter.status.end);
+        });
+    }
+
+    public closeEventStream() {
+        if (!this.eventStreamClosed) {
+            this.logger.info('EventStreamService - Closing event stream', LogOption.LOCAL_AND_REMOTE);
+            this.opfabEventStreamServer.closeStream();
+            this.eventStreamClosed = true;
+        }
+    }
+
+    public getCardOperationStream(): Observable<CardOperation> {
+        return this.opfabEventStreamServer.getEvents().pipe(
+            map((event) => {
+                switch (event.data) {
+                    case 'RELOAD':
+                        this.logger.info(`EventStreamService - RELOAD received`, LogOption.LOCAL_AND_REMOTE);
+                        this.store.dispatch(new UIReloadRequestedAction());
+                        break;
+                    case 'BUSINESS_CONFIG_CHANGE':
+                        this.store.dispatch(new BusinessConfigChangeAction());
+                        this.logger.info(`EventStreamService - BUSINESS_CONFIG_CHANGE received`);
+                        break;
+                    case 'USER_CONFIG_CHANGE':
+                        this.store.dispatch(new UserConfigChangeAction());
+                        this.logger.info(`EventStreamService - USER_CONFIG_CHANGE received`);
+                        break;
+                    case 'DISCONNECT_USER_DUE_TO_NEW_CONNECTION':
+                        this.logger.info(
+                            'EventStreamService - Disconnecting user because a new connection is being opened for this account'
+                        );
+                        this.closeEventStream();
+                        this.receivedDisconnectedSubject.next(true);
+                        break;
+                    default:
+                        let cardOperation;
+                        try {
+                            cardOperation = JSON.parse(event.data, CardOperation.convertTypeIntoEnum);
+                        } catch (error) {
+                            this.logger.warn('EventStreamService - Impossible to parse server message ' + error);
+                        }
+                        return cardOperation;
+                }
+                return null;
+            }),
+            filter((cardOperation) => cardOperation)
+        );
+    }
+
+    public resetAlreadyLoadingPeriod() {
+        this.startOfAlreadyLoadedPeriod = null;
+    }
+
+    private setSubscriptionDates(start: number, end: number) {
+        this.logger.info(
+            'EventStreamService - Set subscription date' + new Date(start) + ' -' + new Date(end),
+            LogOption.LOCAL_AND_REMOTE
+        );
+        if (!this.startOfAlreadyLoadedPeriod) {
+            // First loading , no card loaded yet
+            this.askCardsForPeriod(start, end);
+            return;
+        }
+        if (start < this.startOfAlreadyLoadedPeriod && end > this.endOfAlreadyLoadedPeriod) {
+            this.askCardsForPeriod(start, end);
+            return;
+        }
+        if (start < this.startOfAlreadyLoadedPeriod) {
+            this.askCardsForPeriod(start, this.startOfAlreadyLoadedPeriod);
+            return;
+        }
+        if (end > this.endOfAlreadyLoadedPeriod) {
+            this.askCardsForPeriod(this.endOfAlreadyLoadedPeriod, end);
+            return;
+        }
+        this.logger.info('EventStreamService - Card already loaded for the chosen period', LogOption.LOCAL_AND_REMOTE);
+    }
+
+    private askCardsForPeriod(start: number, end: number) {
+        this.logger.info(
+            'EventStreamService - Need to load card for period ' + new Date(start) + ' -' + new Date(end),
+            LogOption.LOCAL_AND_REMOTE
+        );
+        this.opfabEventStreamServer.setBusinessPeriod(start, end).subscribe(() => {
+            if (!this.startOfAlreadyLoadedPeriod || start < this.startOfAlreadyLoadedPeriod)
+                this.startOfAlreadyLoadedPeriod = start;
+            if (!this.endOfAlreadyLoadedPeriod || end > this.endOfAlreadyLoadedPeriod)
+                this.endOfAlreadyLoadedPeriod = end;
+        });
+    }
+
+    getReceivedDisconnectUser(): Observable<boolean> {
+        return this.receivedDisconnectedSubject.asObservable();
+    }
+}

--- a/ui/main/src/app/modules/activityarea/activityarea.component.ts
+++ b/ui/main/src/app/modules/activityarea/activityarea.component.ts
@@ -1,4 +1,4 @@
-/* Copyright (c) 2022, RTE (http://www.rte-france.com)
+/* Copyright (c) 2022-2023, RTE (http://www.rte-france.com)
  * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -15,11 +15,11 @@ import {UserWithPerimeters} from '@ofModel/userWithPerimeters.model';
 import {FormControl, FormGroup} from '@angular/forms';
 import {SettingsService} from '@ofServices/settings.service';
 import {EntitiesService} from '@ofServices/entities.service';
-import {CardService} from '@ofServices/card.service';
 import {Utilities} from '../../business/common/utilities';
 import {GroupsService} from '@ofServices/groups.service';
 import {Actions, ofType} from '@ngrx/effects';
 import {UserActionsTypes} from '@ofStore/actions/user.actions';
+import {LightCardsStoreService} from '@ofServices/lightcards/lightcards-store.service';
 
 @Component({
     selector: 'of-activityarea',
@@ -51,7 +51,7 @@ export class ActivityareaComponent implements OnInit, OnDestroy {
         private groupsService: GroupsService,
         private modalService: NgbModal,
         private settingsService: SettingsService,
-        private cardService: CardService,
+        private lightCardStoreService : LightCardsStoreService,
         private actions$: Actions
     ) {}
 
@@ -201,7 +201,7 @@ export class ActivityareaComponent implements OnInit, OnDestroy {
                         this.messageAfterSavingSettings = 'shared.error.impossibleToSaveSettings';
                         this.displaySendResultError = true;
                     } else {
-                        this.cardService.removeAllLightCardFromMemory();
+                        this.lightCardStoreService.removeAllLightCards();
                         this.userService.loadUserWithPerimetersData().subscribe();
                     }
                     if (!!this.modalRef) this.modalRef.close();
@@ -221,7 +221,7 @@ export class ActivityareaComponent implements OnInit, OnDestroy {
         // The modal must not be closed until the settings has been saved in the back
         // If not, with slow network, when user goes to the feed before the end of the request
         // it ends up with nothing in the feed
-        // This happens because method this.cardService.removeAllLightCardFromMemory()
+        // This happens because method this.lightCardStoreService.removeAllLightCards();
         // is called too late (in method confirmSaveSettings)
         if (!this.saveSettingsInProgress) this.modalRef.close();
     }

--- a/ui/main/src/app/modules/card/components/card-ack/card-ack.component.ts
+++ b/ui/main/src/app/modules/card/components/card-ack/card-ack.component.ts
@@ -16,7 +16,6 @@ import {AcknowledgmentAllowedEnum, ConsideredAcknowledgedForUserWhenEnum, State}
 import {User} from '@ofModel/user.model';
 import {AcknowledgeService} from '@ofServices/acknowledge.service';
 import {AppService, PageType} from '@ofServices/app.service';
-import {CardService} from '@ofServices/card.service';
 import {EntitiesService} from '@ofServices/entities.service';
 import {LightCardsStoreService} from '@ofServices/lightcards/lightcards-store.service';
 import {LogOption, OpfabLoggerService} from '@ofServices/logs/opfab-logger.service';
@@ -65,7 +64,6 @@ export class CardAckComponent implements OnInit, OnChanges, OnDestroy {
         private userService: UserService,
         private userPermissionsService: UserPermissionsService,
         private processService: ProcessesService,
-        private cardService: CardService,
         private lightCardsStoreService: LightCardsStoreService,
         private logger: OpfabLoggerService
     ) {
@@ -75,7 +73,7 @@ export class CardAckComponent implements OnInit, OnChanges, OnDestroy {
 
     ngOnInit()  {
 
-            this.cardService
+            this.lightCardsStoreService
             .getReceivedAcks()
             .pipe(takeUntil(this.unsubscribe$))
             .subscribe((receivedAck) => {

--- a/ui/main/src/app/modules/card/components/card-acks-footer/card-acks-footer.component.ts
+++ b/ui/main/src/app/modules/card/components/card-acks-footer/card-acks-footer.component.ts
@@ -1,4 +1,4 @@
-/* Copyright (c) 2022, RTE (http://www.rte-france.com)
+/* Copyright (c) 2022-2023, RTE (http://www.rte-france.com)
  * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -9,8 +9,8 @@
 
 import {Component, Input, OnChanges, OnDestroy, OnInit} from '@angular/core';
 import {Card} from '@ofModel/card.model';
-import {CardService} from '@ofServices/card.service';
 import {EntitiesService} from '@ofServices/entities.service';
+import {LightCardsStoreService} from '@ofServices/lightcards/lightcards-store.service';
 import {Utilities} from 'app/business/common/utilities';
 import {Subject} from 'rxjs';
 import {takeUntil} from 'rxjs/operators';
@@ -26,10 +26,10 @@ export class CardAcksFooterComponent implements OnChanges, OnInit, OnDestroy {
 
     private unsubscribe$: Subject<void> = new Subject<void>();
 
-    constructor(private entitiesService: EntitiesService, private cardService: CardService) {}
+    constructor(private entitiesService: EntitiesService, private lightCardStoreService:LightCardsStoreService) {}
 
     ngOnInit() {
-        this.cardService
+        this.lightCardStoreService
             .getReceivedAcks()
             .pipe(takeUntil(this.unsubscribe$))
             .subscribe((receivedAck) => {

--- a/ui/main/src/app/modules/card/components/card-footer-text/card-footer-text.component.ts
+++ b/ui/main/src/app/modules/card/components/card-footer-text/card-footer-text.component.ts
@@ -10,13 +10,13 @@
 import {Component, Input, OnChanges, OnInit} from '@angular/core';
 import {Card} from '@ofModel/card.model';
 import {User} from '@ofModel/user.model';
-import {CardService} from '@ofServices/card.service';
 import {DateTimeFormatterService} from 'app/business/services/date-time-formatter.service';
 import {EntitiesService} from '@ofServices/entities.service';
 import {UserService} from '@ofServices/user.service';
 import {Utilities} from 'app/business/common/utilities';
 import {Subject} from 'rxjs';
 import {takeUntil} from 'rxjs/operators';
+import {LightCardsStoreService} from '@ofServices/lightcards/lightcards-store.service';
 
 @Component({
     selector: 'of-card-footer-text',
@@ -37,10 +37,10 @@ export class CardFooterTextComponent implements OnChanges,OnInit {
     private unsubscribe$: Subject<void> = new Subject<void>();
 
     constructor(
-        private cardService: CardService,
         private entitiesService: EntitiesService,
         private dateTimeFormatterService: DateTimeFormatterService,
-        private userService: UserService
+        private userService: UserService,
+        private lightCardsStoreService: LightCardsStoreService
     ) {
         const userWithPerimeters = this.userService.getCurrentUserWithPerimeters();
         if (!!userWithPerimeters) this.user = userWithPerimeters.userData;
@@ -48,7 +48,7 @@ export class CardFooterTextComponent implements OnChanges,OnInit {
 
     ngOnInit() {
 
-        this.cardService
+        this.lightCardsStoreService
             .getReceivedAcks()
             .pipe(takeUntil(this.unsubscribe$))
             .subscribe((receivedAck) => {

--- a/ui/main/src/app/modules/core/application-loading/app-loaded-in-another-tab/app-loaded-in-another-tab.component.ts
+++ b/ui/main/src/app/modules/core/application-loading/app-loaded-in-another-tab/app-loaded-in-another-tab.component.ts
@@ -1,4 +1,4 @@
-/* Copyright (c) 2022, RTE (http://www.rte-france.com)
+/* Copyright (c) 2022-2023, RTE (http://www.rte-france.com)
  * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -9,12 +9,12 @@
 
 import {Component, HostListener,TemplateRef, ViewChild} from '@angular/core';
 import {NgbModal, NgbModalRef} from '@ng-bootstrap/ng-bootstrap';
-import {CardService} from '@ofServices/card.service';
 import {LogOption, OpfabLoggerService} from '@ofServices/logs/opfab-logger.service';
 import {UrlLockService} from './url-lock.service';
 import {UserService} from '@ofServices/user.service';
 import {ApplicationLoadingStep} from '../application-loading-step';
 import {SoundNotificationService} from '@ofServices/sound-notification.service';
+import {OpfabEventStreamService} from 'app/business/services/opfabEventStream.service';
 
 /** This component checks if the url of opfab is already in use
  *  in the browser (there should not be several accounts connected
@@ -45,7 +45,7 @@ export class AppLoadedInAnotherTabComponent extends ApplicationLoadingStep {
     private isApplicationActive = false;
 
     constructor(
-        private cardService: CardService,
+        private opfabEventStreamService: OpfabEventStreamService,
         private urlLockService: UrlLockService,
         private modalService: NgbModal,
         private logger: OpfabLoggerService,
@@ -96,7 +96,7 @@ export class AppLoadedInAnotherTabComponent extends ApplicationLoadingStep {
             this.isDisconnectedByAnotherTab = true;
             this.isApplicationActive = false;
             this.soundNotificationService.stopService();
-            this.cardService.closeSubscription();
+            this.opfabEventStreamService.closeEventStream();
             const login = this.userService.getCurrentUserWithPerimeters().userData.login;
             this.logger.info(
                 'User ' + login + ' was disconnected by another browser tab having loaded the application',

--- a/ui/main/src/app/modules/core/session-end/session-end.component.ts
+++ b/ui/main/src/app/modules/core/session-end/session-end.component.ts
@@ -1,4 +1,4 @@
-/* Copyright (c) 2022, RTE (http://www.rte-france.com)
+/* Copyright (c) 2022-2023, RTE (http://www.rte-france.com)
  * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -11,10 +11,10 @@ import {Component, OnInit, TemplateRef, ViewChild, ViewEncapsulation} from '@ang
 import {NgbModal, NgbModalRef} from '@ng-bootstrap/ng-bootstrap';
 import {Actions, ofType} from '@ngrx/effects';
 import {Action, Store} from '@ngrx/store';
-import {CardService} from '@ofServices/card.service';
 import {LogOption, OpfabLoggerService} from '@ofServices/logs/opfab-logger.service';
 import {SoundNotificationService} from '@ofServices/sound-notification.service';
 import {AuthenticationActionTypes, TryToLogOutAction} from '@ofStore/actions/authentication.actions';
+import {OpfabEventStreamService} from 'app/business/services/opfabEventStream.service';
 
 @Component({
     selector: 'of-session-end',
@@ -29,7 +29,7 @@ export class SessionEndComponent implements OnInit {
 
     constructor(
         private store: Store,
-        private cardService: CardService,
+        private opfabEventStreamService : OpfabEventStreamService,
         private soundNotificationService: SoundNotificationService,
         private actions$: Actions,
         private modalService: NgbModal,
@@ -45,7 +45,7 @@ export class SessionEndComponent implements OnInit {
         this.actions$.pipe(ofType<Action>(AuthenticationActionTypes.SessionExpired)).subscribe(() => {
             this.logger.info('Session expire ', LogOption.REMOTE);
             this.soundNotificationService.handleSessionEnd();
-            this.cardService.closeSubscription();
+            this.opfabEventStreamService.closeEventStream();
             this.modalRef = this.modalService.open(this.sessionEndPopupRef, {
                 centered: true,
                 backdrop: 'static',
@@ -56,7 +56,7 @@ export class SessionEndComponent implements OnInit {
     }
 
     private subscribeToSessionClosedByNewUser() {
-        this.cardService.getReceivedDisconnectUser().subscribe((isDisconnected) => {
+        this.opfabEventStreamService.getReceivedDisconnectUser().subscribe((isDisconnected) => {
             this.isDisconnectedByNewUser = isDisconnected;
 
             if (isDisconnected) {

--- a/ui/main/src/app/modules/feedconfiguration/feedconfiguration.component.ts
+++ b/ui/main/src/app/modules/feedconfiguration/feedconfiguration.component.ts
@@ -16,9 +16,9 @@ import {UserWithPerimeters} from '@ofModel/userWithPerimeters.model';
 import {ProcessesService} from 'app/business/services/processes.service';
 import {FormArray, FormControl, FormGroup} from '@angular/forms';
 import {SettingsService} from '@ofServices/settings.service';
-import {CardService} from '@ofServices/card.service';
 import {TranslateService} from '@ngx-translate/core';
 import {Utilities} from '../../business/common/utilities';
+import {LightCardsStoreService} from '@ofServices/lightcards/lightcards-store.service';
 
 @Component({
     selector: 'of-feedconfiguration',
@@ -74,7 +74,7 @@ export class FeedconfigurationComponent implements OnInit, AfterViewInit {
         private processesService: ProcessesService,
         private modalService: NgbModal,
         private settingsService: SettingsService,
-        private cardService: CardService,
+        private lightCardStoreService: LightCardsStoreService,
         private translateService: TranslateService
     ) {
         this.processesStatesLabels = new Map();
@@ -368,7 +368,7 @@ export class FeedconfigurationComponent implements OnInit, AfterViewInit {
                         this.messageAfterSavingSettings = 'shared.error.impossibleToSaveSettings';
                         this.displaySendResultError = true;
                     } else {
-                        this.cardService.removeAllLightCardFromMemory();
+                        this.lightCardStoreService.removeAllLightCards();
                         this.userService.loadUserWithPerimetersData().subscribe();
                     }
                     this.modalRef.close();
@@ -386,7 +386,7 @@ export class FeedconfigurationComponent implements OnInit, AfterViewInit {
         // The modal must not be closed until the settings has been saved in the back
         // If not, with  slow network, when user go to the feed before the end of the request
         // it ends up with nothing in the feed
-        // This happens because method this.cardService.removeAllLightCardFromMemory()
+        // This happens because method this.lightCardStoreService.removeAllLightCards();
         // is called too late (in method confirmSaveSettings)
         if (!this.saveSettingsInProgress) this.modalRef.close();
     }

--- a/ui/main/src/app/modules/share/light-card/light-card.component.spec.ts
+++ b/ui/main/src/app/modules/share/light-card/light-card.component.spec.ts
@@ -28,6 +28,7 @@ import {ConfigServerMock} from '@tests/mocks/configServer.mock';
 import {ConfigServer} from 'app/business/server/config.server';
 import {ProcessServerMock} from '@tests/mocks/processServer.mock';
 import {ProcessServer} from 'app/business/server/process.server';
+import {OpfabEventStreamServer} from 'app/business/server/opfabEventStream.server';
 
 describe('LightCardComponent', () => {
     let lightCardDetailsComp: LightCardComponent;
@@ -67,7 +68,8 @@ describe('LightCardComponent', () => {
                 DateTimeFormatterService,
                 I18nService,
                 {provide: ConfigServer, useClass: ConfigServerMock},
-                {provide: ProcessServer, useClass: ProcessServerMock}
+                {provide: ProcessServer, useClass: ProcessServerMock},
+                {provide: OpfabEventStreamServer, use:null}
             ]
         }).compileComponents();
         store = TestBed.inject(Store);

--- a/ui/main/src/app/server/angularOpfabEventStream.server.ts
+++ b/ui/main/src/app/server/angularOpfabEventStream.server.ts
@@ -1,0 +1,135 @@
+/* Copyright (c) 2023, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
+ */
+
+import {HttpClient} from '@angular/common/http';
+import {Injectable} from '@angular/core';
+import {environment} from '@env/environment';
+import {AuthenticationService} from '@ofServices/authentication/authentication.service';
+import {LogOption, OpfabLoggerService} from '@ofServices/logs/opfab-logger.service';
+import {OpfabEventStreamServer} from 'app/business/server/opfabEventStream.server';
+import {ServerResponse} from 'app/business/server/serverResponse';
+import {GuidService} from 'app/business/services/guid.service';
+import {EventSourcePolyfill} from 'ng-event-source';
+import {Observable, Subject} from 'rxjs';
+import packageInfo from '../../../package.json';
+import {AngularServer} from './angular.server';
+
+@Injectable()
+export class AngularOpfabEventStreamServer extends AngularServer implements OpfabEventStreamServer {
+    private static TWO_MINUTES = 120000;
+    private eventStreamUrl: string;
+    private closeEventStreamUrl: string;
+
+    private businessEvents = new Subject<any>();
+    private streamInitDoneEvent = new Subject<void>();
+    private streamStatusEvents = new Subject<string>();
+
+    private lastHeardBeatDate = 0;
+    private firstSubscriptionInitDone = false;
+    private eventSource;
+
+    constructor(
+        private authService: AuthenticationService,
+        guidService: GuidService,
+        private logger: OpfabLoggerService,
+        private httpClient: HttpClient
+    ) {
+        super();
+        const clientId = guidService.getCurrentGuidString();
+        this.eventStreamUrl = `${environment.urls.cards}/cardSubscription?clientId=${clientId}&version=${packageInfo.opfabVersion}`;
+        this.closeEventStreamUrl = `${environment.urls.cards}/cardSubscription?clientId=${clientId}`;
+    }
+
+    public initStream() {
+        // security header needed here as SSE request are not intercepted by our angular header interceptor
+        let securityHeader;
+        if (!this.authService.isAuthModeNone()) {
+            securityHeader = this.authService.getSecurityHeader();
+        }
+        this.eventSource = new EventSourcePolyfill(`${this.eventStreamUrl}&notification=true`, {
+            headers: securityHeader
+            // if necessary, we can set here internal heartbeatTimeout: xxx (in ms)
+        });
+
+        this.checkHeartBeatReceive();
+
+        this.eventSource.onmessage = (message) => {
+            if (message.data === 'HEARTBEAT') {
+                this.lastHeardBeatDate = new Date().valueOf();
+                this.logger.info(`EventStreamServer - HEARTBEAT received - Connection alive `, LogOption.LOCAL);
+            } else {
+                if (message.data === 'INIT') {
+                    if (this.firstSubscriptionInitDone) {
+                        this.recoverAnyLostCardWhenConnectionHasBeenReset();
+                        // process or user config may have change during connection loss
+                        // so reload both configuration
+                        this.businessEvents.next({data: 'BUSINESS_CONFIG_CHANGE'});
+                        this.businessEvents.next({data: 'USER_CONFIG_CHANGE'});
+                    } else {
+                        this.firstSubscriptionInitDone = true;
+                        this.streamInitDoneEvent.next();
+                        this.streamInitDoneEvent.complete();
+                        this.lastHeardBeatDate = new Date().valueOf();
+                    }
+                } else this.businessEvents.next(message);
+            }
+        };
+        this.eventSource.onerror = (error) => {
+            this.streamStatusEvents.next('close');
+            console.error(new Date().toISOString(), 'EventStreamServer - Error event in card subscription:', error);
+        };
+        this.eventSource.onopen = (open) => {
+            this.streamStatusEvents.next('open');
+            console.log(new Date().toISOString(), `EventStreamServer - Open card subscription`);
+        };
+    }
+
+    private checkHeartBeatReceive() {
+        setInterval(() => {
+            this.logger.info(
+                'EventStreamServer - Last heart beat received ' +
+                    (new Date().valueOf() - this.lastHeardBeatDate) +
+                    'ms ago',
+                LogOption.LOCAL_AND_REMOTE
+            );
+        }, 60000);
+    }
+
+    private recoverAnyLostCardWhenConnectionHasBeenReset() {
+        // Subtracts two minutes from the last heart beat to avoid loosing card due to latency, buffering and not synchronized clock
+        const dateForRecovering = this.lastHeardBeatDate - AngularOpfabEventStreamServer.TWO_MINUTES;
+        this.logger.info(
+            `EventStreamServer - Card subscription has been init again , recover any lost card from date ` +
+                new Date(dateForRecovering),
+            LogOption.LOCAL_AND_REMOTE
+        );
+        this.httpClient.post<any>(`${this.eventStreamUrl}`, {publishFrom: dateForRecovering}).subscribe();
+    }
+
+    public getStreamInitDone(): Observable<void> {
+        return this.streamInitDoneEvent.asObservable();
+    }
+
+    public closeStream() {
+        this.httpClient.delete<any>(`${this.closeEventStreamUrl}`).subscribe();
+        this.eventSource.close();
+    }
+    public getEvents(): Observable<any> {
+        return this.businessEvents.asObservable();
+    }
+    public getStreamStatus(): Observable<any> {
+        return this.streamStatusEvents.asObservable();
+    }
+
+    public setBusinessPeriod(startDate: number, endDate: number): Observable<ServerResponse<any>> {
+        return this.processHttpResponse(
+            this.httpClient.post<any>(`${this.eventStreamUrl}`, {rangeStart: startDate, rangeEnd: endDate})
+        );
+    }
+}

--- a/ui/main/src/app/services/acknowledge.service.spec.ts
+++ b/ui/main/src/app/services/acknowledge.service.spec.ts
@@ -27,6 +27,7 @@ import {ConfigServer} from 'app/business/server/config.server';
 import {ConfigServerMock} from '@tests/mocks/configServer.mock';
 import {ProcessServer} from 'app/business/server/process.server';
 import {ProcessServerMock} from '@tests/mocks/processServer.mock';
+import {OpfabEventStreamService} from 'app/business/services/opfabEventStream.service';
 
 describe('AcknowledgeService testing ', () => {
     let acknowledgeService: AcknowledgeService;
@@ -44,7 +45,8 @@ describe('AcknowledgeService testing ', () => {
                 {provide: ConfigServer, useClass: ConfigServerMock},
                 {provide: ProcessServer, useClass: ProcessServerMock},
                 LightCardsStoreService,
-                {provide: EntitiesService, useClass: EntitiesServiceMock}
+                {provide: EntitiesService, useClass: EntitiesServiceMock},
+                {provide : OpfabEventStreamService, useValue: null}
             ],
             imports: [
                 StoreModule.forRoot(appReducer),

--- a/ui/main/src/app/services/card.service.ts
+++ b/ui/main/src/app/services/card.service.ts
@@ -8,84 +8,36 @@
  */
 
 import {Injectable} from '@angular/core';
-import {Observable, Subject} from 'rxjs';
-import {CardOperation, CardOperationType} from '@ofModel/card-operation.model';
-import {EventSourcePolyfill} from 'ng-event-source';
-import {AuthenticationService} from './authentication/authentication.service';
+import {Observable} from 'rxjs';
 import {Card, CardData, CardForPublishing, fromCardToLightCard} from '@ofModel/card.model';
 import {HttpClient, HttpParams, HttpResponse} from '@angular/common/http';
 import {environment} from '@env/environment';
-import {GuidService} from 'app/business/services/guid.service';
 import {LightCard} from '@ofModel/light-card.model';
 import {Page} from '@ofModel/page.model';
-import {AppState} from '@ofStore/index';
-import {Store} from '@ngrx/store';
-import {
-    CardSubscriptionClosedAction,
-    CardSubscriptionOpenAction,
-    UIReloadRequestedAction
-} from '@ofActions/cards-subscription.actions';
-import {catchError, map, takeUntil} from 'rxjs/operators';
-import {RemoveLightCardAction} from '@ofActions/light-card.actions';
-import {BusinessConfigChangeAction} from '@ofStore/actions/processes.actions';
-import {UserConfigChangeAction} from '@ofStore/actions/user.actions';
+import {map} from 'rxjs/operators';
 import {LightCardsStoreService} from './lightcards/lightcards-store.service';
-import {LoadCardAction} from '@ofStore/actions/card.actions';
 import {I18n} from '@ofModel/i18n.model';
-import {FilterService} from '@ofServices/lightcards/filter.service';
-import {LogOption, OpfabLoggerService} from './logs/opfab-logger.service';
-import packageInfo from '../../../package.json';
-import {SoundNotificationService} from './sound-notification.service';
 import {ArchivedCardsFilter} from '@ofModel/archived-cards-filter.model';
 
 @Injectable({
     providedIn: 'root'
 })
 export class CardService {
-
-    private static TWO_MINUTES = 120000;
-
-    readonly cardOperationsUrl: string;
-    readonly deleteCardSubscriptionUrl: string;
     readonly cardsUrl: string;
     readonly archivesUrl: string;
     readonly cardsPubUrl: string;
     readonly userCardReadUrl: string;
     readonly userCardUrl: string;
-    private lastHeardBeatDate = 0;
-    private firstSubscriptionInitDone = false;
-    public initSubscription = new Subject<void>();
-    private unsubscribe$: Subject<void> = new Subject<void>();
-
-    private startOfAlreadyLoadedPeriod: number;
-    private endOfAlreadyLoadedPeriod: number;
-
-    private selectedCardId: string = null;
-
-    private receivedAcksSubject = new Subject<{cardUid: string; entitiesAcks: string[]}>();
-    private receivedDisconnectedSubject = new Subject<boolean>();
-
-    private subscriptionClosed = false;
 
     constructor(
         private httpClient: HttpClient,
-        private guidService: GuidService,
-        private store: Store<AppState>,
-        private authService: AuthenticationService,
         private lightCardsStoreService: LightCardsStoreService,
-        private filterService: FilterService,
-        private soundNotificationService: SoundNotificationService,
-        private logger: OpfabLoggerService
     ) {
-        const clientId = this.guidService.getCurrentGuidString();
-        this.cardOperationsUrl = `${environment.urls.cards}/cardSubscription?clientId=${clientId}&version=${packageInfo.opfabVersion}`;
-        this.deleteCardSubscriptionUrl = `${environment.urls.cards}/cardSubscription?clientId=${clientId}`;
         this.cardsUrl = `${environment.urls.cards}/cards`;
         this.archivesUrl = `${environment.urls.cards}/archives`;
         this.cardsPubUrl = `${environment.urls.cardspub}/cards`;
         this.userCardReadUrl = `${environment.urls.cardspub}/cards/userCardRead`;
         this.userCardUrl = `${environment.urls.cardspub}/cards/userCard`;
-        this.checkHeartBeatReceive();
     }
 
     loadCard(id: string): Observable<CardData> {
@@ -98,244 +50,6 @@ export class CardService {
                 return cardData;
             })
         );
-    }
-
-    public setSelectedCard(cardId) {
-        this.selectedCardId = cardId;
-    }
-
-    public initCardSubscription() {
-        this.getCardSubscription()
-            .pipe(takeUntil(this.unsubscribe$))
-            .subscribe({
-                next: (operation) => {
-                    switch (operation.type) {
-                        case CardOperationType.ADD:
-                            this.logger.info(
-                                'CardService - Receive card to add id=' +
-                                    operation.card.id +
-                                    ' with date=' +
-                                    new Date(operation.card.publishDate).toISOString(),
-                                LogOption.LOCAL_AND_REMOTE
-                            );
-                            this.lightCardsStoreService.addOrUpdateLightCard(operation.card);
-                            if (operation.card.id === this.selectedCardId)
-                                this.store.dispatch(new LoadCardAction({id: operation.card.id}));
-                            break;
-                        case CardOperationType.DELETE:
-                            this.logger.info(
-                                `CardService - Receive card to delete id=` + operation.cardId,
-                                LogOption.LOCAL_AND_REMOTE
-                            );
-                            this.lightCardsStoreService.removeLightCard(operation.cardId);
-                            if (operation.cardId === this.selectedCardId)
-                                this.store.dispatch(new RemoveLightCardAction({card: operation.cardId}));
-                            break;
-                        case CardOperationType.ACK:
-                            this.logger.info(
-                                'CardService - Receive ack on card uid=' +
-                                    operation.cardUid +
-                                    ', id=' +
-                                    operation.cardId,
-                                LogOption.LOCAL_AND_REMOTE
-                            );
-                            this.lightCardsStoreService.addEntitiesAcksForLightCard(
-                                operation.cardId,
-                                operation.entitiesAcks
-                            );
-                            this.receivedAcksSubject.next({
-                                cardUid: operation.cardUid,
-                                entitiesAcks: operation.entitiesAcks
-                            });
-                            break;
-                        default:
-                            this.logger.info(
-                                `CardService - Unknown operation ` +
-                                    operation.type +
-                                    ` for card id=` +
-                                    operation.cardId,
-                                LogOption.LOCAL_AND_REMOTE
-                            );
-                    }
-                },
-                error: (error) => {
-                    console.error('CardService - Error received from  getCardSubscription ', error);
-                }
-            });
-        catchError((error, caught) => {
-            console.error('CardService - Global  error in subscription ', error);
-            return caught;
-        });
-        this.listenForFilterChange();
-    }
-
-    private listenForFilterChange() {
-        this.filterService.getBusinessDateFilterChanges().subscribe((filter) => {
-            this.setSubscriptionDates(filter.status.start, filter.status.end);
-        });
-    }
-
-    public closeSubscription() {
-        if (!this.subscriptionClosed) {
-            this.logger.info('Closing subscription', LogOption.LOCAL_AND_REMOTE);
-            this.deleteCardSubscription().subscribe();
-            this.unsubscribe$.next();
-            this.unsubscribe$.complete();
-            this.subscriptionClosed = true;
-        }
-    }
-
-    private deleteCardSubscription(): Observable<HttpResponse<void>> {
-        return this.httpClient.delete<any>(`${this.deleteCardSubscriptionUrl}`, {observe: 'response'});
-    }
-
-    private getCardSubscription(): Observable<CardOperation> {
-        // security header needed here as SSE request are not intercepted by our header interceptor
-        let securityHeader;
-        if (!this.authService.isAuthModeNone()) {
-            securityHeader = this.authService.getSecurityHeader();
-        }
-        const eventSource = new EventSourcePolyfill(`${this.cardOperationsUrl}&notification=true`, {
-            headers: securityHeader
-            // if necessary, we can set here heartbeatTimeout: xxx (in ms)
-        });
-        return new Observable((observer) => {
-            try {
-                eventSource.onmessage = (message) => {
-                    if (!message) {
-                        return observer.error(message);
-                    }
-                    switch (message.data) {
-                        case 'RELOAD':
-                            this.logger.info(`CardService - RELOAD received`, LogOption.LOCAL_AND_REMOTE);
-                            this.store.dispatch(new UIReloadRequestedAction());
-                            break;
-                        case 'INIT':
-                            console.log(new Date().toISOString(), `CardService - Card subscription initialized`);
-                            this.initSubscription.next();
-                            this.initSubscription.complete();
-                            if (this.firstSubscriptionInitDone) {
-                                this.recoverAnyLostCardWhenConnectionHasBeenReset();
-                                // process or user config may have change during connection loss
-                                // so reload both configuration
-                                this.store.dispatch(new BusinessConfigChangeAction());
-                                this.store.dispatch(new UserConfigChangeAction());
-                            } else {
-                                this.firstSubscriptionInitDone = true;
-                                this.lastHeardBeatDate = new Date().valueOf();
-                            }
-                            break;
-                        case 'HEARTBEAT':
-                            this.lastHeardBeatDate = new Date().valueOf();
-                            this.logger.info(`CardService - HEARTBEAT received - Connection alive `, LogOption.LOCAL);
-                            break;
-                        case 'BUSINESS_CONFIG_CHANGE':
-                            this.store.dispatch(new BusinessConfigChangeAction());
-                            this.logger.info(`CardService - BUSINESS_CONFIG_CHANGE received`);
-                            break;
-                        case 'USER_CONFIG_CHANGE':
-                            this.store.dispatch(new UserConfigChangeAction());
-                            this.logger.info(`CardService - USER_CONFIG_CHANGE received`);
-                            break;
-                        case 'DISCONNECT_USER_DUE_TO_NEW_CONNECTION':
-                            this.logger.info(
-                                'CardService - Disconnecting user because a new connection is being opened for this account'
-                            );
-                            this.soundNotificationService.stopService();
-                            this.closeSubscription();
-                            this.receivedDisconnectedSubject.next(true);
-                            break;
-                        default:
-                            return observer.next(JSON.parse(message.data, CardOperation.convertTypeIntoEnum));
-                    }
-                };
-                eventSource.onerror = (error) => {
-                    this.store.dispatch(new CardSubscriptionClosedAction());
-                    console.error(new Date().toISOString(), 'CardService - Error event in card subscription:', error);
-                };
-                eventSource.onopen = (open) => {
-                    this.store.dispatch(new CardSubscriptionOpenAction());
-                    console.log(new Date().toISOString(), `CardService- Open card subscription`);
-                };
-            } catch (error) {
-                console.error(
-                    new Date().toISOString(),
-                    'CardService - Error in interpreting message from subscription',
-                    error
-                );
-                return observer.error(error);
-            }
-            return () => {
-                if (eventSource && eventSource.readyState !== eventSource.CLOSED) {
-                    eventSource.close();
-                }
-            };
-        });
-    }
-
-    private checkHeartBeatReceive() {
-        setInterval(() => {
-            this.logger.info(
-                'Last heart beat received ' + (new Date().valueOf() - this.lastHeardBeatDate) + 'ms ago',
-                LogOption.LOCAL_AND_REMOTE
-            );
-        }, 60000);
-    }
-
-    private recoverAnyLostCardWhenConnectionHasBeenReset() {
-        // Subtracts two minutes from the last heart beat to avoid loosing card due to latency, buffering and not synchronized clock
-        const dateForRecovering = this.lastHeardBeatDate - CardService.TWO_MINUTES;
-        this.logger.info(
-            `CardService - Card subscription has been init again , recover any lost card from date ` +
-                new Date(dateForRecovering),
-            LogOption.LOCAL_AND_REMOTE
-        );
-        this.httpClient.post<any>(`${this.cardOperationsUrl}`, {publishFrom: dateForRecovering}).subscribe();
-    }
-
-    public removeAllLightCardFromMemory() {
-        this.startOfAlreadyLoadedPeriod = null;
-        this.lightCardsStoreService.removeAllLightCards();
-    }
-
-    private setSubscriptionDates(start: number, end: number) {
-        this.logger.info(
-            'CardService - Set subscription date' + new Date(start) + ' -' + new Date(end),
-            LogOption.LOCAL_AND_REMOTE
-        );
-        if (!this.startOfAlreadyLoadedPeriod) {
-            // First loading , no card loaded yet
-            this.askCardsForPeriod(start, end);
-            return;
-        }
-        if (start < this.startOfAlreadyLoadedPeriod && end > this.endOfAlreadyLoadedPeriod) {
-            this.askCardsForPeriod(start, end);
-            return;
-        }
-        if (start < this.startOfAlreadyLoadedPeriod) {
-            this.askCardsForPeriod(start, this.startOfAlreadyLoadedPeriod);
-            return;
-        }
-        if (end > this.endOfAlreadyLoadedPeriod) {
-            this.askCardsForPeriod(this.endOfAlreadyLoadedPeriod, end);
-            return;
-        }
-        this.logger.info('CardService - Card already loaded for the chosen period', LogOption.LOCAL_AND_REMOTE);
-    }
-
-    private askCardsForPeriod(start: number, end: number) {
-        this.logger.info(
-            'CardService - Need to load card for period ' + new Date(start) + ' -' + new Date(end),
-            LogOption.LOCAL_AND_REMOTE
-        );
-        this.httpClient
-            .post<any>(`${this.cardOperationsUrl}`, {rangeStart: start, rangeEnd: end})
-            .subscribe((result) => {
-                if (!this.startOfAlreadyLoadedPeriod || start < this.startOfAlreadyLoadedPeriod)
-                    this.startOfAlreadyLoadedPeriod = start;
-                if (!this.endOfAlreadyLoadedPeriod || end > this.endOfAlreadyLoadedPeriod)
-                    this.endOfAlreadyLoadedPeriod = end;
-            });
     }
 
     loadArchivedCard(id: string): Observable<CardData> {
@@ -373,13 +87,5 @@ export class CardService {
         return this.httpClient.post<any>(`${this.cardsPubUrl}/translateCardField`, fieldToTranslate, {
             observe: 'response'
         });
-    }
-
-    getReceivedAcks(): Observable<{cardUid: string; entitiesAcks: string[]}> {
-        return this.receivedAcksSubject.asObservable();
-    }
-
-    getReceivedDisconnectUser(): Observable<boolean> {
-        return this.receivedDisconnectedSubject.asObservable();
     }
 }

--- a/ui/main/src/app/services/sound-notification.service.ts
+++ b/ui/main/src/app/services/sound-notification.service.ts
@@ -19,6 +19,7 @@ import {filter, map, switchMap, takeUntil} from 'rxjs/operators';
 import {ExternalDevicesService} from '@ofServices/external-devices.service';
 import {ConfigService} from 'app/business/services/config.service';
 import {LogOption, OpfabLoggerService} from './logs/opfab-logger.service';
+import {OpfabEventStreamService} from 'app/business/services/opfabEventStream.service';
 
 @Injectable({
     providedIn: 'root'
@@ -58,6 +59,7 @@ export class SoundNotificationService implements OnDestroy {
         private lightCardsStoreService: LightCardsStoreService,
         private externalDevicesService: ExternalDevicesService,
         private configService: ConfigService,
+        private opfabEventStreamService: OpfabEventStreamService,
         private logger: OpfabLoggerService
     ) {
         // use to have access from cypress to the current object for stubbing method playSound
@@ -113,6 +115,7 @@ export class SoundNotificationService implements OnDestroy {
         this.initSoundPlayingForSessionEnd();
 
         this.listenForCardUpdate();
+        this.listenForDisconnection();
     }
 
 
@@ -130,6 +133,10 @@ export class SoundNotificationService implements OnDestroy {
 
     private listenForCardUpdate() {
         this.lightCardsStoreService.getNewLightCards().subscribe((card) => this.handleLoadedCard(card));
+    }
+
+    private listenForDisconnection() {
+        this.opfabEventStreamService.getReceivedDisconnectUser().subscribe( () => this.stopService());
     }
 
     ngOnDestroy() {

--- a/ui/main/src/app/store/effects/authentication.effects.spec.ts
+++ b/ui/main/src/app/store/effects/authentication.effects.spec.ts
@@ -41,6 +41,14 @@ import {injectedSpy} from '@tests/helpers';
 import SpyObj = jasmine.SpyObj;
 import createSpyObj = jasmine.createSpyObj;
 import {SoundNotificationService} from '@ofServices/sound-notification.service';
+import {OpfabEventStreamServer} from 'app/business/server/opfabEventStream.server';
+import {UserService} from '@ofServices/user.service';
+import {ProcessServer} from 'app/business/server/process.server';
+import {ConfigServer} from 'app/business/server/config.server';
+import {ConfigServerMock} from '@tests/mocks/configServer.mock';
+import {EntitiesService} from '@ofServices/entities.service';
+import {RemoteLoggerService} from '@ofServices/logs/remote-logger.service';
+import {OpfabEventStreamService} from 'app/business/services/opfabEventStream.service';
 
 describe('AuthenticationEffects', () => {
     let actions$: Observable<any>;
@@ -80,7 +88,14 @@ describe('AuthenticationEffects', () => {
                 {provide: Store, useValue: storeSpy},
                 {provide: Router, useValue: routerSpy},
                 {provide: ConfigService, useValue: configServiceSpy},
-                {provide: SoundNotificationService, useValue: soundNotificationService}
+                {provide: SoundNotificationService, useValue: soundNotificationService},
+                {provide: OpfabEventStreamServer, useValue:null},
+                {provide: OpfabEventStreamService, useValue:null},
+                {provide: UserService, useValue:null},
+                {provide: EntitiesService, useValue:null},
+                {provide: RemoteLoggerService, useValue:null},
+                {provide: ProcessServer, useValue:null},
+                {provide: ConfigServer, ConfigServerMock}
             ]
         });
 
@@ -109,7 +124,7 @@ describe('AuthenticationEffects', () => {
                 authenticationService,
                 null,
                 configService,
-                cardService,
+                null,
                 soundNotificationService
             );
             expect(effects).toBeTruthy();
@@ -117,6 +132,7 @@ describe('AuthenticationEffects', () => {
                 expect(action.type).toEqual(AuthenticationActionTypes.AcceptLogIn)
             );
         });
+
         it('should fail if JWT is not generated from backend', () => {
             const localAction$ = new Actions(
                 hot('-a--', {a: new TryToLogInAction({username: 'johndoe', password: 'pwd'})})
@@ -128,7 +144,7 @@ describe('AuthenticationEffects', () => {
                 authenticationService,
                 null,
                 configService,
-                cardService,
+                null,
                 soundNotificationService
             );
             expect(effects).toBeTruthy();
@@ -142,7 +158,7 @@ describe('AuthenticationEffects', () => {
         it('should success and navigate', () => {
             const localAction$ = new Actions(hot('-a--', {a: new AcceptLogOutAction()}));
             router.navigate.and.callThrough();
-            effects = new AuthenticationEffects(mockStore, localAction$, null, router, configService, cardService,soundNotificationService);
+            effects = new AuthenticationEffects(mockStore, localAction$, null, router, configService, null,soundNotificationService);
             expect(effects).toBeTruthy();
             effects.AcceptLogOut.subscribe((action: AuthenticationActions) => {
                 expect(action.type).toEqual(AuthenticationActionTypes.AcceptLogOutSuccess);
@@ -166,7 +182,7 @@ describe('AuthenticationEffects', () => {
                 authenticationService,
                 router,
                 configService,
-                cardService,
+                null,
                 soundNotificationService
             );
             expect(effects).toBeTruthy();
@@ -187,7 +203,7 @@ describe('AuthenticationEffects', () => {
                 authenticationService,
                 router,
                 configService,
-                cardService,
+                null,
                 soundNotificationService
             );
             expect(effects).toBeTruthy();
@@ -206,7 +222,7 @@ describe('AuthenticationEffects', () => {
                 authenticationService,
                 router,
                 configService,
-                cardService,
+                null,
                 soundNotificationService
             );
             expect(effects).toBeTruthy();

--- a/ui/main/src/app/store/effects/authentication.effects.ts
+++ b/ui/main/src/app/store/effects/authentication.effects.ts
@@ -29,8 +29,8 @@ import {Message, MessageLevel} from '@ofModel/message.model';
 import {I18n} from '@ofModel/i18n.model';
 import {ConfigService} from 'app/business/services/config.service';
 import {redirectToCurrentLocation} from '../../app-routing.module';
-import {CardService} from '@ofServices/card.service';
 import {SoundNotificationService} from '@ofServices/sound-notification.service';
+import {OpfabEventStreamService} from 'app/business/services/opfabEventStream.service';
 
 /**
  * Management of the authentication of the current user
@@ -43,7 +43,7 @@ export class AuthenticationEffects {
         private authService: AuthenticationService,
         private router: Router,
         private configService: ConfigService,
-        private cardService: CardService,
+        private opfabEventStreamService: OpfabEventStreamService,
         private soundNotificationService: SoundNotificationService
     ) {}
 
@@ -264,7 +264,7 @@ export class AuthenticationEffects {
     }
 
     private resetState() {
-        this.cardService.closeSubscription();
+        this.opfabEventStreamService.closeEventStream();
         this.authService.clearAuthenticationInformation();
         window.location.href = this.configService.getConfigValue('security.logout-url', 'https://opfab.github.io');
     }

--- a/ui/main/src/app/store/effects/card-operation.effects.ts
+++ b/ui/main/src/app/store/effects/card-operation.effects.ts
@@ -1,4 +1,4 @@
-/* Copyright (c) 2018-2022, RTE (http://www.rte-france.com)
+/* Copyright (c) 2018-2023, RTE (http://www.rte-france.com)
  * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -9,7 +9,6 @@
 
 import {Injectable} from '@angular/core';
 import {Actions, createEffect, ofType} from '@ngrx/effects';
-import {CardService} from '@ofServices/card.service';
 import {EMPTY, Observable} from 'rxjs';
 import {map, switchMap, withLatestFrom} from 'rxjs/operators';
 import {LightCardActionTypes, RemoveLightCardAction, SelectLightCardAction} from '@ofActions/light-card.actions';
@@ -17,13 +16,14 @@ import {Store} from '@ngrx/store';
 import {AppState} from '@ofStore/index';
 import {selectCardStateSelectedId} from '@ofSelectors/card.selectors';
 import {AppService} from '@ofServices/app.service';
+import {LightCardsStoreService} from '@ofServices/lightcards/lightcards-store.service';
 
 @Injectable()
 export class CardOperationEffects {
     constructor(
         private store: Store<AppState>,
         private actions$: Actions,
-        private cardService: CardService,
+        private lightCardsStoreService: LightCardsStoreService,
         private appService: AppService
     ) {}
 
@@ -45,7 +45,7 @@ export class CardOperationEffects {
         () =>
             this.actions$.pipe(
                 ofType(LightCardActionTypes.SelectLightCard),
-                map((a: SelectLightCardAction) => this.cardService.setSelectedCard(a.payload.selectedCardId))
+                map((a: SelectLightCardAction) => this.lightCardsStoreService.setSelectedCard(a.payload.selectedCardId))
             ),
         {dispatch: false}
     );

--- a/ui/main/src/app/store/effects/card.effects.ts
+++ b/ui/main/src/app/store/effects/card.effects.ts
@@ -1,4 +1,4 @@
-/* Copyright (c) 2018-2022, RTE (http://www.rte-france.com)
+/* Copyright (c) 2018-2023, RTE (http://www.rte-france.com)
  * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -22,10 +22,11 @@ import {
     LoadCardSuccessAction
 } from '@ofActions/card.actions';
 import {ClearLightCardSelectionAction, LightCardActionTypes} from '@ofStore/actions/light-card.actions';
+import {LightCardsStoreService} from '@ofServices/lightcards/lightcards-store.service';
 
 @Injectable()
 export class CardEffects {
-    constructor(private store: Store<AppState>, private actions$: Actions, private service: CardService) {}
+    constructor(private store: Store<AppState>, private actions$: Actions, private service: CardService,private lightCardsStoreService: LightCardsStoreService) {}
 
     loadById: Observable<Action> = createEffect(() =>
         this.actions$.pipe(
@@ -43,7 +44,7 @@ export class CardEffects {
         this.actions$.pipe(
             ofType<ClearLightCardSelectionAction>(LightCardActionTypes.ClearLightCardSelection),
             map(() => {
-                this.service.setSelectedCard(null);
+                this.lightCardsStoreService.setSelectedCard(null);
                 return new ClearCardAction();
             })
         )


### PR DESCRIPTION
Isolate the code that manage the realtime connection to opfab using an interface ui/main/src/app/business/server/opfabEventStream.server.ts implemented in ui/main/src/app/server/angularOpfabEventStream.server.ts

This class manage technically the connection (heartbeat management, recovery ..) 

The business management of the events is shared between 
- A new  class ui/main/src/app/business/services/opfabEventStream.service.ts  for the general events 
- The existing class ui/main/src/app/services/lightcards/lightcards-store.service.ts for the events regarding cards 

The lightcards-store does not access directly to the event stream server but uses the event stream **service** (opfabEventStream.service.ts)

The resulting card.service.ts is now mainly a gateway to the back for cards operations , it will be refactor to be coherent with new UI architecture in an another issue

The ui/main/src/app/services/lightcards/lightcards-store.service.ts becomes rather big so it may be cut in an another issue

Nothing in release note 