### PR TITLE
User card: missing translation for error message when expiration date before start date (#4094)

### DIFF
--- a/ui/main/src/app/modules/usercard/usercard.component.ts
+++ b/ui/main/src/app/modules/usercard/usercard.component.ts
@@ -631,7 +631,7 @@ export class UserCardComponent implements OnInit {
             return false;
         }
         if (!!expirationDate && expirationDate < startDate) {
-            this.displayMessage('shared.expirationDateBeforeStartDate', '', MessageLevel.ERROR);
+            this.displayMessage('userCard.error.expirationDateBeforeStartDate', '', MessageLevel.ERROR);
             return false;
         }
         return true;

--- a/ui/main/src/assets/i18n/en.json
+++ b/ui/main/src/assets/i18n/en.json
@@ -297,7 +297,8 @@
       "templateError": "Technical error : invalid template",
       "impossibleToSendCard": "Impossible to send card for technical reasons",
       "lttdBeforeStartDate": "Limit date for response must be after start date.",
-      "lttdAfterEndDate": "Limit date for response must be before end date."
+      "lttdAfterEndDate": "Limit date for response must be before end date.",
+      "expirationDateBeforeStartDate": "Expiration date must be after start date."
     },
     "filters": {
       "severity": "SEVERITY",

--- a/ui/main/src/assets/i18n/fr.json
+++ b/ui/main/src/assets/i18n/fr.json
@@ -297,7 +297,8 @@
       "templateError" : "Erreur technique : template non conforme",
       "impossibleToSendCard" : "Impossible d'envoyer la carte pour des raisons techniques",
       "lttdBeforeStartDate": "La date limite de réponse doit être postérieure à la date de début.",
-      "lttdAfterEndDate": "La date limite de réponse doit être antérieure à la date de fin."
+      "lttdAfterEndDate": "La date limite de réponse doit être antérieure à la date de fin.",
+      "expirationDateBeforeStartDate": "La date d'expiration doit être postérieure à la date de début."
     },
     "filters": {
       "severity": "SÉVÉRITÉ",

--- a/ui/main/src/assets/i18n/nl.json
+++ b/ui/main/src/assets/i18n/nl.json
@@ -297,7 +297,8 @@
       "templateError": "Technische fout: ongeldige sjabloon",
       "impossibleToSendCard": "Om technische redenen is het onmogelijk om de kaart te verzenden",
       "lttdBeforeStartDate": "De beperkingsdatum voor reactie moet na de startdatum liggen.",
-      "lttdAfterEndDate": "De beperkingsdatum voor reactie moet vóór de einddatum liggen."
+      "lttdAfterEndDate": "De beperkingsdatum voor reactie moet vóór de einddatum liggen.",
+      "expirationDateBeforeStartDate": "De vervaldatum moet na de startdatum liggen."
     },
     "filters": {
       "severity": "ERNST",


### PR DESCRIPTION
Nothing in release notes.