### PR TITLE
Fix Admin menu entry not translated in french (#4092)

### DIFF
--- a/config/docker/ui-config/ui-menu.json
+++ b/config/docker/ui-config/ui-menu.json
@@ -181,10 +181,10 @@
         },
         "adminmenu": {
           "title": {
-            "admin": "Admin menu"
+            "admin": "Menu admin"
           },
           "entry": {
-            "admin": "Admin menu entry"
+            "admin": "Menu admin élément"
           }
         }
       }


### PR DESCRIPTION
Fix #4092

Signed-off-by: Giovanni Ferrari <giovanni.ferrari@soft.it>

- In release note :
  -  In chapter :  Bugs 
  -  Text : #4092 : Fix Admin menu entry not translated in french