### PR TITLE
Usercard template does not change when switching from same state id in a different process (#4154)

### DIFF
--- a/ui/main/src/app/modules/usercard/selectStateForm/usercard-select-state-form.component.ts
+++ b/ui/main/src/app/modules/usercard/selectStateForm/usercard-select-state-form.component.ts
@@ -241,8 +241,8 @@ export class UserCardSelectStateFormComponent implements OnInit, OnDestroy {
                     const oldSelectedState = this.selectedState;
                     this.selectedState = this.stateOptions[0].value;
 
-                   // in case the state is the same as before , the selected value does not change for the select component 
-                   // so we need to send the event here instead of waiting for the event state change 
+                   // in case the state is the same as before , the selected value does not change for the selected component
+                   // so we need to send the event here instead of waiting for the event state change
                     if (this.selectedState === oldSelectedState) {
                         this.stateChange.emit({
                             selectedProcessId: this.selectStateForm.get('usercardProcess').value,
@@ -273,9 +273,10 @@ export class UserCardSelectStateFormComponent implements OnInit, OnDestroy {
             )
             .subscribe((state) => {
                 if (!!state) {
+                    this.selectedState = this.selectStateForm.get('usercardState').value;
                     this.stateChange.emit({
                         selectedProcessId: this.selectStateForm.get('usercardProcess').value,
-                        state: this.selectStateForm.get('usercardState').value
+                        state: this.selectedState
                     });
                 }
             });


### PR DESCRIPTION
- In release note :
  -  In chapter : Bugs
  -  Text : #4154 : Usercard template does not change when switching from same state id in a different process