### PR TITLE
Renamed viewCardInAgenda to viewCardInCalendar #4170

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -40,7 +40,7 @@ It aims to facilitate operational activities for utilities in two ways :
 ** event dispatching rules on a per user basis (based on groups, organizational entities, processes... )
 ** event-sending endpoints for business applications 
 ** a mechanism of templating to customize events rendering (using HTML5 )
-** a view of the events on a timeline and agenda view 
+** a view of the events on a timeline or a calendar 
 ** storage of all the events (archive feature)
 ** notifications via sounds 
 ** possibilities  to integrate screen form other applications

--- a/src/docs/asciidoc/reference_doc/user_cards.adoc
+++ b/src/docs/asciidoc/reference_doc/user_cards.adoc
@@ -128,11 +128,11 @@ for more information) .
 
 If you send a card to an ExternalRecipient, when the user delete it, the external recipient will receive the information via an HTTP DELETE request with the id of the deleted card at the end of the request (example : http://myexternal_app/myendpoint/ID_CARD).
 
-If you want the card to be visible in the agenda feature, you need to set 'timeSpans' field (as array of TimeSpans objects) in the object returned by the method. 
+If you want the card to be visible in the calendar feature, you need to set 'timeSpans' field (as array of TimeSpans objects) in the object returned by the method. 
 You can find an example in the file:
 https://github.com/opfab/operatorfabric-core/tree/master/src/test/resources/bundles/taskExample/template/usercard_task.handlebars[src/test/resources/bundles/taskExample/template/usercard_task.handlebars].
 
-If not using 'timeSpans' it's possible to set the 'viewCardInAgenda' field to true, the card will be visible using card's startDate and endDate as default timeSpan.
+If not using 'timeSpans' it's possible to set the 'viewCardInCalendar' field to true, the card will be visible using card's startDate and endDate as default timeSpan.
 
 The 'recurrence' field is deprecated and could be removed in the future.
 

--- a/src/docs/asciidoc/resources/migration_guide_to_3.13.adoc
+++ b/src/docs/asciidoc/resources/migration_guide_to_3.13.adoc
@@ -13,3 +13,7 @@ When calling an opfab API you cannot use anymore trailing slash on url.
 
 
 If, for example, one makes a request like https://opfab/businessconfig/processes/, it must be replace by https://opfab/businessconfig/processes
+
+== viewCardInAgenda Parameter renamed
+
+The viewCardInAgenda parameter (specified in the usercard template through getSpecificCardInformation) has been renamed viewCardInCalendar to be consistent with other parts of the software. So you may have to update your usercard templates.

--- a/src/test/resources/bundles/conferenceAndITIncidentExample/template/usercard_conference.handlebars
+++ b/src/test/resources/bundles/conferenceAndITIncidentExample/template/usercard_conference.handlebars
@@ -91,7 +91,7 @@
                 return {
                     valid: true,
                     card: card,
-                    viewCardInAgenda: true
+                    viewCardInCalendar: true
                 };
 
             }

--- a/src/test/resources/bundles/conferenceAndITIncidentExample/template/usercard_incidentInProgress.handlebars
+++ b/src/test/resources/bundles/conferenceAndITIncidentExample/template/usercard_incidentInProgress.handlebars
@@ -140,7 +140,7 @@
                 return {
                     valid: true,
                     card: card,
-                    viewCardInAgenda: false
+                    viewCardInCalendar: false
                 };
 
             }

--- a/src/test/resources/bundles/messageOrQuestionExample/template/usercard_confirmation.handlebars
+++ b/src/test/resources/bundles/messageOrQuestionExample/template/usercard_confirmation.handlebars
@@ -83,7 +83,7 @@
                     valid: true,
                     card: card,
                     childCard: childCard,
-                    viewCardInAgenda: false
+                    viewCardInCalendar: false
                 };
             }
         }

--- a/src/test/resources/bundles/messageOrQuestionExample/template/usercard_question.handlebars
+++ b/src/test/resources/bundles/messageOrQuestionExample/template/usercard_question.handlebars
@@ -59,7 +59,7 @@
                 return {
                     valid: true,
                     card: card,
-                    viewCardInAgenda: false
+                    viewCardInCalendar: false
                 };
 
             }

--- a/ui/main/src/app/modules/usercard/usercard.component.ts
+++ b/ui/main/src/app/modules/usercard/usercard.component.ts
@@ -542,7 +542,7 @@ export class UserCardComponent implements OnInit {
     private isSpecificInformationValid(): boolean {
         if (!usercardTemplateGateway.getSpecificCardInformation) {
             this.opfabLogger.error(
-                'ERROR : No usercardTemplateGateway.getSpecificCardInformationMethod() in template, card cannot be send'
+                'ERROR : No usercardTemplateGateway.getSpecificCardInformationMethod() in template, card cannot be sent'
             );
             this.displayMessage('userCard.error.templateError', null, MessageLevel.ERROR);
             return false;
@@ -551,7 +551,7 @@ export class UserCardComponent implements OnInit {
         const specificInformation = usercardTemplateGateway.getSpecificCardInformation();
         if (!specificInformation) {
             this.opfabLogger.error(
-                'ERROR : usercardTemplateGateway.getSpecificCardInformationMethod() in template return no information, card cannot be send'
+                'ERROR : usercardTemplateGateway.getSpecificCardInformationMethod() in template return no information, card cannot be sent'
             );
             this.displayMessage('userCard.error.templateError', null, MessageLevel.ERROR);
             return false;
@@ -564,7 +564,7 @@ export class UserCardComponent implements OnInit {
 
         if (!specificInformation.card) {
             this.opfabLogger.error(
-                'ERROR : usercardTemplateGateway.getSpecificCardInformationMethod() in template return specificInformation with no card field, card cannot be send'
+                'ERROR : usercardTemplateGateway.getSpecificCardInformationMethod() in template return specificInformation with no card field, card cannot be sent'
             );
             this.displayMessage('userCard.error.templateError', null, MessageLevel.ERROR);
             return false;
@@ -713,7 +713,7 @@ export class UserCardComponent implements OnInit {
             specificInformation.timeSpans.forEach((ts) => {
                 timeSpans.push(new TimeSpan(ts.startDate, ts.endDate, ts.recurrence));
             });
-        } else if (!!specificInformation.viewCardInAgenda) {
+        } else if (!!specificInformation.viewCardInCalendar) {
             timeSpans = !!specificInformation.recurrence
                 ? [new TimeSpan(startDate, endDate, specificInformation.recurrence)]
                 : [new TimeSpan(startDate, endDate)];


### PR DESCRIPTION
Signed-off-by: ClementBouvierN <clement.bouvierneveu@rte-france.com>

- In release note :
  -  In chapter :  Features 
  -  Text : #4170 Renamed the viewCardInAgenda parameter to viewCardInCalendar