### PR TITLE
Remove space in end of login to avoid user mistake (#4216)

### DIFF
--- a/ui/main/src/app/modules/core/application-loading/login/login.component.ts
+++ b/ui/main/src/app/modules/core/application-loading/login/login.component.ts
@@ -43,7 +43,7 @@ export class LoginComponent implements OnInit {
 
     onSubmit(): void {
         if (this.userForm.valid) {
-            const username = this.userForm.get('identifier').value;
+            const username = this.userForm.get('identifier').value.trim();
             const password = this.userForm.get('password').value;
             this.store.dispatch(new TryToLogInAction({username: username, password: password}));
         }


### PR DESCRIPTION


- In release note :
  -  In chapter :  Features 
  -  Text : #4216  Remove space in end of login to avoid user mistake