### PR TITLE
Remove use of deprecated method authorizeRequests() (#4234)

### DIFF
--- a/services/businessconfig/src/test/java/org/opfab/businessconfig/application/IntegrationTestApplication.java
+++ b/services/businessconfig/src/test/java/org/opfab/businessconfig/application/IntegrationTestApplication.java
@@ -1,4 +1,4 @@
-/* Copyright (c) 2018-2021, RTE (http://www.rte-france.com)
+/* Copyright (c) 2018-2023, RTE (http://www.rte-france.com)
  * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -20,11 +20,9 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Import;
-import org.springframework.context.annotation.ImportResource;
 
 @SpringBootApplication
 @Import({ProcessesService.class, MonitoringService.class, CustomExceptionHandler.class, JacksonConfig.class, BusinessconfigController.class})
-@ImportResource({"classpath:/security.xml"})
 
 public class IntegrationTestApplication {
 

--- a/services/businessconfig/src/test/resources/security.xml
+++ b/services/businessconfig/src/test/resources/security.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans
-                http://www.springframework.org/schema/beans/spring-beans.xsd">
-    <bean id="webSecurityChecks" class="org.opfab.springtools.configuration.oauth.WebSecurityChecks" />
-</beans>

--- a/services/cards-publication/src/main/java/org/opfab/cards/publication/configuration/oauth2/WebSecurityConfiguration.java
+++ b/services/cards-publication/src/main/java/org/opfab/cards/publication/configuration/oauth2/WebSecurityConfiguration.java
@@ -1,4 +1,4 @@
-/* Copyright (c) 2021-2022, RTE (http://www.rte-france.com)
+/* Copyright (c) 2021-2023, RTE (http://www.rte-france.com)
  * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -11,11 +11,6 @@
 
 package org.opfab.cards.publication.configuration.oauth2;
 
-import lombok.extern.slf4j.Slf4j;
-
-import org.opfab.springtools.configuration.oauth.WebSecurityChecks;
-
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -27,13 +22,16 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.web.SecurityFilterChain;
 
+import static org.opfab.springtools.configuration.oauth.OpfabAuthorizationManager.authenticatedAndIpAllowed;
+
+import static org.opfab.springtools.configuration.oauth.OpfabAuthorizationManager.hasAnyRoleAndIpAllowed;
+
 /**
  * OAuth 2 http authentication configuration and access rules
  *
  *
  */
 @Configuration
-@Slf4j
 @Profile(value = {"!test"})
 public class WebSecurityConfiguration {
 
@@ -41,12 +39,6 @@ public class WebSecurityConfiguration {
     public static final String LOGGERS_PATH ="/actuator/loggers/**";
 
     public static final String ADMIN_ROLE = "ADMIN";
-
-    public static final String AUTH_AND_IP_ALLOWED = "isAuthenticated() and @webSecurityChecks.checkUserIpAddress(authentication)";
-    public static final String ADMIN_AND_IP_ALLOWED = "hasRole('ADMIN') and @webSecurityChecks.checkUserIpAddress(authentication)";
-
-    @Autowired
-    WebSecurityChecks webSecurityChecks;
 
     @Value("${checkAuthenticationForCardSending:true}")
     private boolean checkAuthenticationForCardSending;
@@ -66,20 +58,20 @@ public class WebSecurityConfiguration {
     public static void configureCommon(final HttpSecurity http, boolean checkAuthenticationForCardSending) throws Exception {
         if (checkAuthenticationForCardSending) {
             http
-            .authorizeRequests()
-            .requestMatchers(HttpMethod.GET,PROMETHEUS_PATH).permitAll()
-            .requestMatchers(LOGGERS_PATH).hasRole(ADMIN_ROLE)
-            .requestMatchers("/cards/userCard/**").access(AUTH_AND_IP_ALLOWED)
-            .requestMatchers("/cards/translateCardField").access(AUTH_AND_IP_ALLOWED)
-            .requestMatchers(HttpMethod.DELETE, "/cards").access(ADMIN_AND_IP_ALLOWED)
-            .requestMatchers("/**").access(AUTH_AND_IP_ALLOWED);
+                    .authorizeHttpRequests()
+                    .requestMatchers(HttpMethod.GET, PROMETHEUS_PATH).permitAll()
+                    .requestMatchers(LOGGERS_PATH).hasRole(ADMIN_ROLE)
+                    .requestMatchers("/cards/userCard/**").access(authenticatedAndIpAllowed())
+                    .requestMatchers("/cards/translateCardField").access(authenticatedAndIpAllowed())
+                    .requestMatchers(HttpMethod.DELETE, "/cards").access(hasAnyRoleAndIpAllowed(ADMIN_ROLE))
+                    .requestMatchers("/**").access(authenticatedAndIpAllowed());
         } else {
             http
-            .authorizeRequests()
-            .requestMatchers(LOGGERS_PATH).hasRole(ADMIN_ROLE)
-            .requestMatchers("/cards/userCard/**").access(AUTH_AND_IP_ALLOWED)
-            .requestMatchers("/cards/translateCardField").access(AUTH_AND_IP_ALLOWED)
-            .requestMatchers("/**").permitAll();
+                    .authorizeHttpRequests()
+                    .requestMatchers(LOGGERS_PATH).hasRole(ADMIN_ROLE)
+                    .requestMatchers("/cards/userCard/**").access(authenticatedAndIpAllowed())
+                    .requestMatchers("/cards/translateCardField").access(authenticatedAndIpAllowed())
+                    .requestMatchers("/**").permitAll();
         }
     }
 

--- a/services/cards-publication/src/test/java/org/opfab/cards/publication/application/UnitTestApplication.java
+++ b/services/cards-publication/src/test/java/org/opfab/cards/publication/application/UnitTestApplication.java
@@ -1,4 +1,4 @@
-/* Copyright (c) 2018-2022, RTE (http://www.rte-france.com)
+/* Copyright (c) 2018-2023, RTE (http://www.rte-france.com)
  * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -47,7 +47,7 @@ import org.springframework.context.annotation.ImportResource;
 , CardCommandFactory.class, CardObjectMapper.class, TestCardReceiver.class , TestConsumerConfig.class, JacksonConfig.class
 , Common.class , CardController.class, WebSecurityConfigurationTest.class, I18nProcessesCache.class, I18nProcessesCacheTestApplication.class, 
 ExternalRecipients.class, UserActionLogsConfiguration.class})
-@ImportResource({"classpath:/amqp.xml", "classpath:/security.xml"})
+@ImportResource({"classpath:/amqp.xml"})
 public class UnitTestApplication {
 
     public static void main(String[] args) {

--- a/services/cards-publication/src/test/resources/security.xml
+++ b/services/cards-publication/src/test/resources/security.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans
-                http://www.springframework.org/schema/beans/spring-beans.xsd">
-    <bean id="webSecurityChecks" class="org.opfab.springtools.configuration.oauth.WebSecurityChecks" />
-</beans>

--- a/services/external-devices/src/main/java/org/opfab/externaldevices/configuration/oauth2/WebSecurityConfiguration.java
+++ b/services/external-devices/src/main/java/org/opfab/externaldevices/configuration/oauth2/WebSecurityConfiguration.java
@@ -1,4 +1,4 @@
-/* Copyright (c) 2021-2022, RTE (http://www.rte-france.com)
+/* Copyright (c) 2021-2023, RTE (http://www.rte-france.com)
  * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -9,9 +9,6 @@
 
 package org.opfab.externaldevices.configuration.oauth2;
 
-import lombok.extern.slf4j.Slf4j;
-import org.opfab.springtools.configuration.oauth.WebSecurityChecks;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.convert.converter.Converter;
@@ -21,13 +18,15 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.web.SecurityFilterChain;
 
+import static org.opfab.springtools.configuration.oauth.OpfabAuthorizationManager.authenticatedAndIpAllowed;
+import static org.opfab.springtools.configuration.oauth.OpfabAuthorizationManager.hasAnyRoleAndIpAllowed;
+
 /**
  * OAuth 2 http authentication configuration and access rules
  *
  *
  */
 @Configuration
-@Slf4j
 public class WebSecurityConfiguration {
 
     public static final String PROMETHEUS_PATH ="/actuator/prometheus**";
@@ -38,12 +37,6 @@ public class WebSecurityConfiguration {
     public static final String NOTIFICATIONS_ROOT_PATH = "/notifications";
 
     public static final String ADMIN_ROLE = "ADMIN";
-
-    public static final String AUTH_AND_IP_ALLOWED = "isAuthenticated() and @webSecurityChecks.checkUserIpAddress(authentication)";
-    public static final String ADMIN_AND_IP_ALLOWED = "hasRole('ADMIN') and @webSecurityChecks.checkUserIpAddress(authentication)";
-
-    @Autowired
-    WebSecurityChecks webSecurityChecks;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http,
@@ -58,14 +51,14 @@ public class WebSecurityConfiguration {
 
     public static void configureCommon(final HttpSecurity http) throws Exception {
         http
-                .authorizeRequests()
+                .authorizeHttpRequests()
                 .requestMatchers(HttpMethod.GET,PROMETHEUS_PATH).permitAll()
                 .requestMatchers(LOGGERS_PATH).hasRole(ADMIN_ROLE)
-                .requestMatchers(HttpMethod.POST,NOTIFICATIONS_ROOT_PATH).access(AUTH_AND_IP_ALLOWED)
-                .requestMatchers(HttpMethod.GET, CONFIGURATIONS_USERS_PATH).access(AUTH_AND_IP_ALLOWED)
-                .requestMatchers(CONFIGURATIONS_ROOT_PATH+"**").access(ADMIN_AND_IP_ALLOWED)
-                .requestMatchers(DEVICES_ROOT_PATH+"**").access(ADMIN_AND_IP_ALLOWED)
-                .anyRequest().access(AUTH_AND_IP_ALLOWED);
+                .requestMatchers(HttpMethod.POST,NOTIFICATIONS_ROOT_PATH).access(authenticatedAndIpAllowed())
+                .requestMatchers(HttpMethod.GET, CONFIGURATIONS_USERS_PATH).access(authenticatedAndIpAllowed())
+                .requestMatchers(CONFIGURATIONS_ROOT_PATH+"**").access(hasAnyRoleAndIpAllowed(ADMIN_ROLE))
+                .requestMatchers(DEVICES_ROOT_PATH+"**").access(hasAnyRoleAndIpAllowed(ADMIN_ROLE))
+                .anyRequest().access(hasAnyRoleAndIpAllowed(ADMIN_ROLE));
     }
 
 }

--- a/services/users/src/main/java/org/opfab/users/configuration/oauth2/OpfabIpAuthorizationManager.java
+++ b/services/users/src/main/java/org/opfab/users/configuration/oauth2/OpfabIpAuthorizationManager.java
@@ -1,4 +1,4 @@
-/* Copyright (c) 2018-2023, RTE (http://www.rte-france.com)
+/* Copyright (c) 2023, RTE (http://www.rte-france.com)
  * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -7,74 +7,53 @@
  * This file is part of the OperatorFabric project.
  */
 
-
-
 package org.opfab.users.configuration.oauth2;
 
 import java.util.List;
+import java.util.function.Supplier;
 
+import org.opfab.users.model.CurrentUserWithPerimeters;
 import org.opfab.users.model.User;
-import org.opfab.users.mongo.repositories.MongoUserRepository;
+import org.springframework.security.authorization.AuthorizationDecision;
+import org.springframework.security.authorization.AuthorizationManager;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.web.access.intercept.RequestAuthorizationContext;
 import org.springframework.security.web.authentication.WebAuthenticationDetails;
-import org.springframework.stereotype.Component;
 import org.springframework.util.CollectionUtils;
 
 import lombok.extern.slf4j.Slf4j;
 
-/**
- * WebSecurityChecks
- * This class defines the access checks that can be performed, for use in {@link WebSecurityConfiguration}
- * The behaviour is similar to the WebSecurityChecks class defined in the tools/spring/spring-oauth2-utilities module used by the other services.
- * It is not possible to use WebSecurityChecks in spring-oauth2-utilities module because of class clash between User class with the User interface 
- * already present in other modules (same qualified name).
- *
- */
-
-@Component
 @Slf4j
-public class WebSecurityChecks {
+public class OpfabIpAuthorizationManager implements AuthorizationManager<RequestAuthorizationContext> {
 
-    MongoUserRepository userRepository;
-
-    public WebSecurityChecks(MongoUserRepository userRepository) {
-        this.userRepository = userRepository;
+    @Override
+    public AuthorizationDecision check(Supplier<Authentication> supplier, RequestAuthorizationContext context) {
+        return new AuthorizationDecision(checkUserIpAddress(supplier.get()));
     }
-
-    public boolean checkUserLogin(Authentication authentication, String login) {
-
-        String user;
-
-        //authentication.getPrincipal() is UserData type if there is authentication
-        //but is String type if there is no authentication (jira : OC-655)
-        if (authentication.getPrincipal()  instanceof String principal)
-            user = principal;
-        else
-            user = ((User) authentication.getPrincipal()).getLogin();
-
-        log.debug("login from the principal {} login parameter {}", user, login);
-
-        return user.equals(login);
-    }
-
-    public boolean checkUserIpAddress(Authentication authentication) {
+    
+    private boolean checkUserIpAddress(Authentication authentication) {
         User userData = null;
         String user = null;
         //authentication.getPrincipal() is UserData type if there is authentication
         //but is String type if there is no authentication (jira : OC-655)
         if (authentication.getPrincipal()  instanceof String principal) {
             user = principal;
+        }
+        else if (authentication.getPrincipal()  instanceof CurrentUserWithPerimeters currentUserWithPerimeters){
+            userData = currentUserWithPerimeters.getUserData();
+            user = userData.getLogin();
+            
         } else {
             userData = (User) authentication.getPrincipal();
             user = userData.getLogin();
         }
-            
+
         WebAuthenticationDetails details = (WebAuthenticationDetails) authentication.getDetails();
 
         if (userData != null && details != null) {
-
+            
             String userIp = details.getRemoteAddress();
-
+            
             List<String> ipAddresses = userData.getAuthorizedIPAddresses();
 
             if (!CollectionUtils.isEmpty(ipAddresses) && !ipAddresses.contains(userIp)){
@@ -86,5 +65,4 @@ public class WebSecurityChecks {
         log.info("Call not allowed from not authenticated user: " + user);
         return false;
     }
-      
 }

--- a/services/users/src/main/java/org/opfab/users/configuration/oauth2/OpfabLoginAuthorizationManager.java
+++ b/services/users/src/main/java/org/opfab/users/configuration/oauth2/OpfabLoginAuthorizationManager.java
@@ -1,0 +1,48 @@
+/* Copyright (c) 2023, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
+ */
+
+package org.opfab.users.configuration.oauth2;
+
+import java.util.function.Supplier;
+import org.opfab.users.model.User;
+import org.springframework.security.authorization.AuthorizationDecision;
+import org.springframework.security.authorization.AuthorizationManager;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.access.intercept.RequestAuthorizationContext;
+
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class OpfabLoginAuthorizationManager implements AuthorizationManager<RequestAuthorizationContext> {
+
+    @Override
+    public AuthorizationDecision check(Supplier<Authentication> supplier, RequestAuthorizationContext context) {
+        
+        return new AuthorizationDecision(checkUserLogin(supplier.get(), context));
+    }
+    
+    boolean checkUserLogin(Authentication authentication, RequestAuthorizationContext context) {
+
+        String login = context.getVariables().get("login");
+        String user;
+
+        //authentication.getPrincipal() is UserData type if there is authentication
+        //but is String type if there is no authentication (jira : OC-655)
+        if (authentication.getPrincipal()  instanceof String principal)
+            user = principal;
+        else {
+            user = ((User) authentication.getPrincipal()).getLogin();
+        }
+
+        log.debug("login from the principal {} login parameter {}", user, login);
+
+        return user.equals(login);
+    }
+}

--- a/services/users/src/main/java/org/opfab/users/configuration/oauth2/OpfabLoginNotEqualAuthorizationManager.java
+++ b/services/users/src/main/java/org/opfab/users/configuration/oauth2/OpfabLoginNotEqualAuthorizationManager.java
@@ -1,0 +1,26 @@
+/* Copyright (c) 2023, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
+ */
+
+package org.opfab.users.configuration.oauth2;
+
+import java.util.function.Supplier;
+import org.springframework.security.authorization.AuthorizationDecision;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.access.intercept.RequestAuthorizationContext;
+
+
+public class OpfabLoginNotEqualAuthorizationManager extends OpfabLoginAuthorizationManager {
+
+    @Override
+    public AuthorizationDecision check(Supplier<Authentication> supplier, RequestAuthorizationContext context) {
+        
+        return new AuthorizationDecision(!checkUserLogin(supplier.get(), context));
+    }
+
+}

--- a/tools/spring/spring-oauth2-utilities/src/main/java/org/opfab/springtools/configuration/oauth/OAuth2GenericConfiguration.java
+++ b/tools/spring/spring-oauth2-utilities/src/main/java/org/opfab/springtools/configuration/oauth/OAuth2GenericConfiguration.java
@@ -79,13 +79,6 @@ public class OAuth2GenericConfiguration {
         };
     }
 
-
-    @Bean
-    public WebSecurityChecks webSecurityChecks() {
-        return new WebSecurityChecks();
-    }
-
-
     public AbstractAuthenticationToken generateOpFabJwtAuthenticationToken(Jwt jwt) {
         
         String principalId = jwt.getClaimAsString(jwtProperties.getLoginClaim()).toLowerCase();

--- a/tools/spring/spring-oauth2-utilities/src/main/java/org/opfab/springtools/configuration/oauth/OpfabAuthorizationManager.java
+++ b/tools/spring/spring-oauth2-utilities/src/main/java/org/opfab/springtools/configuration/oauth/OpfabAuthorizationManager.java
@@ -1,0 +1,33 @@
+/* Copyright (c) 2023, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
+ */
+
+package org.opfab.springtools.configuration.oauth;
+
+import org.springframework.security.authorization.AuthenticatedAuthorizationManager;
+import org.springframework.security.authorization.AuthorityAuthorizationManager;
+import org.springframework.security.authorization.AuthorizationManager;
+import org.springframework.security.authorization.AuthorizationManagers;
+import org.springframework.security.web.access.intercept.RequestAuthorizationContext;
+
+public class OpfabAuthorizationManager {
+
+    private OpfabAuthorizationManager() {
+    }
+
+    public static AuthorizationManager<RequestAuthorizationContext> authenticatedAndIpAllowed() {
+        return AuthorizationManagers.allOf(AuthenticatedAuthorizationManager.authenticated(),
+                            new OpfabIpAuthorizationManager());
+    }
+
+    public static AuthorizationManager<RequestAuthorizationContext> hasAnyRoleAndIpAllowed(String... roles) {
+        return AuthorizationManagers.allOf(AuthorityAuthorizationManager.hasAnyRole(roles),
+                            new OpfabIpAuthorizationManager());
+    }
+
+}

--- a/tools/spring/spring-oauth2-utilities/src/main/java/org/opfab/springtools/configuration/oauth/OpfabIpAuthorizationManager.java
+++ b/tools/spring/spring-oauth2-utilities/src/main/java/org/opfab/springtools/configuration/oauth/OpfabIpAuthorizationManager.java
@@ -1,4 +1,4 @@
-/* Copyright (c) 2021-2023, RTE (http://www.rte-france.com)
+/* Copyright (c) 2023, RTE (http://www.rte-france.com)
  * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -7,51 +7,31 @@
  * This file is part of the OperatorFabric project.
  */
 
-
-
 package org.opfab.springtools.configuration.oauth;
 
 import java.util.List;
+import java.util.function.Supplier;
 
 import org.opfab.users.model.CurrentUserWithPerimeters;
 import org.opfab.users.model.User;
+import org.springframework.security.authorization.AuthorizationDecision;
+import org.springframework.security.authorization.AuthorizationManager;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.web.access.intercept.RequestAuthorizationContext;
 import org.springframework.security.web.authentication.WebAuthenticationDetails;
-import org.springframework.stereotype.Component;
 import org.springframework.util.CollectionUtils;
 
 import lombok.extern.slf4j.Slf4j;
 
-/**
- * WebSecurityChecks
- * This class defines the access checks that can be performed, for use in {@link WebSecurityConfiguration}
- *
- *
- */
-
-@Component
 @Slf4j
-public class WebSecurityChecks {
+public class OpfabIpAuthorizationManager implements AuthorizationManager<RequestAuthorizationContext> {
 
-
-    public boolean checkUserLogin(Authentication authentication, String login) {
-
-        String user;
-
-
-        //authentication.getPrincipal() is UserData type if there is authentication
-        //but is String type if there is no authentication (jira : OC-655)
-        if (authentication.getPrincipal()  instanceof String principal)
-            user = principal;
-        else 
-            user = ((User) authentication.getPrincipal()).getLogin();
-
-        log.debug("login from the principal {} login parameter {}", user, login);
-
-        return user.equals(login);
+    @Override
+    public AuthorizationDecision check(Supplier<Authentication> supplier, RequestAuthorizationContext context) {
+        return new AuthorizationDecision(checkUserIpAddress(supplier.get()));
     }
-
-    public boolean checkUserIpAddress(Authentication authentication) {
+    
+    private boolean checkUserIpAddress(Authentication authentication) {
         User userData = null;
         String user = null;
         //authentication.getPrincipal() is UserData type if there is authentication
@@ -85,5 +65,4 @@ public class WebSecurityChecks {
         log.info("Call not allowed from not authenticated user: " + user);
         return false;
     }
-      
 }


### PR DESCRIPTION
- In release note :
  -  In chapter :  Tasks
  -  Text : #4234 : Remove use of deprecated method authorizeRequests() 