### PR TITLE
Fix bug in IT Incident example (#4426)

### DIFF
--- a/src/test/resources/bundles/conferenceAndITIncidentExample/template/usercard_incidentInProgress.handlebars
+++ b/src/test/resources/bundles/conferenceAndITIncidentExample/template/usercard_incidentInProgress.handlebars
@@ -49,7 +49,6 @@
 
         init: function() {
             this.initMultiSelect();
-            this.selectValuesInEditMode();
             this.initUserCardTemplateGateway();
         },
 
@@ -63,6 +62,7 @@
 
             let services = await opfab.businessconfig.businessData.get("services");
             this.serviceSelect.setOptions(services);
+            this.selectValuesInEditMode();
 
         },
 

--- a/ui/main/src/app/business/services/businessdata.service.ts
+++ b/ui/main/src/app/business/services/businessdata.service.ts
@@ -13,6 +13,7 @@ import {BusinessDataServer} from '../server/businessData.server';
 import {ServerResponseStatus} from '../server/serverResponse';
 import {LogOption, OpfabLoggerService} from './logs/opfab-logger.service';
 import {OpfabEventStreamService} from './opfabEventStream.service';
+import * as _ from 'lodash-es';
 
 @Injectable({
     providedIn: 'root'
@@ -41,12 +42,12 @@ export class BusinessDataService {
 
     public async getBusinessData(resourceName: string): Promise<any> {
         if (this._cachedResources.has(resourceName)) {
-            return this.getCachedValue(resourceName);
+            return _.clone(this.getCachedValue(resourceName));
         }
         const resource = await firstValueFrom(this.businessDataServer.getBusinessData(resourceName));
         if (resource.status === ServerResponseStatus.OK) {
             this.addResourceToCache(resourceName, resource.data);
-            return resource.data;
+            return _.clone(resource.data);
         } else {
             this.loggerService.info(`Could not find the resource. See : ${resource.statusMessage}`);
             return {};


### PR DESCRIPTION
Modify template to have  the select of the field in mutliselect  done after the init of the mutliselect component  : the addition of the keyword async done in this release implies that the method initMultiSelect() is not called right away.

Not related to the bug : Clone business  data object to avoid side effect (without cloning the template is able to modify the data in the cache) 

Nothing in release note as it was not present in previous release 

