### PR TITLE
Do not limit the number of cards returned in archives export (#4480)

### DIFF
--- a/ui/main/src/app/modules/archives/archives.component.ts
+++ b/ui/main/src/app/modules/archives/archives.component.ts
@@ -290,7 +290,7 @@ export class ArchivesComponent implements OnDestroy, OnInit {
         };
         this.modalRef = this.modalService.open(this.exportTemplate, modalOptions);
 
-        const filter = this.getFilter(0, 1 + this.historySize, this.filtersTemplate.filters, false);
+        const filter = this.getFilter(null, null, this.filtersTemplate.filters, false);
         this.cardService
             .fetchFilteredArchivedCards(filter)
             .pipe(takeUntil(this.unsubscribe$))


### PR DESCRIPTION
- In release note :
  -  In chapter : Bugs
  -  Text : #4480 : Do not limit the number of cards returned in archives export