### PR TITLE
Solve issue Session close in implicit mode without warning (#4514)

### DIFF
--- a/ui/main/src/app/authentication/auth.service.ts
+++ b/ui/main/src/app/authentication/auth.service.ts
@@ -78,7 +78,8 @@ export class AuthService {
                     this.configService,
                     this.httpClient,
                     this.logger,
-                    this.oauthServiceForImplicitMode
+                    this.oauthServiceForImplicitMode,
+                    this.currentUserStore
                 );
                 break;
             default:


### PR DESCRIPTION
- In release note :
  -  In chapter :  Bugs 
  -  Text : #4514 Session close in implicit mode without warning

To test : 

- Set opfab in implicit mode ` 


- Config keyloak :  You need to set short  time value for testing :  

  - Set access token lifespan for implicit flow to a short value  example : 1 min 

   ![image](https://github.com/opfab/operatorfabric-core/assets/58251627/da3835ee-1f5c-4563-abda-74ad05cd642d)

  - Set SSO Session max to a short value to test that session is properly closed : example 4 minutes 

   ![image](https://github.com/opfab/operatorfabric-core/assets/58251627/93517483-26c2-43e9-b36a-c65f5746f46c)

- Configure web-ui param `secondsToCloseSession` to a short value , example 5 
