### PR TITLE
Adding of the new helper 'findObjectByProperty'

### DIFF
--- a/ui/main/src/app/modules/card/services/handlebars.service.ts
+++ b/ui/main/src/app/modules/card/services/handlebars.service.ts
@@ -47,6 +47,7 @@ export class HandlebarsService {
         HandlebarsService.registerReplace();
         HandlebarsService.registerPadStart();
         HandlebarsService.registerObjectContainsKey();
+        HandlebarsService.registerFindObjectByProperty();
         this.configService.getConfigValueAsObservable('settings.locale').subscribe((locale) => this.changeLocale(locale));
     }
 
@@ -248,6 +249,12 @@ export class HandlebarsService {
     private static registerConditionalAttribute() {
         Handlebars.registerHelper('conditionalAttribute', function (condition, attribute) {
             return condition ? attribute : '';
+        });
+    }
+
+    private static registerFindObjectByProperty() {
+        Handlebars.registerHelper('findObjectByProperty', function (list, propertyName, propertyValue) {
+            return list.find(obj => obj[propertyName] === propertyValue);
         });
     }
 


### PR DESCRIPTION
- In release note :
  -  In chapter :  Features
  -  Text : Documentation part :
     - **11.2.1.22.** 
     _findObjectByProperty_
        Searching directly an object in a list using the value of a property. Returns the object if it contains it, null otherwise.
        ```
        {{#with (findObjectByProperty card.data.myObjectsList propertyName propertyValue)}}
          <p>Property value of found object: {{this.propertyName}}</p>
        {{/with}}
        ```