### PR TITLE
Removed the orange outline from the autofocus on the cancel button of a new card

### DIFF
--- a/ui/main/src/shared/css/opfab-application.css
+++ b/ui/main/src/shared/css/opfab-application.css
@@ -599,6 +599,7 @@ input:-webkit-autofill {
 
 .opfab-btn-cancel {
     color: #2784ff;
+    outline:none;
     background-color: var(--opfab-bg-color);
     border-width: 0px;
     border-radius: 2px;


### PR DESCRIPTION
Nothing in release note
