### PR TITLE
Logging screen : display header names of columns on two lines if it needs (#4534)

### DIFF
--- a/ui/main/src/app/modules/logging/components/logging-table/logging-table.component.ts
+++ b/ui/main/src/app/modules/logging/components/logging-table/logging-table.component.ts
@@ -1,4 +1,4 @@
-/* Copyright (c) 2022, RTE (http://www.rte-france.com)
+/* Copyright (c) 2022-2023, RTE (http://www.rte-france.com)
  * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -80,7 +80,8 @@ export class LoggingTableComponent implements OnDestroy {
             },
             domLayout: 'autoHeight',
             defaultColDef: {
-                editable: false
+                editable: false,
+                wrapHeaderText: true
             },
             getLocaleText: function (params) {
                 // To avoid clashing with opfab assets, all keys defined by ag-grid are prefixed with "ag-grid."


### PR DESCRIPTION
I propose to add nothing in release notes.