### PR TITLE
Add reminder service in migration guide for 4.0 (#4664)

### DIFF
--- a/src/docs/asciidoc/reference_doc/card_notification.adoc
+++ b/src/docs/asciidoc/reference_doc/card_notification.adoc
@@ -115,7 +115,7 @@ For example:
 [[card_reminder]]
 == Card reminder 
 
-For certain process and state, it is possible to configure a reminder. The reminder "reactivates" the card in the feed at a certain time. "Reactivate" means setting the card to the status "unread" and "unacknowledged".
+For certain process and state, it is possible to configure a reminder. The reminder triggers the resending of the card at a certain time with status "unread" and "unacknowledged" and publishDate updated.
 
 
 The time for "reactivation" is defined with the parameter "secondsBeforeTimeSpanForReminder" in the card.
@@ -194,13 +194,9 @@ recurrence : {
 
 If secondsBeforeTimeSpanForReminder is set to 600 seconds, the reminder will arise every Saturday and Sunday, in November and December at 10:20 starting from startDate.
 
-=== Last time for reminding
-
-If the user is not connected at the time of the reminder,  when he connects if current time is superior to 15 minutes from the event date, no  remind will arise.
-
 === Debugging 
 
-When the user receives a card with a reminder to set, the log (console) of the browser contains a line with the date when the reminder will arise . For example :
+When a card with a reminder set is sent, the log of the "cards-reminder" service will contain a line with the date when the reminder will arise . For example :
 
 `2020-11-22T21:00:36.011Z Reminder Will remind card conferenceAndITIncidentExample.0cf5537b-f0df-4314-f17f-2797ccd8e4e9 at
                          Sun Nov 22 2020 22:55:00 GMT+0100 (heure normale d’Europe centrale)`

--- a/src/docs/asciidoc/resources/migration_guide_to_4.0.adoc
+++ b/src/docs/asciidoc/resources/migration_guide_to_4.0.adoc
@@ -168,3 +168,6 @@ automate it, you can do it directly in the database via the following request :
 
 `db.perimeter.updateMany({"stateRights.right": "Write"}, {"$set": {"stateRights.$.right": "ReceiveAndWrite"}});`
 
+== Cards reminder
+Cards reminder logic has been moved from front-end to back-end. The reminder logic is handled by the new "cards-reminder" service.
+You must adapt the configuration to your environment by using the configuration file config/docker/node-services.json and adapt it to your deployment context.


### PR DESCRIPTION
Fix #4664 

Nothing in release notes
