### PR TITLE
Do not consider character case when checking publisher is equal to lo…

### DIFF
--- a/services/cards-publication/src/main/java/org/opfab/cards/publication/services/CardPermissionControlService.java
+++ b/services/cards-publication/src/main/java/org/opfab/cards/publication/services/CardPermissionControlService.java
@@ -26,9 +26,9 @@ public class CardPermissionControlService {
     boolean isCardPublisherAllowedForUser(CardPublicationData card, String login) {
         if (card.getRepresentative() != null) {
             if (card.getRepresentativeType().equals(org.opfab.cards.publication.model.PublisherTypeEnum.EXTERNAL))
-                return card.getRepresentative().equals(login);
+                return card.getRepresentative().equalsIgnoreCase(login);
         } else if (card.getPublisherType().equals(org.opfab.cards.publication.model.PublisherTypeEnum.EXTERNAL)) {
-            return card.getPublisher().equals(login);
+            return card.getPublisher().equalsIgnoreCase(login);
         }
         return true;
     }
@@ -66,8 +66,7 @@ public class CardPermissionControlService {
             && user.getUserData().getEntities().contains(card.getPublisher()) && checkUserPerimeterForCard(user.getComputedPerimeters(), card);
     }
 
-    boolean isUserAuthorizedToSendCard(CardPublicationData card, CurrentUserWithPerimeters user){
-
+    boolean isUserAuthorizedToSendCard(CardPublicationData card, CurrentUserWithPerimeters user) {
         return !isCurrentUserReadOnly(user) && checkUserPerimeterForCard(user.getComputedPerimeters(), card);
     }
 

--- a/services/cards-publication/src/test/java/org/opfab/cards/publication/services/CardProcessServiceShould.java
+++ b/services/cards-publication/src/test/java/org/opfab/cards/publication/services/CardProcessServiceShould.java
@@ -691,6 +691,29 @@ class CardProcessServiceShould {
         }
 
         @Test
+        void GIVEN_a_card_WHEN_card_is_send_with_a_login_case_different_than_publisher_THEN_card_is_accepted() {
+                User user = new User();
+                user.setLogin("DummyUser");
+                CurrentUserWithPerimeters sameUser = new CurrentUserWithPerimeters();
+                sameUser.setUserData(user);
+
+                ComputedPerimeter cp = new ComputedPerimeter();
+                cp.setProcess("PROCESS_CARD_USER");
+                cp.setState("state1");
+                cp.setRights(RightsEnum.RECEIVEANDWRITE);
+                List<ComputedPerimeter> list = new ArrayList<>();
+                list.add(cp);
+                sameUser.setComputedPerimeters(list);
+
+                CardPublicationData card = generateOneCard(currentUserWithPerimeters.getUserData().getLogin());
+                card.setPublisherType(PublisherTypeEnum.EXTERNAL);
+                Optional<CurrentUserWithPerimeters> optionalSameUser = Optional.of(sameUser);
+
+                cardProcessingService.processCard(card, optionalSameUser, token);
+                Assertions.assertThat(checkCardCount(1)).isTrue();
+        }
+
+        @Test
         void GIVEN_an_existing_card_WHEN_card_is_deleted_with_a_login_different_than_publisher_THEN_card_deletion_is_rejected() {
                 User user = new User();
                 user.setLogin("wrongUser");
@@ -732,6 +755,32 @@ class CardProcessServiceShould {
                                 .isInstanceOf(ApiErrorException.class).hasMessage(
                                                 "Card representative is set to dummyUser and account login is wrongUser, the card cannot be sent");
                 Assertions.assertThat(checkCardCount(0)).isTrue();
+        }
+
+        @Test
+        void GIVEN_a_card_with_representative_dummyUser_WHEN_card_is_send_with_a_login_case_different_than_representative_THEN_card_is_accepted() {
+
+                User user = new User();
+                user.setLogin("DummyUser");
+                CurrentUserWithPerimeters sameUser = new CurrentUserWithPerimeters();
+                sameUser.setUserData(user);
+
+                ComputedPerimeter cp = new ComputedPerimeter();
+                cp.setProcess("PROCESS_CARD_USER");
+                cp.setState("state1");
+                cp.setRights(RightsEnum.RECEIVEANDWRITE);
+                List<ComputedPerimeter> list = new ArrayList<>();
+                list.add(cp);
+                sameUser.setComputedPerimeters(list);
+
+                CardPublicationData card = generateOneCard("IGNORED_PUBLISHER");
+                card.setPublisherType(PublisherTypeEnum.EXTERNAL);
+                card.setRepresentativeType(PublisherTypeEnum.EXTERNAL);
+                card.setRepresentative(currentUserWithPerimeters.getUserData().getLogin());
+                Optional<CurrentUserWithPerimeters> optionalSameUser = Optional.of(sameUser);
+
+                cardProcessingService.processCard(card, optionalSameUser, token);
+                Assertions.assertThat(checkCardCount(1)).isTrue();
         }
 
         @Test

--- a/services/cards-publication/src/test/java/org/opfab/cards/publication/services/CardProcessServiceShould.java
+++ b/services/cards-publication/src/test/java/org/opfab/cards/publication/services/CardProcessServiceShould.java
@@ -693,9 +693,9 @@ class CardProcessServiceShould {
         @Test
         void GIVEN_a_card_WHEN_card_is_send_with_a_login_case_different_than_publisher_THEN_card_is_accepted() {
                 User user = new User();
-                user.setLogin("DummyUser");
-                CurrentUserWithPerimeters sameUser = new CurrentUserWithPerimeters();
-                sameUser.setUserData(user);
+                user.setLogin("DUMMYUSER");
+                CurrentUserWithPerimeters caseDifferentUser = new CurrentUserWithPerimeters();
+                caseDifferentUser.setUserData(user);
 
                 ComputedPerimeter cp = new ComputedPerimeter();
                 cp.setProcess("PROCESS_CARD_USER");
@@ -703,13 +703,13 @@ class CardProcessServiceShould {
                 cp.setRights(RightsEnum.RECEIVEANDWRITE);
                 List<ComputedPerimeter> list = new ArrayList<>();
                 list.add(cp);
-                sameUser.setComputedPerimeters(list);
+                caseDifferentUser.setComputedPerimeters(list);
 
                 CardPublicationData card = generateOneCard(currentUserWithPerimeters.getUserData().getLogin());
                 card.setPublisherType(PublisherTypeEnum.EXTERNAL);
-                Optional<CurrentUserWithPerimeters> optionalSameUser = Optional.of(sameUser);
+                Optional<CurrentUserWithPerimeters> optionalCaseDifferentUser = Optional.of(caseDifferentUser);
 
-                cardProcessingService.processCard(card, optionalSameUser, token);
+                cardProcessingService.processCard(card, optionalCaseDifferentUser, token);
                 Assertions.assertThat(checkCardCount(1)).isTrue();
         }
 
@@ -761,9 +761,9 @@ class CardProcessServiceShould {
         void GIVEN_a_card_with_representative_dummyUser_WHEN_card_is_send_with_a_login_case_different_than_representative_THEN_card_is_accepted() {
 
                 User user = new User();
-                user.setLogin("DummyUser");
-                CurrentUserWithPerimeters sameUser = new CurrentUserWithPerimeters();
-                sameUser.setUserData(user);
+                user.setLogin("DUMMYUSER");
+                CurrentUserWithPerimeters caseDifferentUser = new CurrentUserWithPerimeters();
+                caseDifferentUser.setUserData(user);
 
                 ComputedPerimeter cp = new ComputedPerimeter();
                 cp.setProcess("PROCESS_CARD_USER");
@@ -771,15 +771,15 @@ class CardProcessServiceShould {
                 cp.setRights(RightsEnum.RECEIVEANDWRITE);
                 List<ComputedPerimeter> list = new ArrayList<>();
                 list.add(cp);
-                sameUser.setComputedPerimeters(list);
+                caseDifferentUser.setComputedPerimeters(list);
 
                 CardPublicationData card = generateOneCard("IGNORED_PUBLISHER");
                 card.setPublisherType(PublisherTypeEnum.EXTERNAL);
                 card.setRepresentativeType(PublisherTypeEnum.EXTERNAL);
                 card.setRepresentative(currentUserWithPerimeters.getUserData().getLogin());
-                Optional<CurrentUserWithPerimeters> optionalSameUser = Optional.of(sameUser);
+                Optional<CurrentUserWithPerimeters> optionalCaseDifferentUser = Optional.of(caseDifferentUser);
 
-                cardProcessingService.processCard(card, optionalSameUser, token);
+                cardProcessingService.processCard(card, optionalCaseDifferentUser, token);
                 Assertions.assertThat(checkCardCount(1)).isTrue();
         }
 


### PR DESCRIPTION
- In release note :
  -  In chapter :  Features
  -  Text : #4669 No longer consider case when checking login is equal to publisher / representative in CardPermissionControlService