### PR TITLE
Add an endpoint to card reminder to reset and reprocess reminder database (#4732)

### DIFF
--- a/node-services/cards-reminder/src/cardsReminder.ts
+++ b/node-services/cards-reminder/src/cardsReminder.ts
@@ -96,6 +96,18 @@ app.get('/stop', (req, res) => {
 
 });
 
+app.get('/reset', (req, res) => {
+
+    if (!authenticationService.authorize(req))
+        res.status(403).send();
+    else {
+        logger.info('Reset card reminder service asked');
+        cardsReminderService.reset();
+        res.send('Reset service');
+    }
+
+});
+
 app.listen(adminPort, () => {
     logger.info(`Opfab cards reminder service listening on port ${adminPort}`);
 });

--- a/node-services/cards-reminder/src/domain/application/cardsReminderControl.ts
+++ b/node-services/cards-reminder/src/domain/application/cardsReminderControl.ts
@@ -53,4 +53,19 @@ export default class CardsReminderControl {
             })
         )
     }
+
+    public resetReminderDatabase() {
+        this.reminderService.clearReminders();
+        this.rruleReminderService.clearReminders();
+
+        this.rruleReminderService.getAllCardsToRemind().then(cardsWithReminders => 
+
+            cardsWithReminders.forEach(card => {
+                this.reminderService.addCardReminder(card);
+                this.rruleReminderService.addCardReminder(card);
+            })
+        );
+
+    }
+
 }

--- a/node-services/cards-reminder/src/domain/application/reminderService.ts
+++ b/node-services/cards-reminder/src/domain/application/reminderService.ts
@@ -116,4 +116,14 @@ export default class ReminderService implements EventListener {
             reminderDate + card.secondsBeforeTimeSpanForReminder + ReminderService.MAX_MILLISECONDS_FOR_REMINDING_AFTER_EVENT_STARTS
         );
     }
+
+
+    public async getAllCardsToRemind(): Promise<Card[]> {
+        return this.databaseService.getAllCardsToRemind();
+    }
+
+    public clearReminders() {
+        this.databaseService.clearReminders();
+    }
+
 }

--- a/node-services/cards-reminder/src/domain/application/rruleReminderService.ts
+++ b/node-services/cards-reminder/src/domain/application/rruleReminderService.ts
@@ -117,4 +117,12 @@ export class RRuleReminderService implements EventListener{
             reminderDate + card.secondsBeforeTimeSpanForReminder + RRuleReminderService.MAX_MILLISECONDS_FOR_REMINDING_AFTER_EVENT_STARTS
         );
     }
+
+    public async getAllCardsToRemind(): Promise<Card[]> {
+        return this.databaseService.getAllCardsToRemind();
+    }
+
+    public clearReminders() {
+        this.databaseService.clearReminders();
+    }
 }

--- a/node-services/cards-reminder/src/domain/client-side/cardsRemiderService.ts
+++ b/node-services/cards-reminder/src/domain/client-side/cardsRemiderService.ts
@@ -42,6 +42,16 @@ export default class CardsReminderService {
         this.active = false;
     }
 
+    public reset() {
+        const wasActive = this.active;
+        this.stop();
+
+        this.cardsReminderControl.resetReminderDatabase();
+
+        if (wasActive) this.start();
+    }
+
+
     private checkRegularly() {
         if (this.active) {
             this.logger.debug("checkRegularly");

--- a/node-services/cards-reminder/src/domain/server-side/remindDatabaseService.ts
+++ b/node-services/cards-reminder/src/domain/server-side/remindDatabaseService.ts
@@ -31,6 +31,9 @@ export default class RemindDatabaseService {
         return this.mongoDB.collection(this.remindersCollection).find({hasBeenRemind: false, timeForReminding: { $lte: new Date().valueOf() }}).toArray();
     }
 
+    public async getAllCardsToRemind(): Promise<any[]> {       
+        return this.mongoDB.collection('cards').find({$and: [{secondsBeforeTimeSpanForReminder: { $exists: true}}, {$or: [{endDate: { $exists: false}}, {endDate: { $gte: new Date() } }] }]}).toArray();
+    }    
 
     public getReminder(id: string) {
         return this.mongoDB.collection(this.remindersCollection).findOne({cardId: id});
@@ -48,4 +51,9 @@ export default class RemindDatabaseService {
     public getCardByUid(uid: string) {
         return this.mongoDB.collection("cards").findOne({uid: uid});
     }
+
+    public clearReminders() {
+        this.mongoDB.collection(this.remindersCollection).deleteMany({});
+    }
+
 }

--- a/src/docs/asciidoc/resources/migration_guide_to_4.0.adoc
+++ b/src/docs/asciidoc/resources/migration_guide_to_4.0.adoc
@@ -172,6 +172,11 @@ automate it, you can do it directly in the database via the following request :
 Cards reminder logic has been moved from front-end to back-end. The reminder logic is handled by the new "cards-reminder" service.
 You must adapt the configuration to your environment by using the configuration file config/docker/node-services.json and adapt it to your deployment context.
 
+After upgrading to 4.0, you must call the `/reset` endpoint to populate the reminders database by processing all current cards with reminder set. For example using cURL:
+....
+curl http://localhost:2107/reset -H "Authorization:Bearer $token"
+....
+
 
 == Port mapping
 


### PR DESCRIPTION
Fix #4732

- In release note :
  -  In chapter :  Features
  -  Text : #4732 :Add an endpoint to card reminder to reset and reprocess reminder database