### PR TITLE
Added hideBusinessAlertMessages to hide all message with level BUSINESS

### DIFF
--- a/config/docker/ui-config/web-ui.json
+++ b/config/docker/ui-config/web-ui.json
@@ -5,9 +5,12 @@
   "showUserEntitiesOnTopRightOfTheScreen": true,
   "externalDevicesEnabled": true,
   "selectActivityAreaOnLogin": false,
-  "alertMessageBusinessAutoClose": false,
-  "alertMessageOnBottomOfTheScreen": false,
   "heartbeatSendingInterval": 30,
+  "alerts": {
+    "messageBusinessAutoClose": false,
+    "messageOnBottomOfTheScreen": false,
+    "hideBusinessMessages": false
+  },
   "archive": {
     "filters": {
       "page": {

--- a/src/docs/asciidoc/deployment/configuration/web-ui_configuration.adoc
+++ b/src/docs/asciidoc/deployment/configuration/web-ui_configuration.adoc
@@ -18,7 +18,7 @@ It  serves the Angular SPA to browsers and act as a reverse proxy for other serv
 An external `nginx.conf` file configures the OperatorFabric Nginx instance named `web-ui` service.
 Those files are mounted as docker volumes. There are two of them in OperatorFabric, one in `config/dev` and one in `config/docker`.
 
-The one in `config/dev` is set with 
+The one in `config/dev` is set with
  permissive `CORS` rules to enable web development using `ng serve` within the `ui/main` project.It's possible to use `ng serve` with the one in `config/docker` version also. To do so use the conf file named
 `nginx-cors-permissive.conf` by configuring the `/docker-compose.yml` with the following line:
 ----
@@ -78,7 +78,7 @@ a|card time display mode in the feed. Values :
 |feed.card.hideResponseFilter|false|no|Control if you want to show or hide the response filter in the feed page
 |feed.card.hideApplyFiltersToTimeLineChoice|false|no|Control if you want to show or hide the option of applying filters or not to timeline in the feed page
 |feed.card.hideAckAllCardsFeature|true|no|Control if you want to show or hide the option for acknowledging all the visible cards of the feed
-|feed.card.secondsBeforeLttdForClockDisplay|180|no| Number of seconds before lttd when a clock is activated in cards on the feed 
+|feed.card.secondsBeforeLttdForClockDisplay|180|no| Number of seconds before lttd when a clock is activated in cards on the feed
 |feed.card.maxNbOfCardsToDisplay|100|no| Max number of card visible in feed (This limit is used for performance reasons, setting the value too high can have consequences on browser response times)
 |feed.card.titleUpperCase|true|no| If set to true, the card titles are in UPPERCASE. (Option applies to the 'Card Feed', 'Archives' and 'Monitoring')
 
@@ -151,7 +151,7 @@ For example adding `Keycloak` application, with `'Keycloak'` as `name`, `1` as `
 ----
 |logo.base64|medium OperatorFabric icon|no|The encoding result of converting the svg logo to Base64, use this link:https://base64.guru/converter/encode/image/svg[online tool] to encode your svg. If it is not set, a medium (32px) OperatorFabric icon is displayed.
 |logo.height|40|no|The height of the logo (in px) (only taken into account if logo.base64 is set). The value cannot be more than 48px (if it is set to more than 48px, it will be ignored and set to 48px).
-|logo.width|40|no|The width of the logo (in px) (only taken into account if logo.base64 is set). 
+|logo.width|40|no|The width of the logo (in px) (only taken into account if logo.base64 is set).
 |title|OperatorFabric|no|Title of the application, displayed on the browser
 |environmentName||no| Name of the environment to display in the top-right corner (examples: PROD , TEST .. ), if the value not set the environment name is not shown .
 |environmentColor|blue|no| Color of the background of the environment name. The format of color is css, for example : `red` , `#4052FF`
@@ -160,21 +160,22 @@ For example adding `Keycloak` application, with `'Keycloak'` as `name`, `1` as `
 |usercard.useDescriptionFieldForEntityList|false|no|If true, show entity `description` field instead of `name` in user card page
 |externalDevicesEnabled|false|no|If true, users have the opportunity to play sounds on external devices rather than in the browser. See `settings.playSoundOnExternalDevice`
 |secondsToCloseSession|60|no|Number of seconds between logout and token expiration
-|selectActivityAreaOnLogin|false|no| if set to true the users belonging to multiple Entities will be required to configure activity area on login 
+|selectActivityAreaOnLogin|false|no| if set to true the users belonging to multiple Entities will be required to configure activity area on login
 |checkIfUrlIsLocked|true|no| if set to false, an OperatorFabric url can be used by several tabs in the same browser. Note that there can only be one token per browser for a given OperatorFabric url, so the first session will be replaced by the second one
-|alertMessageBusinessAutoClose|false|no| if set to true, the (red) business alert message will automatically close after a few seconds.
-|alertMessageOnBottomOfTheScreen|false|no| if set to true, the alert message is shown on the bottom of the page.
-|heartbeatSendingInterval|30|yes| Frequency in seconds at which the ui sends heartbeat to the server.
+|alerts.messageBusinessAutoClose|false|no| if set to true, the (red) business alert message will automatically close after a few seconds
+|alerts.messageOnBottomOfTheScreen|false|no| if set to true, the alert message is shown on the bottom of the page
+|alerts.hideBusinessMessages|false|no| if set to true, the business alert messages are hidden
+|heartbeatSendingInterval|30|yes| Frequency in seconds at which the ui sends heartbeat to the server
 
 
 |===
 
-IMPORTANT: 
+IMPORTANT:
 ====
-To declare settings parameters, you now need to group all fields under `settings: { }` 
-For example: 
+To declare settings parameters, you now need to group all fields under `settings: { }`
+For example:
 
-Replace the following invalid settings config 
+Replace the following invalid settings config
 ```
   "settings.replayInterval": 10,
   "settings.replayEnabled": true,
@@ -193,7 +194,7 @@ Replace the following invalid settings config
   },
 ```
 
-By this valid one : 
+By this valid one :
 
 ```
   "settings": {

--- a/src/docs/asciidoc/resources/migration_guide_to_4.0.adoc
+++ b/src/docs/asciidoc/resources/migration_guide_to_4.0.adoc
@@ -22,13 +22,18 @@ NOTE: With the new structure of the file, it is now possible to mix core menus a
 You can find more information and a full example in the documentation :
 https://opfab.github.io/documentation/current/reference_doc/#menu_entries
 
+== UI Configuration
+Some fields of the `web-ui.json` file have changed and renamed:
 
-== OpfabAPI 
+* `alertMessageBusinessAutoClose` has been moved to the  `alerts` section and is now called `messageBusinessAutoClose`
+* `alertMessageOnBottomOfTheScreen` has been moved to the  `alerts` section and is now called `messageOnBottomOfTheScreen`
 
-Use of methods or attributes starting with templateGateway are now deprecated , the following table give you the new methods to use 
+== OpfabAPI
+
+Use of methods or attributes starting with templateGateway are now deprecated , the following table give you the new methods to use
 
 |===
-|Deprecated method or attribute | New method 
+|Deprecated method or attribute | New method
 
 |templateGateway.getEntityName(entityId)
 |opfab.users.entities.getEntityName(entityId)
@@ -175,7 +180,7 @@ You must adapt the configuration to your environment by using the configuration 
 
 == Port mapping
 
-In release 4.0, the listening port is not any more 8080 for services in docker, it is now identical to the default port mapping outside the docker. 
+In release 4.0, the listening port is not any more 8080 for services in docker, it is now identical to the default port mapping outside the docker.
 
 So you need to modify your port mapping to migrate replacing the 8080 legacy port by the new port :
 

--- a/ui/main/src/app/business/view/core/alert/alert.view.spec.ts
+++ b/ui/main/src/app/business/view/core/alert/alert.view.spec.ts
@@ -116,9 +116,9 @@ describe('Alert view ', () => {
         expect(alertView.getAlertPage().backgroundColor).toEqual('#a71a1a');
     });
 
-    it('GIVEN alertMessageOnBottomOfTheScreen is true  WHEN message is display THEN message is on bottom of the screen ', async () => {
+    it('GIVEN messageOnBottomOfTheScreen is true  WHEN message is display THEN message is on bottom of the screen ', async () => {
         configServerMock.setResponseForWebUIConfiguration(
-            new ServerResponse({alertMessageOnBottomOfTheScreen: true}, ServerResponseStatus.OK, null)
+            new ServerResponse({alerts: {messageOnBottomOfTheScreen: true}}, ServerResponseStatus.OK, null)
         );
         await firstValueFrom(configService.loadWebUIConfiguration());
 
@@ -130,9 +130,9 @@ describe('Alert view ', () => {
         expect(alertView.getAlertPage().style).toEqual('bottom: 0');
     });
 
-    it('GIVEN alertMessageOnBottomOfTheScreen is false  WHEN message is display THEN message is on top of the screen ', async () => {
+    it('GIVEN messageOnBottomOfTheScreen is false  WHEN message is display THEN message is on top of the screen ', async () => {
         configServerMock.setResponseForWebUIConfiguration(
-            new ServerResponse({alertMessageOnBottomOfTheScreen: false}, ServerResponseStatus.OK, null)
+            new ServerResponse({alerts: {messageOnBottomOfTheScreen: false}}, ServerResponseStatus.OK, null)
         );
         await firstValueFrom(configService.loadWebUIConfiguration());
 
@@ -146,7 +146,7 @@ describe('Alert view ', () => {
 
     it('GIVEN a message WHEN alert is closed THEN message disappear', async () => {
         configServerMock.setResponseForWebUIConfiguration(
-            new ServerResponse({alertMessageOnBottomOfTheScreen: false}, ServerResponseStatus.OK, null)
+            new ServerResponse({alerts: {messageOnBottomOfTheScreen: false}}, ServerResponseStatus.OK, null)
         );
         await firstValueFrom(configService.loadWebUIConfiguration());
 
@@ -161,7 +161,7 @@ describe('Alert view ', () => {
 
     it('GIVEN a message WHEN message is displayed THEN message disappears after 5 seconds', async () => {
         configServerMock.setResponseForWebUIConfiguration(
-            new ServerResponse({alertMessageOnBottomOfTheScreen: false}, ServerResponseStatus.OK, null)
+            new ServerResponse({alerts: {messageOnBottomOfTheScreen: false}}, ServerResponseStatus.OK, null)
         );
         await firstValueFrom(configService.loadWebUIConfiguration());
 
@@ -181,7 +181,7 @@ describe('Alert view ', () => {
 
     it('GIVEN a message is displayed WHEN a new message arrives THEN the new message disappears after 5 seconds', async () => {
         configServerMock.setResponseForWebUIConfiguration(
-            new ServerResponse({alertMessageOnBottomOfTheScreen: false}, ServerResponseStatus.OK, null)
+            new ServerResponse({alerts: {messageOnBottomOfTheScreen: false}}, ServerResponseStatus.OK, null)
         );
         await firstValueFrom(configService.loadWebUIConfiguration());
 
@@ -204,9 +204,9 @@ describe('Alert view ', () => {
         expect(alertView.getAlertPage().display).toBeFalsy();
     });
 
-    it('GIVEN a message of level BUSINESS WHEN alertMessageBusinessAutoClose is false or not set THEN message never disappear automatically', async () => {
+    it('GIVEN a message of level BUSINESS WHEN messageBusinessAutoClose is false or not set THEN message never disappear automatically', async () => {
         configServerMock.setResponseForWebUIConfiguration(
-            new ServerResponse({alertMessageOnBottomOfTheScreen: false}, ServerResponseStatus.OK, null)
+            new ServerResponse({alerts: {messageOnBottomOfTheScreen: false}}, ServerResponseStatus.OK, null)
         );
         await firstValueFrom(configService.loadWebUIConfiguration());
 
@@ -228,9 +228,9 @@ describe('Alert view ', () => {
         expect(alertView.getAlertPage().message).toEqual('message');
     });
 
-    it('GIVEN a message of level BUSINESS WHEN alertMessageBusinessAutoClose is true THEN message disappear after 5 seconds', async () => {
+    it('GIVEN a message of level BUSINESS WHEN messageBusinessAutoClose is true THEN message disappear after 5 seconds', async () => {
         configServerMock.setResponseForWebUIConfiguration(
-            new ServerResponse({alertMessageBusinessAutoClose: true}, ServerResponseStatus.OK, null)
+            new ServerResponse({alerts: {messageBusinessAutoClose: true}}, ServerResponseStatus.OK, null)
         );
         await firstValueFrom(configService.loadWebUIConfiguration());
 
@@ -251,4 +251,40 @@ describe('Alert view ', () => {
     function delay() {
         return new Promise((resolve) => setTimeout(resolve, 1));
     }
+
+    it('Given a message of level BUSINESS WHEN hideBusinessMessages is true THEN message should not appear', async () => {
+        configServerMock.setResponseForWebUIConfiguration(
+            new ServerResponse({alerts: {hideBusinessMessages: true}}, ServerResponseStatus.OK, null)
+        );
+        await firstValueFrom(configService.loadWebUIConfiguration());
+
+        const alertView = new AlertView(configService, alertMessageService, translationService);
+        alertMessageService.sendAlertMessage(new Message('message', MessageLevel.BUSINESS));
+        await delay();
+        expect(alertView.getAlertPage().display).toBeFalsy();
+    });
+
+    it('Given a message of level BUSINESS WHEN hideBusinessMessages is false THEN message should appear', async () => {
+        configServerMock.setResponseForWebUIConfiguration(
+            new ServerResponse({alerts: {hideBusinessMessages: false}}, ServerResponseStatus.OK, null)
+        );
+        await firstValueFrom(configService.loadWebUIConfiguration());
+
+        const alertView = new AlertView(configService, alertMessageService, translationService);
+        alertMessageService.sendAlertMessage(new Message('message', MessageLevel.BUSINESS));
+        await delay();
+        expect(alertView.getAlertPage().display).toBeTruthy();
+    });
+
+    it('Given a message of level BUSINESS WHEN hideBusinessMessages is not set THEN message should appear', async () => {
+        configServerMock.setResponseForWebUIConfiguration(
+            new ServerResponse({}, ServerResponseStatus.OK, null)
+        );
+        await firstValueFrom(configService.loadWebUIConfiguration());
+
+        const alertView = new AlertView(configService, alertMessageService, translationService);
+        alertMessageService.sendAlertMessage(new Message('message', MessageLevel.BUSINESS));
+        await delay();
+        expect(alertView.getAlertPage().display).toBeTruthy();
+    });
 });

--- a/ui/main/src/app/business/view/core/alert/alert.view.ts
+++ b/ui/main/src/app/business/view/core/alert/alert.view.ts
@@ -7,7 +7,6 @@
  * This file is part of the OperatorFabric project.
  */
 
-
 import {AlertMessageService} from 'app/business/services/alert-message.service';
 import {ConfigService} from 'app/business/services/config.service';
 import {AlertPage} from './alertPage';
@@ -17,20 +16,31 @@ import {TranslationService} from 'app/business/services/translation/translation.
 export class AlertView {
     private alertMessageBusinessAutoClose: boolean;
     private alertPage: AlertPage;
-    private lastMessageDate : number;
+    private lastMessageDate: number;
+    private hideMessagesLevel: MessageLevel[] = [];
 
-    constructor(private configService: ConfigService, private alertMessageService: AlertMessageService, private translationService: TranslationService) {
-        this.alertMessageBusinessAutoClose = this.configService.getConfigValue('alertMessageBusinessAutoClose', false);
+    constructor(
+        private configService: ConfigService,
+        private alertMessageService: AlertMessageService,
+        private translationService: TranslationService
+    ) {
+        this.alertMessageBusinessAutoClose = this.configService.getConfigValue('alerts.messageBusinessAutoClose', false);
         this.alertPage = new AlertPage();
         this.alertPage.style = 'top: 0';
-        if (this.configService.getConfigValue('alertMessageOnBottomOfTheScreen', false))
+        if (this.configService.getConfigValue('alerts.messageOnBottomOfTheScreen', false))
             this.alertPage.style = 'bottom: 0';
+        if (this.configService.getConfigValue('alerts.hideBusinessMessages', false))
+            this.hideMessagesLevel.push(MessageLevel.BUSINESS);
+
         alertMessageService.getAlertMessage().subscribe((message: Message) => this.processAlertMessage(message));
     }
 
     private processAlertMessage(message: Message) {
+        if (this.hideMessagesLevel.includes(message.level)) return;
+
         this.alertPage.display = true;
-        if (message.i18n) this.alertPage.message = this.translationService.getTranslation(message.i18n.key,message.i18n.parameters);
+        if (message.i18n)
+            this.alertPage.message = this.translationService.getTranslation(message.i18n.key, message.i18n.parameters);
         else this.alertPage.message = message.message;
         this.alertPage.backgroundColor = this.getBackgroundColor(message.level);
         this.lastMessageDate = new Date().valueOf();


### PR DESCRIPTION
- In release note :
  -  In chapter :  Features
  -  Text : 
         -  Added the option 'hideBusinessMessages' to web-ui.json to hide alert messages with level "BUSINESS'. 
         - Renamed and moved alertMessageBusinessAutoClose and alertMessageOnBottomOfTheScreen to a new `alerts` section in the config