### PR TITLE
Migrate to java 17.0.7 (#4704)

### DIFF
--- a/bin/load_environment_light.sh
+++ b/bin/load_environment_light.sh
@@ -11,7 +11,7 @@
 
 source ${BASH_SOURCE%/*}/load_variables.sh
 
-sdk install java 17.0.4.1-zulu
-sdk use java 17.0.4.1-zulu
+sdk install java 17.0.7-zulu
+sdk use java 17.0.7-zulu
 nvm install v18.12.1
 nvm use v18.12.1

--- a/services/businessconfig/src/main/docker/Dockerfile
+++ b/services/businessconfig/src/main/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM azul/zulu-openjdk-alpine:17.0.4.1-jre
+FROM azul/zulu-openjdk-alpine:17.0.7-jre
 VOLUME /tmp
 ARG JAR_FILE
 RUN apk add bash curl --no-cache

--- a/services/cards-consultation/src/main/docker/Dockerfile
+++ b/services/cards-consultation/src/main/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM azul/zulu-openjdk-alpine:17.0.4.1-jre
+FROM azul/zulu-openjdk-alpine:17.0.7-jre
 VOLUME /tmp
 ARG JAR_FILE
 RUN apk add bash curl --no-cache

--- a/services/cards-publication/src/main/docker/Dockerfile
+++ b/services/cards-publication/src/main/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM azul/zulu-openjdk-alpine:17.0.4.1-jre
+FROM azul/zulu-openjdk-alpine:17.0.7-jre
 VOLUME /tmp
 ARG JAR_FILE
 RUN apk add bash curl --no-cache

--- a/services/external-devices/src/main/docker/Dockerfile
+++ b/services/external-devices/src/main/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM azul/zulu-openjdk-alpine:17.0.4.1-jre
+FROM azul/zulu-openjdk-alpine:17.0.7-jre
 VOLUME /tmp
 ARG JAR_FILE
 RUN apk add bash curl --no-cache

--- a/services/users/src/main/docker/Dockerfile
+++ b/services/users/src/main/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM azul/zulu-openjdk-alpine:17.0.4.1-jre
+FROM azul/zulu-openjdk-alpine:17.0.7-jre
 VOLUME /tmp
 ARG JAR_FILE
 RUN apk add bash curl --no-cache

--- a/src/test/dummyModbusDevice/src/main/docker/Dockerfile
+++ b/src/test/dummyModbusDevice/src/main/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM azul/zulu-openjdk-alpine:17.0.4.1-jre
+FROM azul/zulu-openjdk-alpine:17.0.7-jre
 VOLUME /tmp
 ARG JAR_FILE
 COPY ${JAR_FILE} app.jar

--- a/src/test/externalApp/src/main/docker/Dockerfile
+++ b/src/test/externalApp/src/main/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM azul/zulu-openjdk-alpine:17.0.4.1-jre
+FROM azul/zulu-openjdk-alpine:17.0.7-jre
 VOLUME /tmp
 RUN env
 ARG JAR_FILE


### PR DESCRIPTION
Fix #4704

- In release note :
  -  In chapter :  Features 
  -  Text : #4704 : Migrate to java 17.0.7 