### PR TITLE
External-devices : Do not print stacktrace in logs when device is not available or exiting

### DIFF
--- a/services/external-devices/src/main/java/org/opfab/externaldevices/services/DevicesService.java
+++ b/services/external-devices/src/main/java/org/opfab/externaldevices/services/DevicesService.java
@@ -163,7 +163,7 @@ public class DevicesService {
                 exceptionMessage = buildSignalSendingExceptionMessage(opFabSignalKey,
                         resolvedConfiguration.getSignalId(), userLogin,
                         resolvedConfiguration.getDeviceConfiguration().getId(), "as device is disabled");
-                log.warn(exceptionMessage, e);
+                log.warn(exceptionMessage);
             }
         }
         if (exceptionMessage != null)


### PR DESCRIPTION
Nothing in release note