### PR TITLE
Simplify some configuration

### DIFF
--- a/config/dev/common-dev.yml
+++ b/config/dev/common-dev.yml
@@ -1,18 +1,17 @@
 # This file contains only parameters that need to be overridden form the docker configuration
 spring:
-  rabbitmq:
-    host: localhost
   security:
     provider-url: http://localhost:89
     oauth2:
       resourceserver:
         jwt:
           jwk-set-uri: ${spring.security.provider-url}/auth/realms/dev/protocol/openid-connect/certs
-  data:
-    mongodb:
-      uri: mongodb://root:password@localhost:27017/operator-fabric?authSource=admin&authMode=scram-sha1
-
+          
 operatorfabric:
+  rabbitmq:
+    host: localhost
+  mongodb:
+    uri: mongodb://root:password@mongodb:27017/operator-fabric?authSource=admin&authMode=scram-sha1
   servicesUrls:
     users: "http://localhost:2103"
     businessconfig: "http://localhost:2100"

--- a/config/dev/common-dev.yml
+++ b/config/dev/common-dev.yml
@@ -1,12 +1,4 @@
 # This file contains only parameters that need to be overridden form the docker configuration
-spring:
-  security:
-    provider-url: http://localhost:89
-    oauth2:
-      resourceserver:
-        jwt:
-          jwk-set-uri: ${spring.security.provider-url}/auth/realms/dev/protocol/openid-connect/certs
-          
 operatorfabric:
   rabbitmq:
     host: localhost
@@ -15,4 +7,11 @@ operatorfabric:
   servicesUrls:
     users: "http://localhost:2103"
     businessconfig: "http://localhost:2100"
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          jwk-set-uri: http://keycloak:89/auth/realms/dev/protocol/openid-connect/certs
+
+
 

--- a/config/docker/common.yml
+++ b/config/docker/common.yml
@@ -5,21 +5,22 @@ management:
       exposure:
         include: '*'
 spring:
-  rabbitmq:
-    # host: rabbitmq
-    # SECURITY WARNING : To set and change in production if rabbit port is open outside of docker network
-    # username: guest
-    # password: guest
   security:
     oauth2:
       resourceserver:
         jwt:
           jwk-set-uri: http://keycloak:89/auth/realms/dev/protocol/openid-connect/certs
-  data:
-    mongodb:
-      uri: mongodb://root:password@mongodb:27017/operator-fabric?authSource=admin&authMode=scram-sha1
 
-    
+
+operatorfabric:
+  rabbitmq:
+    # host: rabbitmq
+    # SECURITY WARNING : To set and change in production if rabbit port is open outside of docker network
+    # username: guest
+    # password: guest
+  mongodb:
+    uri: mongodb://root:password@mongodb:27017/operator-fabric?authSource=admin&authMode=scram-sha1
+
 ### activate the following if you want to the groups or entities to come from the token and not mongo DB
 #  security:
 #    jwt:

--- a/config/docker/common.yml
+++ b/config/docker/common.yml
@@ -4,13 +4,6 @@ management:
     web:
       exposure:
         include: '*'
-spring:
-  security:
-    oauth2:
-      resourceserver:
-        jwt:
-          jwk-set-uri: http://keycloak:89/auth/realms/dev/protocol/openid-connect/certs
-
 
 operatorfabric:
   rabbitmq:
@@ -20,9 +13,14 @@ operatorfabric:
     # password: guest
   mongodb:
     uri: mongodb://root:password@mongodb:27017/operator-fabric?authSource=admin&authMode=scram-sha1
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          jwk-set-uri: http://keycloak:89/auth/realms/dev/protocol/openid-connect/certs
+
 
 ### activate the following if you want to the groups or entities to come from the token and not mongo DB
-#  security:
 #    jwt:
 
 ### activate the folLowing if you want the entities of the user to come from the token and not mongoDB

--- a/config/docker/node-services.yml
+++ b/config/docker/node-services.yml
@@ -3,7 +3,6 @@ opfab:
   cardsPublicationUrl: "http://cards-publication:2102"
   cardsConsultationUrl: http://cards-consultation:2104
   getTokenUrl: http://web-ui/auth/token
-  tokenExpireClaim: exp
 rabbitmq:
   host: rabbitmq
   port: 5672

--- a/config/docker/ui-config/web-ui.json
+++ b/config/docker/ui-config/web-ui.json
@@ -92,7 +92,6 @@
   },
   "security": {
     "jwt": {
-      "expire-claim": "exp",
       "login-claim": "preferred_username"
     },
     "logout-url": "http://localhost:89/auth/realms/dev/protocol/openid-connect/logout?post_logout_redirect_uri=http://localhost:2002/&client_id=opfab-client",
@@ -100,13 +99,9 @@
       "client-id": "opfab-client",
       "flow": {
         "delegate-url": "http://localhost:89/auth/realms/dev/protocol/openid-connect/auth?response_type=code&client_id=opfab-client",
-        "mode": "PASSWORD",
-        "provider": "Opfab Keycloak"
+        "mode": "PASSWORD"
       }
-    },
-    "provider-realm": "dev",
-    "provider-url": "http://localhost:89",
-    "changePasswordUrl": "http://localhost:89/auth/realms/dev/account/#/security/signingin"
+    }
   },
   "settings": {
     "locale": "en",

--- a/config/docker/ui-config/web-ui.json
+++ b/config/docker/ui-config/web-ui.json
@@ -101,7 +101,8 @@
         "delegate-url": "http://localhost:89/auth/realms/dev/protocol/openid-connect/auth?response_type=code&client_id=opfab-client",
         "mode": "PASSWORD"
       }
-    }
+    },
+    "changePasswordUrl": "http://localhost:89/auth/realms/dev/account/#/security/signingin"
   },
   "settings": {
     "locale": "en",

--- a/node-services/cards-external-diffusion/config/default-docker.yml
+++ b/node-services/cards-external-diffusion/config/default-docker.yml
@@ -4,7 +4,6 @@ opfab:
   usersUrl: "http://users:2103/users"
   cardsConsultationUrl: "http://cards-consultation:2104"
   getTokenUrl: "http://web-ui/auth/token"
-  tokenExpireClaim: "exp"
 rabbitmq:
   host: rabbitmq
   port: 5672

--- a/node-services/cards-external-diffusion/config/default.yml
+++ b/node-services/cards-external-diffusion/config/default.yml
@@ -4,7 +4,6 @@ opfab:
   usersUrl: "http://127.0.0.1:2103"
   cardsConsultationUrl: "http://127.0.0.1:2104"
   getTokenUrl: "http://127.0.0.1:2002/auth/token"
-  tokenExpireClaim: "exp"
 rabbitmq:
   host: localhost
   port: 5672

--- a/node-services/cards-external-diffusion/src/cardsExternalDiffusion.ts
+++ b/node-services/cards-external-diffusion/src/cardsExternalDiffusion.ts
@@ -35,7 +35,6 @@ const configService = new ConfigService(config.get('cardsExternalDiffusion.defau
 
 
 const authenticationService = new AuthenticationService()
-    .setTokenExpireClaim(config.get('opfab.tokenExpireClaim'))
     .setLogger(logger);
 
 

--- a/node-services/cards-reminder/config/default-docker.yml
+++ b/node-services/cards-reminder/config/default-docker.yml
@@ -1,7 +1,6 @@
 opfab: 
   cardsPublicationUrl: "http://cards-publication:2102"
   getTokenUrl: "http://web-ui/auth/token"
-  tokenExpireClaim: "exp"
 
 rabbitmq:
   host: "rabbitmq"

--- a/node-services/cards-reminder/config/default.yml
+++ b/node-services/cards-reminder/config/default.yml
@@ -1,7 +1,6 @@
 opfab: 
   cardsPublicationUrl: "http://127.0.0.1:2102"
   getTokenUrl: "http://127.0.0.1:2002/auth/token"
-  tokenExpireClaim: "exp"
 
 rabbitmq:
   host: "localhost"

--- a/node-services/cards-reminder/src/cardsReminder.ts
+++ b/node-services/cards-reminder/src/cardsReminder.ts
@@ -33,7 +33,6 @@ const adminPort = config.get('cardsReminder.adminPort');
 const activeOnStartUp = config.get('cardsReminder.activeOnStartup');
 
 const authenticationService = new AuthenticationService()
-    .setTokenExpireClaim(config.get('opfab.tokenExpireClaim'))
     .setLogger(logger);
 
 const remindDatabaseService = new RemindDatabaseService()

--- a/node-services/common/src/common/client-side/authenticationService.ts
+++ b/node-services/common/src/common/client-side/authenticationService.ts
@@ -12,16 +12,11 @@ import jwt_decode from 'jwt-decode';
 import OpfabServicesInterface from '../server-side/opfabServicesInterface';
 
 export default class AuthenticationService {
-    tokenExpireClaim: any;
     loginClaim: any = 'preferred_username';
     opfabServicesInterface: OpfabServicesInterface;
     logger: any;
 
 
-    public setTokenExpireClaim(tokenExpireClaim: string) {
-        this.tokenExpireClaim = tokenExpireClaim;
-        return this;
-    }
 
     public setLogger(logger: any) {
         this.logger = logger;
@@ -74,7 +69,7 @@ export default class AuthenticationService {
             const jwt = this.decodeToken(token);
 
             if (jwt) {
-                const expirationDate = jwt[this.tokenExpireClaim];
+                const expirationDate = jwt['exp'];
                 if (new Date().valueOf() < (expirationDate * 1000) - margin) {
                     return true;
                 }

--- a/node-services/supervisor/config/default-docker.yml
+++ b/node-services/supervisor/config/default-docker.yml
@@ -5,7 +5,6 @@ opfab:
   cardsPublicationUrl: "http://cards-publication:2102"
   cardsConsultationUrl: "http://cards-consultation:2104"
   getTokenUrl: "http://web-ui/auth/token"
-  tokenExpireClaim: "exp"
 logConfig:
   logLevel: info
 supervisor:

--- a/node-services/supervisor/config/default.yml
+++ b/node-services/supervisor/config/default.yml
@@ -5,7 +5,6 @@ opfab:
   cardsPublicationUrl: "http://127.0.0.1:2102"
   cardsConsultationUrl: "http://127.0.0.1:2104"
   getTokenUrl: "http://localhost:2002/auth/token"
-  tokenExpireClaim: "exp"
 logConfig:
   logFolder: logs/
   logFile: "%DATE%.log"

--- a/node-services/supervisor/src/connectionSupervisor.ts
+++ b/node-services/supervisor/src/connectionSupervisor.ts
@@ -29,7 +29,6 @@ const configService = new ConfigService(config.get('supervisor.defaultConfig'), 
 const activeOnStartUp = config.get('supervisor.activeOnStartup');
 
 const authenticationService = new AuthenticationService()
-    .setTokenExpireClaim(config.get('opfab.tokenExpireClaim'))
     .setLogger(logger);
 
 

--- a/services/businessconfig/src/main/resources/application.yml
+++ b/services/businessconfig/src/main/resources/application.yml
@@ -7,7 +7,12 @@ spring:
   data:
     mongodb:
       database: operator-fabric
-      uri: ${operatorfabric.mongodb.uri}
+      uri: ${operatorfabric.mongodb.uri} # To be set outside of docker
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          jwk-set-uri: ${operatorfabric.security.oauth2.resourceserver.jwt.jwk-set-uri} #To be set outside of docker
 
 # default values for docker mode 
 operatorfabric:

--- a/services/businessconfig/src/main/resources/application.yml
+++ b/services/businessconfig/src/main/resources/application.yml
@@ -7,15 +7,16 @@ spring:
   data:
     mongodb:
       database: operator-fabric
+      uri: ${operatorfabric.mongodb.uri}
 
 # default values for docker mode 
+operatorfabric:
   rabbitmq:
     host: rabbitmq
     port: 5672
     username: guest
     password: guest   
 
-operatorfabric:
   businessconfig:
     storage:
       path: "/businessconfig-storage"

--- a/services/cards-consultation/src/main/resources/application.yml
+++ b/services/cards-consultation/src/main/resources/application.yml
@@ -7,8 +7,12 @@ spring:
   data:
     mongodb:
       database: operator-fabric
-      uri: ${operatorfabric.mongodb.uri}
-
+      uri: ${operatorfabric.mongodb.uri} # To be set outside of docker
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          jwk-set-uri: ${operatorfabric.security.oauth2.resourceserver.jwt.jwk-set-uri} #To be set outside of docker
 
 # default values for docker mode 
 operatorfabric:

--- a/services/cards-consultation/src/main/resources/application.yml
+++ b/services/cards-consultation/src/main/resources/application.yml
@@ -7,16 +7,17 @@ spring:
   data:
     mongodb:
       database: operator-fabric
+      uri: ${operatorfabric.mongodb.uri}
 
 
+# default values for docker mode 
+operatorfabric:
+  servicesUrls:
+    businessconfig: "businessconfig:2100"
+    users: "users:2103"
 # default values for docker mode 
   rabbitmq:
     host: rabbitmq
     port: 5672
     username: guest
     password: guest
-    
-operatorfabric:
-  servicesUrls:
-    businessconfig: "businessconfig:2100"
-    users: "users:2103"

--- a/services/cards-publication/src/main/java/org/opfab/cards/publication/configuration/Services.java
+++ b/services/cards-publication/src/main/java/org/opfab/cards/publication/configuration/Services.java
@@ -42,9 +42,9 @@ public class Services {
             @Value("${operatorfabric.cards-publication.checkAuthenticationForCardSending:true}") boolean checkAuthenticationForCardSending,
             @Value("${operatorfabric.cards-publication.checkPerimeterForCardSending:true}") boolean checkPerimeterForCardSending,
             @Value("${operatorfabric.cards-publication.authorizeToSendCardWithInvalidProcessState:false}") boolean authorizeToSendCardWithInvalidProcessState,
-            @Value("${cardSendingLimitCardCount:1000}") int cardSendingLimitCardCount,
-            @Value("${cardSendingLimitPeriod:3600}") int cardSendingLimitPeriod,
-            @Value("${activateCardSendingLimiter:true}") boolean activateCardSendingLimiter) {
+            @Value("${operatorfabric.cards-publication.cardSendingLimitCardCount:1000}") int cardSendingLimitCardCount,
+            @Value("${operatorfabric.cards-publication.cardSendingLimitPeriod:3600}") int cardSendingLimitPeriod,
+            @Value("${operatorfabric.cards-publication.activateCardSendingLimiter:true}") boolean activateCardSendingLimiter) {
         this.cardTranslationService = new CardTranslationService(i18nProcessesCache, processesCache, eventBus);
         this.userActionLogService = userActionLogService;
         CardNotificationService cardNotificationService = new CardNotificationService(eventBus, objectMapper);

--- a/services/cards-publication/src/main/resources/application.yml
+++ b/services/cards-publication/src/main/resources/application.yml
@@ -8,7 +8,7 @@ spring:
   data:
     mongodb:
       database: operator-fabric
-      uri: ${operatorfabric.mongodb.uri}
+      uri: ${operatorfabric.mongodb.uri} # To be set outside of docker
   deserializer:
     value:
       delegate:
@@ -17,7 +17,11 @@ spring:
     value:
       delegate:
         class: io.confluent.kafka.serializers.KafkaAvroSerializer
-
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          jwk-set-uri: ${operatorfabric.security.oauth2.resourceserver.jwt.jwk-set-uri} #To be set outside of docker
 # default values for docker mode 
 operatorfabric:
   rabbitmq:

--- a/services/cards-publication/src/main/resources/application.yml
+++ b/services/cards-publication/src/main/resources/application.yml
@@ -8,6 +8,7 @@ spring:
   data:
     mongodb:
       database: operator-fabric
+      uri: ${operatorfabric.mongodb.uri}
   deserializer:
     value:
       delegate:
@@ -18,13 +19,12 @@ spring:
         class: io.confluent.kafka.serializers.KafkaAvroSerializer
 
 # default values for docker mode 
+operatorfabric:
   rabbitmq:
     host: rabbitmq
     port: 5672
     username: guest
     password: guest
-
-operatorfabric:
   servicesUrls:
     users: "users:2103"
     businessconfig: "businessconfig:2100"

--- a/services/external-devices/src/main/resources/application.yml
+++ b/services/external-devices/src/main/resources/application.yml
@@ -7,15 +7,16 @@ spring:
   data:
     mongodb:
       database: operator-fabric
+      uri: ${operatorfabric.mongodb.uri}
 
   # default values for docker mode 
+  
+operatorfabric:
   rabbitmq:
     host: rabbitmq
     port: 5672
     username: guest
     password: guest
-  
-operatorfabric:
   servicesUrls:
     businessconfig: "businessconfig:2100"
     users: "users:2103"

--- a/services/external-devices/src/main/resources/application.yml
+++ b/services/external-devices/src/main/resources/application.yml
@@ -7,8 +7,12 @@ spring:
   data:
     mongodb:
       database: operator-fabric
-      uri: ${operatorfabric.mongodb.uri}
-
+      uri: ${operatorfabric.mongodb.uri} # To be set outside of docker
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          jwk-set-uri: ${operatorfabric.security.oauth2.resourceserver.jwt.jwk-set-uri} #To be set outside of docker
   # default values for docker mode 
   
 operatorfabric:

--- a/services/users/src/main/resources/application.yml
+++ b/services/users/src/main/resources/application.yml
@@ -7,8 +7,12 @@ spring:
   data:
     mongodb:
       database: operator-fabric
-      uri: ${operatorfabric.mongodb.uri}
-
+      uri: ${operatorfabric.mongodb.uri} # To be set outside of docker
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          jwk-set-uri: ${operatorfabric.security.oauth2.resourceserver.jwt.jwk-set-uri} #To be set outside of docker
 
 # default values for docker mode 
 operatorfabric:

--- a/services/users/src/main/resources/application.yml
+++ b/services/users/src/main/resources/application.yml
@@ -7,9 +7,11 @@ spring:
   data:
     mongodb:
       database: operator-fabric
+      uri: ${operatorfabric.mongodb.uri}
 
 
 # default values for docker mode 
+operatorfabric:
   rabbitmq:
     host: rabbitmq
     port: 5672

--- a/src/docs/asciidoc/deployment/configuration/configuration.adoc
+++ b/src/docs/asciidoc/deployment/configuration/configuration.adoc
@@ -32,7 +32,7 @@ The configuration shared by all services is in a yaml file, you can find an exam
 
 ==== Mongo configuration
 
-We only use URI configuration for mongo through the usage of the ```spring.data.mongodb.uris```,
+We only use URI configuration for mongo through the usage of the ```operatorfabric.mongodb.uri```,
 it allows us to share the same configuration behavior for simple or cluster
 configuration and with both spring classic and reactive mongo configuration.
 See link:{mongo_doc}connection-string/[mongo connection string] for the complete URI syntax.

--- a/src/docs/asciidoc/deployment/configuration/configuration.adoc
+++ b/src/docs/asciidoc/deployment/configuration/configuration.adoc
@@ -105,11 +105,11 @@ KafkaAvroSerializer|Serializer used to convert cards to bytes
 |operatorfabric.cards-publication.kafka.schema.registry.url|http://localhost:8081|URL of the schema registry. Can be set to the empty string "" is no registry is used
 |operatorfabric.cards-publication.delayForDeleteExpiredCardsScheduling|60000|The delay in millisecond after the last execution finished and the next execution starts.
 [[cardSendingLimitCardCount]]
-|cardSendingLimitCardCount|1000|For the Rate limiter, this defines how many cards can be sent during `cardSendingLimitPeriod`.
+|operatorfabric.cards-publication.cardSendingLimitCardCount|1000|For the Rate limiter, this defines how many cards can be sent during `cardSendingLimitPeriod`.
 [[cardSendingLimitPeriod]]
-|cardSendingLimitPeriod|3600|For the Rate limiter, this defines the time period (in seconds) during which `cardSendingLimitCardCount` is applied.
+|operatorfabric.cards-publication.cardSendingLimitPeriod|3600|For the Rate limiter, this defines the time period (in seconds) during which `cardSendingLimitCardCount` is applied.
 [[activateCardSendingLimiter]]
-|activateCardSendingLimiter|true|If false, the Rate limiter will be ignored when sending cards.
+|operatorfabric.cards-publication.activateCardSendingLimiter|true|If false, the Rate limiter will be ignored when sending cards.
 |===
 
 

--- a/src/docs/asciidoc/deployment/configuration/configuration.adoc
+++ b/src/docs/asciidoc/deployment/configuration/configuration.adoc
@@ -354,7 +354,6 @@ Node services can be configured with the following properties:
 |opfab.cardReminderUrl||yes| Opfab card resetReadAndAcks endpoint URL
 |opfab.entitiesUrl||yes|Entities endpoint URL
 |opfab.getTokenUrl||yes|Authentication service URL
-|opfab.tokenExpireClaim||yes|Token expiration property
 |rabbitmq.host||yes|RabbitMQ host address
 |rabbitmq.port||yes|RabbitMQ listen port
 |rabbitmq.username||yes|RabbitMQ username

--- a/src/docs/asciidoc/deployment/configuration/security_configuration.adoc
+++ b/src/docs/asciidoc/deployment/configuration/security_configuration.adoc
@@ -69,7 +69,7 @@ where `b3BmYWItY2xpZW50Om9wZmFiLWtleWNsb2FrLXNlY3JldA==` is the base64 encoded s
 
 |===
 |name|default|mandatory?|Description 
-|operatorfabric.security.oauth2.resourceserver.jwt.jwk-set-uri|null|yes|The url providing the certificat used to verify the jwt signature
+|operatorfabric.security.oauth2.resourceserver.jwt.jwk-set-uri|null|yes|The url providing the certificate used to verify the jwt signature
 |===
 
 [NOTE]

--- a/src/docs/asciidoc/deployment/configuration/security_configuration.adoc
+++ b/src/docs/asciidoc/deployment/configuration/security_configuration.adoc
@@ -68,11 +68,8 @@ where `b3BmYWItY2xpZW50Om9wZmFiLWtleWNsb2FrLXNlY3JldA==` is the base64 encoded s
 === Configuration file common.yml
 
 |===
-|name|default|mandatory?|Description
-
-|spring.security.provider-url|null|no|The keycloak instance url. 
-|spring.security.provider-realm|null|no|The realm name within the keycloak instance. 
-|spring.security.oauth2.resourceserver.jwt.jwk-set-uri|null|yes|The url providing the certificat used to verify the jwt signature
+|name|default|mandatory?|Description 
+|operatorfabric.security.oauth2.resourceserver.jwt.jwk-set-uri|null|yes|The url providing the certificat used to verify the jwt signature
 |===
 
 [NOTE]
@@ -83,15 +80,12 @@ where `b3BmYWItY2xpZW50Om9wZmFiLWtleWNsb2FrLXNlY3JldA==` is the base64 encoded s
 ----
 spring:
   security:
-    provider-url: http://localhost:89
-    provider-realm: dev
     oauth2:
       resourceserver:
         jwt:
-          jwk-set-uri: ${spring.security.provider-url}/auth/realms/${spring.security.provider-realm}/protocol/openid-connect/certs
+          jwk-set-uri:  http://localhost:89/auth/realms/dev/protocol/openid-connect/certs
 ----
 
-where `jwt-set-uri` reuses `provider-url` and `provider-realm` properties.
 ====
 
 === Configuration file web-ui.json

--- a/src/docs/asciidoc/deployment/configuration/security_configuration.adoc
+++ b/src/docs/asciidoc/deployment/configuration/security_configuration.adoc
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2021 RTE (http://www.rte-france.com)
+// Copyright (c) 2018-2023 RTE (http://www.rte-france.com)
 // See AUTHORS.txt
 // This document is subject to the terms of the Creative Commons Attribution 4.0 International license.
 // If a copy of the license was not distributed with this

--- a/src/docs/asciidoc/deployment/configuration/security_configuration.adoc
+++ b/src/docs/asciidoc/deployment/configuration/security_configuration.adoc
@@ -95,13 +95,9 @@ Nginx web server serves this file. OperatorFabric creates and uses a custom Dock
 For OAuth2 security concerns into this file, there are two ways to configure it, based on the Oauth2 chosen flow.
 There are several common properties:
 
-- `security.provider-realm`: OAuth2 provider realm under which the OpertaroFabric client is declared;
-- `security.provider-url`: url of the keycloak server instance.
 - `security.logout-url`: url used when a user is logged out of the UI;
-- `security.oauth2.flow.provider`: name of the OAuth2 provider;
 - `security.oauth2.flow.delegate-url`: url used to connect to the Authentication provider;
 - `security.oauth2.flow.mode`: technical way to be authenticated by the Autentication provider.
-
 
 
 
@@ -124,13 +120,10 @@ These two modes share the same way of declaring the delegate URL.
       "oauth2": {
         "flow": {
           "mode": "CODE",
-          "provider": "Opfab Keycloak",
           "delegate-url": "http://localhost:89/auth/realms/dev/protocol/openid-connect/auth?response_type=code&client_id=opfab-client"
+        }
       },
-      "logout-url":"http://localhost:89/auth/realms/dev/protocol/openid-connect/logout?redirect_uri=http://localhost:2002/",
-    "provider-realm": "dev",
-    "provider-url": "http://localhost:89"
-    }
+      "logout-url":"http://localhost:89/auth/realms/dev/protocol/openid-connect/logout?redirect_uri=http://localhost:2002/"
   }
 }
 ----
@@ -154,19 +147,14 @@ To enable IMPLICIT Flow authentication the following properties need to be set:
 [source,json]
 ----
 {
-  "operatorfabric": {
-    "security": {
-      "oauth2": {
-        "flow": {
-          "mode": "IMPLICIT",
-          "provider": "Opfab Keycloak",
-          "delegate-url": "http://localhost:89/auth/realms/dev"
-      },
-      "logout-url":"http://localhost:89/auth/realms/dev/protocol/openid-connect/logout?redirect_uri=http://localhost:2002/",
-    "provider-realm": "dev",
-    "provider-url": "http://localhost:89"
+  "security": {
+    "oauth2": {
+      "flow": {
+        "mode": "IMPLICIT",
+        "delegate-url": "http://localhost:89/auth/realms/dev"
       }
     }
+    "logout-url":"http://localhost:89/auth/realms/dev/protocol/openid-connect/logout?redirect_uri=http://localhost:2002/",
   }
 }
 ----
@@ -212,31 +200,25 @@ Use the security.jwt.login-claim to select value from the token will be used to 
 Settings that are not required are:
 
 * delegate-url
-* provider-realm
 
 
 ==== Example of configuration 
 [source, json]
 ----
 {
-  "operatorfabric": {
     "security": {
       "jwt": {
-        "expire-claim": "exp",
         "login-claim": "preferred_username"
       },
       "oauth2": {
         "client-id": "OAUTHCLIENTID",
         "flow": {
-          "mode": "NONE",
-          "provider": "My Secured Proxy"
-      },
-      "logout-url":"http://my-secured-proxy/OAUTHTENANTID/oauth2/logout?client_id=OAUTHCLIENTID&post_logout_redirect_uri=https%3A%2F%2Flocalhost:2002%2Fui%2Fui/",
-      "provider-url": "http://my-secured-proxy/"
+          "mode": "NONE"
+        }
       }
+      "logout-url":"http://my-secured-proxy/OAUTHTENANTID/oauth2/logout?client_id=OAUTHCLIENTID&post_logout_redirect_uri=https%3A%2F%2Flocalhost:2002%2Fui%2Fui/"
     }
-  }
-}
+ }
 ----
 
 == User creation

--- a/src/docs/asciidoc/deployment/configuration/web-ui_configuration.adoc
+++ b/src/docs/asciidoc/deployment/configuration/web-ui_configuration.adoc
@@ -42,9 +42,6 @@ The properties lie in the `web-ui.json`.The following table describes their mean
 |===
 |name|default|mandatory?|Description
 
-
-|security.provider-realm||yes|The realm name in keycloak server settings page. This is used for the log out process to know which realm should be affected.
-|security.provider-url||yes|The keycloak server instance
 |security.logout-url||yes
 a|The keycloak logout URL. Is a composition of:
  - Your keycloak instance and the _auth_ keyword (ex: https://www.keycloakurl.com/auth), but we also support domains without _auth_ (ex: https://www.keycloakurl.com/customPath)
@@ -57,7 +54,6 @@ a|authentication mode, available options:
  - CODE: Authorization Code Flow;
  - PASSWORD: Direct Password Flow (fallback);
  - IMPLICIT: Implicit Flow.
-|security.oauth2.flow.provider|null|no|provider name to display on log in button
 |security.oauth2.flow.delegate-url|null|no
 a|Url to redirect the browser to for authentication. Mandatory with:
 

--- a/src/docs/asciidoc/resources/migration_guide_to_4.0.adoc
+++ b/src/docs/asciidoc/resources/migration_guide_to_4.0.adoc
@@ -210,7 +210,7 @@ The configuration has been simplified, you have now default parameters you do no
  - a default kafka configuration is provided, you only have to add "kafka.consumer.group-id : opfab-command" to enable kafka
  - a default rabbit configuration is provided
  - default value are provided for "operatorfabric.servicesUrls.users" and "operatorfabric.servicesUrls.businessconfig"
- - "data.mongodb.database" is not to be set anymore but you still need to set "data.mongodb.uri"
+ - "spring.data.mongodb.database" is not to be set anymore 
  - you still need to set "management.endpoints.web.exposure.include: '*'" if you want to monitor opfab via prometheus
  - operatorfabric.businessconfig.storage.path is set by default to "/businessconfig-storage"
 
@@ -252,3 +252,5 @@ concerned parameters (old name -> new name):
 - opfab.kafka.schema.registry.url -> operatorfabric.cards-publication.kafka.schema.registry.url
 - delayForDeleteExpiredCardsScheduling -> operatorfabric.cards-publication.delayForDeleteExpiredCardsScheduling
 - checkIfUserIsAlreadyConnected -> operatorfabric.checkIfUserIsAlreadyConnected
+- spring.data.mongodb.uri -->  operatorfabric.mongodb.uri
+- spring.rabbit.* --> operatorfabric.rabbit.*

--- a/src/docs/asciidoc/resources/migration_guide_to_4.0.adoc
+++ b/src/docs/asciidoc/resources/migration_guide_to_4.0.adoc
@@ -204,7 +204,7 @@ If you want to keep the old port 8080, you can change it via the server.port par
 == Configuration
 
 
-The configuration has been simplified, you have now default parameters you do not need to set anymore :
+The configuration has been simplified, you have now default parameters you do not need to set anymore in the back configuration:
 
  - in all yml file you do not need to set anymore spring.application.name
  - a default kafka configuration is provided, you only have to add "kafka.consumer.group-id : opfab-command" to enable kafka
@@ -237,6 +237,13 @@ becomes :
     volumes:
       - "./ui-config:/usr/share/nginx/html/config"
 ```
+
+In the web-ui.json file, you do not need anymore to set :
+- security.jwt.expire-claim
+- security.oauth2.flow.provider
+- security.oauth2.provider-realm
+- security.oauth2.provider-url
+
 
 == Normalization of some configuration parameters
 

--- a/src/docs/asciidoc/resources/migration_guide_to_4.0.adoc
+++ b/src/docs/asciidoc/resources/migration_guide_to_4.0.adoc
@@ -254,3 +254,4 @@ concerned parameters (old name -> new name):
 - checkIfUserIsAlreadyConnected -> operatorfabric.checkIfUserIsAlreadyConnected
 - spring.data.mongodb.uri -->  operatorfabric.mongodb.uri
 - spring.rabbit.* --> operatorfabric.rabbit.*
+- spring.security.oauth2.resourceserver.jwt.jwk-set-uri -->  operatorfabric.security.oauth2.resourceserver.jwt.jwk-set-uri

--- a/src/test/externalApp/src/main/resources/application.yml
+++ b/src/test/externalApp/src/main/resources/application.yml
@@ -6,6 +6,11 @@ spring:
     output:
       ansi:
         enabled: DETECT
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          jwk-set-uri: ${operatorfabric.security.oauth2.resourceserver.jwt.jwk-set-uri} #To be set outside of docker
 logging:
   file: logs/externalApp.log
   pattern:

--- a/src/test/resources/uiConfig/security-CODE-flow.json
+++ b/src/test/resources/uiConfig/security-CODE-flow.json
@@ -1,6 +1,5 @@
 {
   "jwt": {
-    "expire-claim": "exp",
     "login-claim": "preferred_username"
   },
   "logout-url": "http://localhost:89/auth/realms/dev/protocol/openid-connect/logout?post_logout_redirect_uri=http://localhost:2002/&client_id=opfab-client",
@@ -8,10 +7,7 @@
     "client-id": "opfab-client",
     "flow": {
       "delegate-url": "http://localhost:89/auth/realms/dev/protocol/openid-connect/auth?response_type=code&client_id=opfab-client",
-      "mode": "CODE",
-      "provider": "Opfab Keycloak"
+      "mode": "CODE"
     }
-  },
-  "provider-realm": "dev",
-  "provider-url": "http://localhost:89"
+  }
 }

--- a/src/test/resources/uiConfig/security-IMPLICIT-flow.json
+++ b/src/test/resources/uiConfig/security-IMPLICIT-flow.json
@@ -1,6 +1,5 @@
 {
   "jwt": {
-    "expire-claim": "exp",
     "login-claim": "preferred_username"
   },
   "logout-url": "http://localhost:89/auth/realms/dev/protocol/openid-connect/logout?post_logout_redirect_uri=http://localhost:2002/&client_id=opfab-client",
@@ -8,10 +7,7 @@
     "client-id": "opfab-client",
     "flow": {
       "delegate-url": "http://localhost:89/auth/realms/dev",
-      "mode": "IMPLICIT",
-      "provider": "Opfab Keycloak"
+      "mode": "IMPLICIT"
     }
-  },
-  "provider-realm": "dev",
-  "provider-url": "http://localhost:89"
+  }
 }

--- a/src/test/resources/uiConfig/security-PASSWORD-flow.json
+++ b/src/test/resources/uiConfig/security-PASSWORD-flow.json
@@ -1,6 +1,5 @@
 {
   "jwt": {
-    "expire-claim": "exp",
     "login-claim": "preferred_username"
   },
   "logout-url": "http://localhost:89/auth/realms/dev/protocol/openid-connect/logout?post_logout_redirect_uri=http://localhost:2002/&client_id=opfab-client",
@@ -8,10 +7,7 @@
     "client-id": "opfab-client",
     "flow": {
       "delegate-url": "http://localhost:89/auth/realms/dev/protocol/openid-connect/auth?response_type=code&client_id=opfab-client",
-      "mode": "PASSWORD",
-      "provider": "Opfab Keycloak"
+      "mode": "PASSWORD"
     }
-  },
-  "provider-realm": "dev",
-  "provider-url": "http://localhost:89"
+  }
 }

--- a/tools/generic/utilities/src/main/java/org/opfab/utilities/eventbus/rabbit/RabbitEventBus.java
+++ b/tools/generic/utilities/src/main/java/org/opfab/utilities/eventbus/rabbit/RabbitEventBus.java
@@ -40,22 +40,22 @@ public class RabbitEventBus implements EventBus {
     @Value("${spring.application.name}")
     private String appName;
 
-    @Value("${operatorfabric.amqp.connectionRetries:30}")
+    @Value("${operatorfabric.rabbitmq.connectionRetries:30}")
     private int retries;
 
-    @Value("${operatorfabric.amqp.connectionRetryInterval:5000}")
+    @Value("${operatorfabric.rabbitmq.connectionRetryInterval:5000}")
     private long retryInterval;
 
-    @Value("${spring.rabbitmq.host:localhost}")
+    @Value("${operatorfabric.rabbitmq.host:localhost}")
     private String host;
 
-    @Value("${spring.rabbitmq.port:5672}")
+    @Value("${operatorfabric.rabbitmq.port:5672}")
     private int port;
 
-    @Value("${spring.rabbitmq.username:guest}")
+    @Value("${operatorfabric.rabbitmq.username:guest}")
     private String username;
 
-    @Value("${spring.rabbitmq.password:guest}")
+    @Value("${operatorfabric.rabbitmq.password:guest}")
     private String password;
 
     private Channel channelForListening; // use to listen to events

--- a/ui/main/src/app/authentication/auth-handler.ts
+++ b/ui/main/src/app/authentication/auth-handler.ts
@@ -20,6 +20,7 @@ import {Observable, of, Subject} from 'rxjs';
 
 export const ONE_SECOND = 1000;
 export const MILLIS_TO_WAIT_BETWEEN_TOKEN_EXPIRATION_DATE_CONTROLS = 5000;
+export const EXPIRE_CLAIM = 'exp';
 export abstract class AuthHandler {
     protected checkTokenUrl = `${environment.url}/auth/check_token`;
     protected askTokenUrl = `${environment.url}/auth/token`;
@@ -32,14 +33,12 @@ export abstract class AuthHandler {
     protected clientId: string;
     protected delegateUrl: string;
     protected loginClaim: string;
-    protected expireClaim: string;
 
     constructor(configService: ConfigService, protected httpClient: HttpClient, protected logger: OpfabLoggerService) {
         this.secondsToCloseSession = configService.getConfigValue('secondsToCloseSession', 60);
         this.clientId = configService.getConfigValue('security.oauth2.client-id', null);
         this.delegateUrl = configService.getConfigValue('security.oauth2.flow.delegate-url', null);
         this.loginClaim = configService.getConfigValue('security.jwt.login-claim', 'sub');
-        this.expireClaim = configService.getConfigValue('security.jwt.expire-claim', 'exp');
     }
 
     abstract initializeAuthentication();
@@ -79,10 +78,8 @@ export abstract class AuthHandler {
         const jwt = this.decodeToken(authInfo.access_token);
         if (authInfo.expires_in) {
             expirationDate = Date.now() + ONE_SECOND * authInfo.expires_in;
-        } else if (this.expireClaim) {
-            expirationDate = jwt[this.expireClaim];
-        } else {
-            expirationDate = 0;
+        } else  {
+            expirationDate = jwt[EXPIRE_CLAIM];
         }
         const user = new AuthenticatedUser();
         user.login = jwt[this.loginClaim];


### PR DESCRIPTION

- To be consistent : prefix back configuration parameters with operatorfabric 
- Remove tokenExpiredClaim parameter as it has a standard value ( exp) 
- Remove some unused security parameters


In release note :
  -  In chapter :   Tasks
  -  Text : #4934  Simplify some configuration