### PR TITLE
Rename external recipients config params (#4945)

### DIFF
--- a/config/dev/cards-publication-dev.yml
+++ b/config/dev/cards-publication-dev.yml
@@ -1,29 +1,30 @@
 # This file contains only parameters that need to be overridden from the docker configuration
-
-external-recipients:
-  recipients:
-    - id: "processAction"
-      url: "http://localhost:8090/test"
-      propagateUserToken: true
-    - id: "api_test_externalRecipient1"
-      url: "http://localhost:8090/test"
-      propagateUserToken: true
-    - id: "api_test_externalRecipient2"
-      url: "http://localhost:8090/test"
-      propagateUserToken: true
-    - id: "externalRecipient1"
-      url: "http://localhost:8090/test"
-      propagateUserToken: true
-    - id: "externalRecipient2"
-      url: "http://localhost:8090/test"
-      propagateUserToken: true
-    - id: "notFoundExternalRecipient"
-      url: "http://localhost:8090/wrongpath"
-      propagateUserToken: true
-    - id: "invalidUrlExternalRecipient"
-      url: "notaurl/test"
-      propagateUserToken: true
-    - id: "connectionRefusedExternalRecipient"
-      url: "http://localhost:8091/test"
-      propagateUserToken: true
+operatorfabric:
+  cards-publication:
+    external-recipients:
+      recipients:
+        - id: "processAction"
+          url: "http://localhost:8090/test"
+          propagateUserToken: true
+        - id: "api_test_externalRecipient1"
+          url: "http://localhost:8090/test"
+          propagateUserToken: true
+        - id: "api_test_externalRecipient2"
+          url: "http://localhost:8090/test"
+          propagateUserToken: true
+        - id: "externalRecipient1"
+          url: "http://localhost:8090/test"
+          propagateUserToken: true
+        - id: "externalRecipient2"
+          url: "http://localhost:8090/test"
+          propagateUserToken: true
+        - id: "notFoundExternalRecipient"
+          url: "http://localhost:8090/wrongpath"
+          propagateUserToken: true
+        - id: "invalidUrlExternalRecipient"
+          url: "notaurl/test"
+          propagateUserToken: true
+        - id: "connectionRefusedExternalRecipient"
+          url: "http://localhost:8091/test"
+          propagateUserToken: true
 

--- a/config/docker/cards-publication.yml
+++ b/config/docker/cards-publication.yml
@@ -7,32 +7,33 @@
 #  VALUE FOR TESTING
 #  TO BE REMOVE FOR PRODUCTION MODE
 #
-
-external-recipients:
-  recipients:
-    - id: "processAction"
-      url: "http://ext-app:8090/test"
-      propagateUserToken: true
-    - id: "api_test_externalRecipient1"
-      url: "http://ext-app:8090/test"
-      propagateUserToken: true
-    - id: "api_test_externalRecipient2"
-      url: "http://ext-app:8090/test"
-      propagateUserToken: true
-    - id: "externalRecipient1"
-      url: "http://ext-app:8090/test"
-      propagateUserToken: true
-    - id: "externalRecipient2"
-      url: "http://ext-app:8090/test"
-      propagateUserToken: true
-    - id: "notFoundExternalRecipient"
-      url: "http://ext-app:8090/wrongpath"
-      propagateUserToken: true
-    - id: "invalidUrlExternalRecipient"
-      url: "notaurl/test"
-      propagateUserToken: true
-    - id: "connectionRefusedExternalRecipient"
-      url: "http://ext-app:8091/test"
-      propagateUserToken: true
+operatorfabric:
+  cards-publication:
+    external-recipients:
+      recipients:
+        - id: "processAction"
+          url: "http://ext-app:8090/test"
+          propagateUserToken: true
+        - id: "api_test_externalRecipient1"
+          url: "http://ext-app:8090/test"
+          propagateUserToken: true
+        - id: "api_test_externalRecipient2"
+          url: "http://ext-app:8090/test"
+          propagateUserToken: true
+        - id: "externalRecipient1"
+          url: "http://ext-app:8090/test"
+          propagateUserToken: true
+        - id: "externalRecipient2"
+          url: "http://ext-app:8090/test"
+          propagateUserToken: true
+        - id: "notFoundExternalRecipient"
+          url: "http://ext-app:8090/wrongpath"
+          propagateUserToken: true
+        - id: "invalidUrlExternalRecipient"
+          url: "notaurl/test"
+          propagateUserToken: true
+        - id: "connectionRefusedExternalRecipient"
+          url: "http://ext-app:8091/test"
+          propagateUserToken: true
 
 #logging.level.org.opfab: debug

--- a/services/cards-publication/src/main/java/org/opfab/cards/publication/configuration/ExternalRecipients.java
+++ b/services/cards-publication/src/main/java/org/opfab/cards/publication/configuration/ExternalRecipients.java
@@ -1,4 +1,4 @@
-/* Copyright (c) 2022, RTE (http://www.rte-france.com)
+/* Copyright (c) 2022-2023, RTE (http://www.rte-france.com)
  * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -15,7 +15,7 @@ import org.springframework.stereotype.Component;
 
 import lombok.Data;
 
-@ConfigurationProperties("external-recipients")
+@ConfigurationProperties("operatorfabric.cards-publication.external-recipients")
 @Component
 @Data
 public class ExternalRecipients {

--- a/services/cards-publication/src/test/resources/application-kafka.yml
+++ b/services/cards-publication/src/test/resources/application-kafka.yml
@@ -23,11 +23,11 @@ operatorfabric:
           topicname: m_opfab-card-commands_dev
         response-card:
           topicname: m_opfab-card-response_dev
-external-recipients:
-  recipients:
-    - id:  "api_test_externalRecipient1"
-      url: "http://localhost:8090/test"
-      propagateUserToken : true 
-    - id:  "camunda1"
-      url: "kafka:"
-      propagateUserToken: false 
+    external-recipients:
+      recipients:
+        - id:  "api_test_externalRecipient1"
+          url: "http://localhost:8090/test"
+          propagateUserToken : true 
+        - id:  "camunda1"
+          url: "kafka:"
+          propagateUserToken: false 

--- a/services/cards-publication/src/test/resources/application.yml
+++ b/services/cards-publication/src/test/resources/application.yml
@@ -1,13 +1,13 @@
-external-recipients:
-  recipients:
-    - id:  "api_test_externalRecipient1"
-      url: "http://localhost:8090/test"
-      propagateUserToken: true 
-    - id:  "api_test_externalRecipient2"
-      url: "http://localhost:8090/test"
-      propagateUserToken: true
 operatorfabric:
   cards-publication:
     checkAuthenticationForCardSending: true
     checkPerimeterForCardSending: false
     delayForDeleteExpiredCardsScheduling: "60000"
+    external-recipients:
+      recipients:
+        - id:  "api_test_externalRecipient1"
+          url: "http://localhost:8090/test"
+          propagateUserToken: true 
+        - id:  "api_test_externalRecipient2"
+          url: "http://localhost:8090/test"
+          propagateUserToken: true

--- a/src/docs/asciidoc/deployment/configuration/configuration.adoc
+++ b/src/docs/asciidoc/deployment/configuration/configuration.adoc
@@ -137,14 +137,16 @@ are to be returned via Kafka by setting the `external-recipients` in the `cards-
 
 [source, yaml]
 ----
-external-recipients:
-  recipients: 
-    - id: "processAction"
-      url: "http://localhost:8090/test"
-      propagateUserToken: true
-    - id: "mykafka"
-      url: "kafka:topicname"
-      propagateUserToken: false
+operatorfabric:
+  cards-publication:
+    external-recipients:
+      recipients: 
+        - id: "processAction"
+          url: "http://localhost:8090/test"
+          propagateUserToken: true
+        - id: "mykafka"
+          url: "kafka:topicname"
+          propagateUserToken: false
 
 ----
 

--- a/src/docs/asciidoc/dev_env/kafka.adoc
+++ b/src/docs/asciidoc/dev_env/kafka.adoc
@@ -175,14 +175,16 @@ convention to configure a REST endpoint. Instead of setting the 'http://host/api
 section from the cards-publication.yml file:
 [source, yaml]
 ----
-external-recipients:
-  recipents:
-    - id: "processAction"
-      url: "http://localhost:8090/test"
-      propagateUserToken: false
-    - id: "mykafka"
-      url: "kafka:topicname"
-      propagateUserToken: false
+operatorfabric:
+  cards-publication:
+    external-recipients:
+      recipents:
+        - id: "processAction"
+          url: "http://localhost:8090/test"
+          propagateUserToken: false
+        - id: "mykafka"
+          url: "kafka:topicname"
+          propagateUserToken: false
 ----
 
 Note that `topicname` is a placeholder for now. All response cards are returned via the same Kafka response topic, as specified in the `opfab.kafka.topics.response-card` field.

--- a/src/docs/asciidoc/reference_doc/response_cards.adoc
+++ b/src/docs/asciidoc/reference_doc/response_cards.adoc
@@ -41,14 +41,16 @@ The url of the third party receiving the response card is to be set in the .yml 
 possible to configure whether the user token shall be propagated to the third party or not by setting the
 "propagateUserToken" boolean property. Here is an example with two third parties configured.
 ....
-external-recipients:
-  recipients: 
-    - id: "third-party1"
-      url: "http://thirdparty1/test1"
-      propagateUserToken: true
-    - id: "third-party2"
-      url: "http://thirdparty2:8090/test2"
-      propagateUserToken: false
+operatorfabric:
+  cards-publication:
+    external-recipients:
+      recipients: 
+        - id: "third-party1"
+          url: "http://thirdparty1/test1"
+          propagateUserToken: true
+        - id: "third-party2"
+          url: "http://thirdparty2:8090/test2"
+          propagateUserToken: false
 ....
 
 The name to use for the third-party is the publisherId of the parent card.

--- a/src/docs/asciidoc/resources/migration_guide_to_4.0.adoc
+++ b/src/docs/asciidoc/resources/migration_guide_to_4.0.adoc
@@ -283,6 +283,7 @@ concerned parameters (old name -> new name):
 - checkAuthenticationForCardSending -> operatorfabric.cards-publication.checkAuthenticationForCardSending
 - authorizeToSendCardWithInvalidProcessState -> operatorfabric.cards-publication.authorizeToSendCardWithInvalidProcessState
 - checkPerimeterForCardSending -> operatorfabric.cards-publication.checkPerimeterForCardSending
+- external-recipients.* -> operatorfabric.cards-publication.external-recipients.*
 - opfab.kafka.topics.card.topicname -> operatorfabric.cards-publication.kafka.topics.card.topicname
 - opfab.kafka.topics.response-card.topicname -> operatorfabric.cards-publication.kafka.topics.response-card.topicname
 - opfab.kafka.schema.registry.url -> operatorfabric.cards-publication.kafka.schema.registry.url


### PR DESCRIPTION
Fix #4945

- In release note :
  -  In chapter :  Tasks
  -  Text : #4945 : Rename external recipients config params 