### PR TITLE
Reduce secondsToCloseSession to 60s to avoid being logout before silent refresh in IMPLICIT auth mode

### DIFF
--- a/src/docs/asciidoc/deployment/configuration/web-ui_configuration.adoc
+++ b/src/docs/asciidoc/deployment/configuration/web-ui_configuration.adoc
@@ -153,7 +153,7 @@ For example adding `Keycloak` application, with `'Keycloak'` as `name`, `1` as `
 |usercard.displayConnectionCirclesInPreview|false|no|Displays a green circle next to the recipient entities if any account associated to the entity is connected. If not, displays a red circle. The green circle doesn't take filters or perimeters into account. It doesn't warrant that the message will be received.
 |usercard.useDescriptionFieldForEntityList|false|no|If true, show entity `description` field instead of `name` in user card page
 |externalDevicesEnabled|false|no|If true, users have the opportunity to play sounds on external devices rather than in the browser. See `settings.playSoundOnExternalDevice`
-|secondsToCloseSession|600|no|Number of seconds between logout and token expiration
+|secondsToCloseSession|60|no|Number of seconds between logout and token expiration. If you use IMPLICIT authentication mode, exercise caution when modifying the value to prevent logouts before token silent refresh.
 |selectActivityAreaOnLogin|false|no| if set to true the users belonging to multiple Entities will be required to configure activity area on login
 |checkIfUrlIsLocked|true|no| if set to false, an OperatorFabric url can be used by several tabs in the same browser. Note that there can only be one token per browser for a given OperatorFabric url, so the first session will be replaced by the second one
 |alerts.messageBusinessAutoClose|false|no| if set to true, the (red) business alert message will automatically close after a few seconds

--- a/src/docs/asciidoc/resources/migration_guide_to_4.0.adoc
+++ b/src/docs/asciidoc/resources/migration_guide_to_4.0.adoc
@@ -328,10 +328,6 @@ to
     uri: mongodb://root:password@mongodb:27017/operator-fabric?authSource=admin
 ```
 
-== secondsToCloseSession
-
-The default value for "secondsToCloseSession" has been updated to 600 seconds, as opposed to the previous 60 seconds. This "secondsToCloseSession" define in web-ui.json reflects the duration before the end of token validity when the end-of-session popup will be displayed.
-
 == Rate limiter for card sendings
 
 External publishers are now monitored by a new module which limits how many cards they can send

--- a/ui/main/src/app/authentication/auth-handler.ts
+++ b/ui/main/src/app/authentication/auth-handler.ts
@@ -36,7 +36,7 @@ export abstract class AuthHandler {
     protected loginClaim: string;
 
     constructor(configService: ConfigService, protected httpClient: HttpClient, protected logger: OpfabLoggerService) {
-        this.secondsToCloseSession = configService.getConfigValue('secondsToCloseSession', 600);
+        this.secondsToCloseSession = configService.getConfigValue('secondsToCloseSession', 60);
         this.clientId = configService.getConfigValue('security.oauth2.client-id', null);
         this.delegateUrl = configService.getConfigValue('security.oauth2.flow.delegate-url', null);
         this.loginClaim = configService.getConfigValue('security.jwt.login-claim', 'sub');


### PR DESCRIPTION
Nothing in release note (pb not present in previous release) 