### PR TITLE
When loading an empty processgroup file the information is not updated on ui (#5118)

### DIFF
--- a/ui/main/src/app/business/services/businessconfig/processes.service.ts
+++ b/ui/main/src/app/business/services/businessconfig/processes.service.ts
@@ -87,13 +87,15 @@ export class ProcessesService {
                 const processGroupsFile = response.data;
                 if (processGroupsFile) {
                     const processGroupsList = processGroupsFile.groups;
-                    if (processGroupsList)
+                    if (processGroupsList) {
+                        this.processGroups.clear();
                         processGroupsList.forEach((processGroup) => {
                             this.processGroups.set(processGroup.id, {
                                 name: processGroup.name,
                                 processes: processGroup.processes
                             });
                         });
+                    }
                     console.log(new Date().toISOString(), 'List of process groups loaded');
                 }
                 if (response.status !== ServerResponseStatus.OK)


### PR DESCRIPTION
- In release note :
  -  In chapter : Bugs
  -  Text : #5118 : When loading an empty processgroup file the information is not updated on ui