### PR TITLE
Fix search in the Card Feed when the translatedSummary is missing (#5169)

### DIFF
--- a/ui/main/src/app/business/services/lightcards/search-service.ts
+++ b/ui/main/src/app/business/services/lightcards/search-service.ts
@@ -32,8 +32,8 @@ export class SearchService {
         if (!this.searchTerm) {
             return cards;
         } else {
-            const titleCards = cards.filter(card => card.titleTranslated.toUpperCase().includes(this.searchTerm));
-            const summaryCards = cards.filter(card => card.summaryTranslated.toUpperCase().includes(this.searchTerm))
+            const titleCards = cards.filter(card => card.titleTranslated?.toUpperCase().includes(this.searchTerm));
+            const summaryCards = cards.filter(card => card.summaryTranslated?.toUpperCase().includes(this.searchTerm))
             const searchedCards = titleCards.concat(summaryCards);
             return searchedCards.filter((card, index) => searchedCards.indexOf(card) === index);
         }


### PR DESCRIPTION
Fix #5169

- In release note :
  -  In chapter : Bugs
  -  Text : #5169 : Fix search in the Card Feed when the translatedSummary is missing