### PR TITLE
Set /var/log/opfab as log directory in all node-service dockers

### DIFF
--- a/node-services/cards-external-diffusion/config/default-docker.yml
+++ b/node-services/cards-external-diffusion/config/default-docker.yml
@@ -12,7 +12,7 @@ operatorfabric:
   internalAccount:
     login: opfab
   logConfig:
-    logFolder: logs/
+    logFolder: /var/log/opfab/
     logFile: "opfab.%DATE%.log"
     logLevel: info
   cardsExternalDiffusion:

--- a/node-services/cards-external-diffusion/docker/Dockerfile
+++ b/node-services/cards-external-diffusion/docker/Dockerfile
@@ -1,8 +1,8 @@
 FROM node:20.8-alpine
 WORKDIR /usr/app
 RUN chown node:node /usr/app
+RUN mkdir -m777 /var/log/opfab
 USER node
-RUN mkdir -m777 logs
 COPY dockerBuild ./build
 RUN mkdir -m777 config
 COPY dockerConfig/default-docker.yml ./config/base.yml

--- a/node-services/cards-reminder/config/default-docker.yml
+++ b/node-services/cards-reminder/config/default-docker.yml
@@ -14,7 +14,7 @@ operatorfabric:
   internalAccount:
     login: opfab
   logConfig:
-    logFolder: logs/
+    logFolder: /var/log/opfab/
     logFile: "opfab.%DATE%.log"
     logLevel: "info"
 

--- a/node-services/cards-reminder/docker/Dockerfile
+++ b/node-services/cards-reminder/docker/Dockerfile
@@ -2,8 +2,8 @@ FROM node:20.8-alpine
 RUN apk add --no-cache tzdata
 WORKDIR /usr/app
 RUN chown node:node /usr/app
+RUN mkdir -m777 /var/log/opfab
 USER node
-RUN mkdir -m777 logs
 COPY dockerBuild ./build
 RUN mkdir -m777 config
 COPY dockerConfig/default-docker.yml ./config/base.yml

--- a/node-services/supervisor/config/default-docker.yml
+++ b/node-services/supervisor/config/default-docker.yml
@@ -7,7 +7,7 @@ operatorfabric:
   internalAccount:
     login: opfab
   logConfig:
-    logFolder: logs/
+    logFolder: /var/log/opfab/
     logFile: "opfab.%DATE%.log"
     logLevel: info
   supervisor:

--- a/node-services/supervisor/docker/Dockerfile
+++ b/node-services/supervisor/docker/Dockerfile
@@ -1,8 +1,8 @@
 FROM node:20.8-alpine
 WORKDIR /usr/app
 RUN chown node:node /usr/app
+RUN mkdir -m777 /var/log/opfab
 USER node
-RUN mkdir -m777 logs
 COPY dockerBuild ./build
 RUN mkdir -m777 config
 COPY dockerConfig/default-docker.yml ./config/base.yml

--- a/src/docs/asciidoc/deployment/index.adoc
+++ b/src/docs/asciidoc/deployment/index.adoc
@@ -41,11 +41,26 @@ include::configuration/configuration.adoc[leveloffset=+1]
 == Monitoring
 
 Operator Fabric provides end points for monitoring via link:https://prometheus.io/[prometheus]. The monitoring is available for the four following services: user, businessconfig, cards-consultation, cards-publication. You can start a test prometheus instance via `config/monitoring/startPrometheus.sh` , the monitoring will be accessible on http://localhost:9090/
-It is also possible to monitor the health status of cards-external-diffusion, cards-reminder and supervisor services by making an HTTP GET request to the "/healthcheck" endpoint exposed by each service. The healthcheck enpoint will return a HTTP 200 status code if the service is up and running.
+It is also possible to monitor the health status of cards-external-diffusion, cards-reminder and supervisor services by making an HTTP GET request to the "/healthcheck" endpoint exposed by each service. The healthcheck endpoint will return a HTTP 200 status code if the service is up and running.
 
 == Logging Administration
 
-Operator Fabric includes the ability to view and configure the log levels at runtime through APIs. It is possible to configure and view an individual logger configuration, which is made up of both the explicitly configured logging level as well as the effective logging level given to it by the logging framework. These levels can be one of:
+
+=== Logging configuration 
+
+Log levels can be defined either globally in the YAML configuration file or individually for each service. You will find a commented configuration for each service within the directory config/docker.
+
+Services are designed to write logs to two primary destinations: standard output and log files within the Docker containers.
+
+If you want to save logs you can redirect the standard output to a file.
+
+Or you can also map the Docker directory /var/log/opfab to a location on the host machine for each business services, keeping logs outside of the container.
+
+For the web-ui service's logs are in the /var/log/nginx directory. You can map this directory to the host to preserve those logs.
+
+=== Runtime configuration 
+
+Operator Fabric includes the ability to view and configure the log levels at runtime through APIs for most of the business services (the service supervisor , cards-external-diffusion and cards-reminder does not provide this feature). It is possible to configure and view an individual logger configuration, which is made up of both the explicitly configured logging level as well as the effective logging level given to it by the logging framework. These levels can be one of:
 
 * TRACE
 * DEBUG
@@ -53,10 +68,7 @@ Operator Fabric includes the ability to view and configure the log levels at run
 * WARN
 * ERROR
 * FATAL
-* OFF
-* null
 
-null indicates that there is no explicit configuration.
 
 Querying and setting logging levels is restricted to administrators.
 

--- a/src/docs/asciidoc/resources/migration_guide_to_4.1.adoc
+++ b/src/docs/asciidoc/resources/migration_guide_to_4.1.adoc
@@ -23,4 +23,6 @@ For example :
   }
 ```
  
+== Log directories in docker 
 
+For the services cards-reminder, supervisor, cards-external-diffusion the log directory in the docker is not anymore /usr/app/logs but /var/log/opfab. So if you map the log directory in your configuration , you need to change it. 


### PR DESCRIPTION
- In release note :
  -  In chapter :  Tasks
  -  Text : #5206 Set /var/log/opfab as log directory in all node-service dockers