### PR TITLE
fix bug on buildin template task, for task description field

### DIFF
--- a/ui/main/src/app/business/buildInTemplates/task/usercard/taskUserCardTemplate.ts
+++ b/ui/main/src/app/business/buildInTemplates/task/usercard/taskUserCardTemplate.ts
@@ -29,7 +29,7 @@ export class TaskUserCardTemplate extends BaseUserCardTemplate {
         <br/>
         <div class="opfab-input">
             <label for="taskDescription"> ${opfab.utils.getTranslation('buildInTemplate.taskUserCard.taskDescriptionLabel')}</label>
-            <input size="50" type="text" id="taskDescription" value=${this.view.getTaskDescription()}> </input> 
+            <input size="50" type="text" id="taskDescription" value='${this.view.getTaskDescription()}'> </input> 
         </div>
         <br/>
         


### PR DESCRIPTION
The bug : if you set a task description field containing several words, then if you edit the card, only the first word is taken into account.