### PR TITLE
Opening a card from dashboard closes the popover #5110

### DIFF
--- a/ui/main/src/app/modules/dashboard/dashboard.component.ts
+++ b/ui/main/src/app/modules/dashboard/dashboard.component.ts
@@ -51,6 +51,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
     }
 
     selectCard(info) {
+        this.openPopover?.close();
         this.selectedCardService.setSelectedCardId(info);
         const options: NgbModalOptions = {
             size: 'fullscreen'
@@ -73,6 +74,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
     }
 
     onCircleClick(circle) {
+        this.openPopover?.close();
         if (circle.numberOfCards == 1) {
             const cardId = circle.cards[0].id;
             this.selectCard(cardId);


### PR DESCRIPTION
- In release note :
  -  In chapter : Bugs
  -  Text : #5110 Opening a card from dashboard now closes the tooltip