### PR TITLE
Refacto LightCardsFeedFilterService

### DIFF
--- a/ui/main/src/app/app.component.ts
+++ b/ui/main/src/app/app.component.ts
@@ -47,7 +47,7 @@ export class AppComponent {
     @HostListener('window:beforeunload')
     onBeforeUnload() {
         logger.info('Unload opfab', LogOption.LOCAL_AND_REMOTE);
-        this.opfabEventStreamService.closeEventStream();
+        OpfabEventStreamService.closeEventStream();
         RemoteLoggerService.flush(); // flush log before exiting opfab
         return null;
     }
@@ -73,7 +73,6 @@ export class AppComponent {
 
     constructor(
         private soundNotificationService: SoundNotificationService,
-        private opfabEventStreamService: OpfabEventStreamService,
         private routerNavigationService: RouterNavigationService, // put it here to have it injected and started a startup
         private selectedCardLoaderService: SelectedCardLoaderService  // put it here to have it injected and started a startup
     ) {

--- a/ui/main/src/app/business/services/businessconfig/businessdata.service.ts
+++ b/ui/main/src/app/business/services/businessconfig/businessdata.service.ts
@@ -24,14 +24,13 @@ export class BusinessDataService implements CrudService {
     private _cachedResources = new Map<string, string>();
 
     constructor(
-        private opfabEventStreamService: OpfabEventStreamService,
         private businessDataServer: BusinessDataServer
     ) {
         this.listenForBusinessDataUpdate();
     }
 
     listenForBusinessDataUpdate() {
-        this.opfabEventStreamService.getBusinessDataChanges().subscribe(() => {
+        OpfabEventStreamService.getBusinessDataChanges().subscribe(() => {
             logger.info(`New business data posted, emptying cache`, LogOption.LOCAL_AND_REMOTE);
             this.emptyCache();
         });

--- a/ui/main/src/app/business/services/events/application-update.service.ts
+++ b/ui/main/src/app/business/services/events/application-update.service.ts
@@ -26,7 +26,6 @@ import {BusinessDataService} from '../businessconfig/businessdata.service';
 })
 export class ApplicationUpdateService {
     constructor(
-        private opfabEventStreamService: OpfabEventStreamService,
         private handlebarsService: HandlebarsService,
         private templateCssService: TemplateCssService,
         private applicationEventsService: ApplicationEventsService,
@@ -40,7 +39,7 @@ export class ApplicationUpdateService {
     }
 
     private listenForBusinessConfigUpdate() {
-        this.opfabEventStreamService
+        OpfabEventStreamService
             .getBusinessConfigChangeRequests()
             .pipe(
                 debounce(() => timer(5000 + Math.floor(Math.random() * 5000))), // use a random  part to avoid all UI to access at the same time the server
@@ -61,7 +60,7 @@ export class ApplicationUpdateService {
     }
 
     private listenForUserConfigUpdate() {
-        this.opfabEventStreamService
+        OpfabEventStreamService
             .getUserConfigChangeRequests()
             .pipe(
                 debounce(() => timer(5000 + Math.floor(Math.random() * 5000))), // use a random  part to avoid all UI to access at the same time the server
@@ -84,7 +83,7 @@ export class ApplicationUpdateService {
     }
 
     private listenForBusinessDataUpdate() {
-        this.opfabEventStreamService.getBusinessDataChanges().subscribe(() => {
+        OpfabEventStreamService.getBusinessDataChanges().subscribe(() => {
             logger.info(`New business data posted, emptying cache`, LogOption.LOCAL_AND_REMOTE);
             this.businessDataService.emptyCache();
         });

--- a/ui/main/src/app/business/services/events/opfabEventStream.service.ts
+++ b/ui/main/src/app/business/services/events/opfabEventStream.service.ts
@@ -9,7 +9,6 @@
 
 import {Injectable} from '@angular/core';
 import {CardOperation} from '@ofModel/card-operation.model';
-import {FilterService} from 'app/business/services/lightcards/filter.service';
 import {LogOption, LoggerService as logger} from 'app/business/services/logs/logger.service';
 import {filter, map, Observable, Subject} from 'rxjs';
 import {OpfabEventStreamServer} from '../../server/opfabEventStream.server';
@@ -33,19 +32,11 @@ export class OpfabEventStreamService {
     private eventStreamClosed = false;
 
     constructor(
-        private opfabEventStreamServer: OpfabEventStreamServer,
-        private filterService: FilterService
+        private opfabEventStreamServer: OpfabEventStreamServer
     ) {}
 
     public initEventStream() {
         this.opfabEventStreamServer.initStream();
-        this.listenForFilterChange();
-    }
-
-    private listenForFilterChange() {
-        this.filterService.getBusinessDateFilterChanges().subscribe((filter) => {
-            this.setSubscriptionDates(filter.status.start, filter.status.end);
-        });
     }
 
     public closeEventStream() {
@@ -101,7 +92,7 @@ export class OpfabEventStreamService {
         this.startOfAlreadyLoadedPeriod = null;
     }
 
-    private setSubscriptionDates(start: number, end: number) {
+    public setSubscriptionDates(start: number, end: number) {
         logger.info(
             'EventStreamService - Set subscription date' + new Date(start) + ' -' + new Date(end),
             LogOption.LOCAL_AND_REMOTE

--- a/ui/main/src/app/business/services/lightcards/filter.service.spec.ts
+++ b/ui/main/src/app/business/services/lightcards/filter.service.spec.ts
@@ -10,6 +10,8 @@
 import {FilterType} from '@ofModel/feed-filter.model';
 import {LightCard, Severity} from '@ofModel/light-card.model';
 import {getSeveralRandomLightCards} from '@tests/helpers';
+import {OpfabEventStreamServerMock} from '@tests/mocks/opfab-event-stream.server.mock';
+import {OpfabEventStreamService} from '../events/opfabEventStream.service';
 import {FilterService} from './filter.service';
 
 describe('NewFilterService ', () => {
@@ -17,7 +19,7 @@ describe('NewFilterService ', () => {
     const ONE_HOUR = 3600000;
 
     beforeEach(() => {
-        service = new FilterService();
+        service = new FilterService(new OpfabEventStreamService(new OpfabEventStreamServerMock()));
     });
 
     function getFourCards() {

--- a/ui/main/src/app/business/services/lightcards/filter.service.ts
+++ b/ui/main/src/app/business/services/lightcards/filter.service.ts
@@ -12,6 +12,7 @@ import {Filter, FilterType} from '@ofModel/feed-filter.model';
 import {LightCard, Severity} from '@ofModel/light-card.model';
 import {LogOption, LoggerService as logger} from 'app/business/services/logs/logger.service';
 import {Observable, Subject, ReplaySubject} from 'rxjs';
+import {OpfabEventStreamService} from '../events/opfabEventStream.service';
 
 @Injectable({
     providedIn: 'root'
@@ -26,7 +27,7 @@ export class FilterService {
     private newBusinessDateFilter = new Subject();
     private filterChanges = new ReplaySubject(1);
 
-    constructor() {
+    constructor(private eventStreamServer:OpfabEventStreamService) {
         this.initFilter();
     }
 
@@ -42,6 +43,7 @@ export class FilterService {
         if (filterType === FilterType.BUSINESSDATE_FILTER) {
             this.businessDateFilter.active = active;
             this.businessDateFilter.status = status;
+            this.eventStreamServer.setSubscriptionDates(status.start, status.end);
             this.newBusinessDateFilter.next(this.businessDateFilter);
         } else {
             const filterToUpdate = this.filters[filterType];

--- a/ui/main/src/app/business/services/lightcards/lightcards-feed-filter.service.ts
+++ b/ui/main/src/app/business/services/lightcards/lightcards-feed-filter.service.ts
@@ -37,7 +37,6 @@ export class LightCardsFeedFilterService {
 
     constructor(
         private lightCardsStoreService: LightCardsStoreService,
-        private opfabEventStreamService: OpfabEventStreamService,
         private groupedCardsService: GroupedCardsService
     ) {
         this.lightCardFilter = new LightCardsFilter();
@@ -137,7 +136,7 @@ export class LightCardsFeedFilterService {
     }
 
     public updateFilter(filterType: FilterType, active: boolean, status: any) {
-        if (filterType === FilterType.BUSINESSDATE_FILTER) this.opfabEventStreamService.setSubscriptionDates(status.start, status.end);
+        if (filterType === FilterType.BUSINESSDATE_FILTER) OpfabEventStreamService.setSubscriptionDates(status.start, status.end);
         this.lightCardFilter.updateFilter(filterType,active,status);
     }
 

--- a/ui/main/src/app/business/services/lightcards/lightcards-feed-filter.service.ts
+++ b/ui/main/src/app/business/services/lightcards/lightcards-feed-filter.service.ts
@@ -13,7 +13,7 @@ import {combineLatest, Observable, ReplaySubject, Subject} from 'rxjs';
 import {LightCard} from '@ofModel/light-card.model';
 import {LightCardsStoreService} from './lightcards-store.service';
 import {LightCardsFilter} from './lightcards-filter';
-import {SortService} from './sort.service';
+import {LightCardsSorter} from './lightcards-sorter';
 import {GroupedCardsService} from 'app/business/services/lightcards/grouped-cards.service';
 import {ConfigService} from 'app/business/services/config.service';
 import {LogOption, LoggerService as logger} from 'app/business/services/logs/logger.service';
@@ -32,15 +32,16 @@ export class LightCardsFeedFilterService {
     private filteredLightCardsForTimeLine = new Subject();
     private onlyBusinessFilterForTimeLine = new Subject();
     private filterService: LightCardsFilter;
+    private lightCardsSorter: LightCardsSorter;
 
     constructor(
         private lightCardsStoreService: LightCardsStoreService,
         private opfabEventStreamService: OpfabEventStreamService,
-        private sortService: SortService,
         private searchService: SearchService,
         private groupedCardsService: GroupedCardsService
     ) {
         this.filterService = new LightCardsFilter();
+        this.lightCardsSorter = new LightCardsSorter();
         this.computeFilteredAndSortedLightCards();
         this.computeFilteredAndSearchedLightCards();
         this.computeFilteredLightCards();
@@ -48,7 +49,7 @@ export class LightCardsFeedFilterService {
     }
 
     private computeFilteredAndSortedLightCards() {
-        combineLatest([this.sortService.getSortFunctionChanges(), this.getFilteredAndSearchedLightCards()])
+        combineLatest([this.lightCardsSorter.getSortFunctionChanges(), this.getFilteredAndSearchedLightCards()])
             .pipe(
                 map((results) => {
                     results[1] = results[1].sort(results[0]);
@@ -139,13 +140,15 @@ export class LightCardsFeedFilterService {
         this.filterService.updateFilter(filterType,active,status);
     }
 
-
     public getBusinessDateFilter(): Filter {
         return this.filterService.getBusinessDateFilter();
     }
 
-
     public getBusinessDateFilterChanges(): Observable<any> {
         return this.filterService.getBusinessDateFilterChanges();
+    }
+
+    public setSortBy(sortBy: string) {
+        return this.lightCardsSorter.setSortBy(sortBy);
     }
 }

--- a/ui/main/src/app/business/services/lightcards/lightcards-filter.spec.ts
+++ b/ui/main/src/app/business/services/lightcards/lightcards-filter.spec.ts
@@ -10,16 +10,14 @@
 import {FilterType} from '@ofModel/feed-filter.model';
 import {LightCard, Severity} from '@ofModel/light-card.model';
 import {getSeveralRandomLightCards} from '@tests/helpers';
-import {OpfabEventStreamServerMock} from '@tests/mocks/opfab-event-stream.server.mock';
-import {OpfabEventStreamService} from '../events/opfabEventStream.service';
-import {FilterService} from './filter.service';
+import {LightCardsFilter} from './lightcards-filter';
 
 describe('NewFilterService ', () => {
-    let service: FilterService;
+    let service: LightCardsFilter;
     const ONE_HOUR = 3600000;
 
     beforeEach(() => {
-        service = new FilterService(new OpfabEventStreamService(new OpfabEventStreamServerMock()));
+        service = new LightCardsFilter();
     });
 
     function getFourCards() {

--- a/ui/main/src/app/business/services/lightcards/lightcards-filter.ts
+++ b/ui/main/src/app/business/services/lightcards/lightcards-filter.ts
@@ -7,17 +7,13 @@
  * This file is part of the OperatorFabric project.
  */
 
-import {Injectable} from '@angular/core';
 import {Filter, FilterType} from '@ofModel/feed-filter.model';
 import {LightCard, Severity} from '@ofModel/light-card.model';
 import {LogOption, LoggerService as logger} from 'app/business/services/logs/logger.service';
 import {Observable, Subject, ReplaySubject} from 'rxjs';
-import {OpfabEventStreamService} from '../events/opfabEventStream.service';
 
-@Injectable({
-    providedIn: 'root'
-})
-export class FilterService {
+
+export class LightCardsFilter {
 
     private static TWO_HOURS_IN_MILLIS = 2 * 60 * 60 * 1000;
     private static TWO_DAYS_IN_MILLIS = 48 * 60 * 60 * 1000;
@@ -27,11 +23,11 @@ export class FilterService {
     private newBusinessDateFilter = new Subject();
     private filterChanges = new ReplaySubject(1);
 
-    constructor(private eventStreamServer:OpfabEventStreamService) {
+    constructor() {
         this.initFilter();
     }
 
-    public initFilter() {
+    private initFilter() {
         this.filters[FilterType.TYPE_FILTER] = this.initTypeFilter();
         this.filters[FilterType.PUBLISHDATE_FILTER] = this.initPublishDateFilter();
         this.filters[FilterType.ACKNOWLEDGEMENT_FILTER] = this.initAcknowledgementFilter();
@@ -43,7 +39,6 @@ export class FilterService {
         if (filterType === FilterType.BUSINESSDATE_FILTER) {
             this.businessDateFilter.active = active;
             this.businessDateFilter.status = status;
-            this.eventStreamServer.setSubscriptionDates(status.start, status.end);
             this.newBusinessDateFilter.next(this.businessDateFilter);
         } else {
             const filterToUpdate = this.filters[filterType];
@@ -127,8 +122,8 @@ export class FilterService {
             },
             false,
             {
-                start: new Date().valueOf() - FilterService.TWO_HOURS_IN_MILLIS,
-                end: new Date().valueOf() + FilterService.TWO_DAYS_IN_MILLIS
+                start: new Date().valueOf() - LightCardsFilter.TWO_HOURS_IN_MILLIS,
+                end: new Date().valueOf() + LightCardsFilter.TWO_DAYS_IN_MILLIS
             }
         );
     }

--- a/ui/main/src/app/business/services/lightcards/lightcards-sorter.spec.ts
+++ b/ui/main/src/app/business/services/lightcards/lightcards-sorter.spec.ts
@@ -9,14 +9,14 @@
 
 import {LightCard, Severity} from '@ofModel/light-card.model';
 import {getSeveralRandomLightCards} from '@tests/helpers';
-import {SortService} from './sort.service';
+import {LightCardsSorter} from './lightcards-sorter';
 
-describe('NewFilterService ', () => {
-    let service: SortService;
+describe('Lightcards sorter ', () => {
+    let lightCardsSorter: LightCardsSorter;
     const ONE_HOUR = 3600000;
 
     beforeEach(() => {
-        service = new SortService();
+        lightCardsSorter = new LightCardsSorter();
     });
 
     function getFourCard() {
@@ -68,29 +68,29 @@ describe('NewFilterService ', () => {
         return cards;
     }
 
-    describe(' filter', () => {
-        it('unread filter  ', () => {
+    describe(' sort', () => {
+        it('unread sort  ', () => {
             const cards = getFourCard();
-            service.setSortBy('unread');
-            const sortedCards = [...cards].sort(service.getSortFunction());
+            lightCardsSorter.setSortBy('unread');
+            const sortedCards = [...cards].sort(lightCardsSorter.getSortFunction());
             expect(sortedCards[0]).toEqual(cards[3]);
             expect(sortedCards[1]).toEqual(cards[2]);
             expect(sortedCards[2]).toEqual(cards[0]);
             expect(sortedCards[3]).toEqual(cards[1]);
         });
-        it('severity filter  ', () => {
+        it('severity sort  ', () => {
             const cards = getFourCard();
-            service.setSortBy('severity');
-            const sortedCards = [...cards].sort(service.getSortFunction());
+            lightCardsSorter.setSortBy('severity');
+            const sortedCards = [...cards].sort(lightCardsSorter.getSortFunction());
             expect(sortedCards[0]).toEqual(cards[2]);
             expect(sortedCards[1]).toEqual(cards[0]);
             expect(sortedCards[2]).toEqual(cards[1]);
             expect(sortedCards[3]).toEqual(cards[3]);
         });
-        it('date filter  ', () => {
+        it('date sort  ', () => {
             const cards = getFourCard();
-            service.setSortBy('date');
-            const sortedCards = [...cards].sort(service.getSortFunction());
+            lightCardsSorter.setSortBy('date');
+            const sortedCards = [...cards].sort(lightCardsSorter.getSortFunction());
             expect(sortedCards[0]).toEqual(cards[0]);
             expect(sortedCards[1]).toEqual(cards[1]);
             expect(sortedCards[2]).toEqual(cards[3]);

--- a/ui/main/src/app/business/services/lightcards/lightcards-sorter.ts
+++ b/ui/main/src/app/business/services/lightcards/lightcards-sorter.ts
@@ -7,14 +7,10 @@
  * This file is part of the OperatorFabric project.
  */
 
-import {Injectable} from '@angular/core';
 import {LightCard, Severity} from '@ofModel/light-card.model';
 import {Subject, Observable} from 'rxjs';
 
-@Injectable({
-    providedIn: 'root'
-})
-export class SortService {
+export class LightCardsSorter {
     private sortChanges = new Subject();
     private sortBy = 'unread';
 

--- a/ui/main/src/app/business/services/lightcards/lightcards-store.service.ts
+++ b/ui/main/src/app/business/services/lightcards/lightcards-store.service.ts
@@ -68,7 +68,6 @@ export class LightCardsStoreService {
     private receivedAcksSubject = new Subject<{cardUid: string; entitiesAcks: string[]}>();
 
     constructor(
-        private opfabEventStreamService: OpfabEventStreamService,
         private selectedCardService: SelectedCardService,
         private acknowledgeService: AcknowledgeService
     ) {
@@ -146,7 +145,7 @@ export class LightCardsStoreService {
     }
 
     initStore() {
-        this.opfabEventStreamService.getCardOperationStream().subscribe({
+        OpfabEventStreamService.getCardOperationStream().subscribe({
             next: (operation) => {
                 switch (operation.type) {
                     case CardOperationType.ADD:
@@ -350,7 +349,7 @@ export class LightCardsStoreService {
     }
 
     public removeAllLightCards() {
-        this.opfabEventStreamService.resetAlreadyLoadingPeriod();
+        OpfabEventStreamService.resetAlreadyLoadingPeriod();
         this.lightCards.clear();
         this.lightCardsEvents.next(this.lightCards);
     }

--- a/ui/main/src/app/business/services/lightcards/lightcards-text-filter.ts
+++ b/ui/main/src/app/business/services/lightcards/lightcards-text-filter.ts
@@ -8,14 +8,10 @@
  * This file is part of the OperatorFabric project.
  */
 
-import {Injectable} from '@angular/core';
 import {Observable, Subject} from 'rxjs';
 import {LightCard} from '@ofModel/light-card.model';
 
-@Injectable({
-    providedIn: 'root'
-})
-export class SearchService {
+export class LightCardsTextFilter {
     private searchChanges = new Subject();
     private searchTerm = '';
 
@@ -23,13 +19,13 @@ export class SearchService {
         return this.searchChanges.asObservable();
     }
 
-    public getSearchTerm(searchTerm: string) {
+    public setSearchTerm(searchTerm: string) {
         this.searchTerm = searchTerm.toUpperCase();
         this.searchChanges.next(this.searchTerm);
     }
 
     public searchLightCards(cards: LightCard[]): LightCard[] {
-        if (!this.searchTerm) {
+        if (!this.searchTerm || this.searchTerm.length===0) {
             return cards;
         } else {
             const titleCards = cards.filter(card => card.titleTranslated?.toUpperCase().includes(this.searchTerm));

--- a/ui/main/src/app/business/services/services-config.ts
+++ b/ui/main/src/app/business/services/services-config.ts
@@ -21,6 +21,7 @@ import {EntitiesService} from './users/entities.service';
 import {GroupsService} from './users/groups.service';
 import {PerimetersService} from './users/perimeters.service';
 import {ProcessesService} from './businessconfig/processes.service';
+import {OpfabEventStreamService} from './events/opfabEventStream.service';
 
 declare const opfab: any;
 export class ServicesConfig {
@@ -39,7 +40,8 @@ export class ServicesConfig {
         EntitiesService.setEntitiesServer(servers.entitiesServer);
         GroupsService.setGroupsServer(servers.groupsServer);
         PerimetersService.setPerimeterServer(servers.perimetersServer);
-        ProcessesService.setProcessServer(servers.processServer)
+        ProcessesService.setProcessServer(servers.processServer);
+        OpfabEventStreamService.setEventStreamServer(servers.opfabEventStreamServer);
     }
 
     public static load(): Observable<any> {

--- a/ui/main/src/app/business/services/session-manager.service.ts
+++ b/ui/main/src/app/business/services/session-manager.service.ts
@@ -23,7 +23,6 @@ export class SessionManagerService {
     private endSessionEvent = new Subject<string>();
 
     constructor(
-        private opfabEventStreamService: OpfabEventStreamService,
         private soundNotificationService: SoundNotificationService,
         private authService: AuthService
     ) {
@@ -50,12 +49,12 @@ export class SessionManagerService {
             // so we can stop sending request to external devices
             if (this.soundNotificationService.getPlaySoundOnExternalDevice())
                 this.soundNotificationService.clearOutstandingNotifications();
-            this.opfabEventStreamService.closeEventStream();
+            OpfabEventStreamService.closeEventStream();
         });
     }
 
     private subscribeToSessionClosedByNewUser() {
-        this.opfabEventStreamService.getReceivedDisconnectUser().subscribe((isDisconnected) => {
+        OpfabEventStreamService.getReceivedDisconnectUser().subscribe((isDisconnected) => {
             if (isDisconnected) {
                 this.soundNotificationService.stopService();
                 this.endSessionEvent.next('DisconnectedByNewUser');
@@ -70,7 +69,7 @@ export class SessionManagerService {
     public logout() {
         logger.info('Logout : end session ', LogOption.REMOTE);
         this.soundNotificationService.stopService();
-        this.opfabEventStreamService.closeEventStream();
+        OpfabEventStreamService.closeEventStream();
         this.authService.logout();
     }
 }

--- a/ui/main/src/app/business/view/activityarea/activityarea.view.spec.ts
+++ b/ui/main/src/app/business/view/activityarea/activityarea.view.spec.ts
@@ -68,7 +68,7 @@ describe('ActivityAreaView', () => {
 
     function mockLightCardStoreService() {
         lightCardsStoreService = new LightCardsStoreService(
-            new OpfabEventStreamService(new OpfabEventStreamServerMock(), null),
+            new OpfabEventStreamService(new OpfabEventStreamServerMock()),
             null,
             null
         );

--- a/ui/main/src/app/business/view/activityarea/activityarea.view.spec.ts
+++ b/ui/main/src/app/business/view/activityarea/activityarea.view.spec.ts
@@ -11,13 +11,11 @@ import {Entity} from '@ofModel/entity.model';
 import {User} from '@ofModel/user.model';
 import {UserWithPerimeters} from '@ofModel/userWithPerimeters.model';
 import {EntitiesServerMock} from '@tests/mocks/entitiesServer.mock';
-import {OpfabEventStreamServerMock} from '@tests/mocks/opfab-event-stream.server.mock';
 import {SettingsServerMock} from '@tests/mocks/settingsServer.mock';
 import {UserServerMock} from '@tests/mocks/userServer.mock';
 import {ServerResponse, ServerResponseStatus} from 'app/business/server/serverResponse';
 import {EntitiesService} from 'app/business/services/users/entities.service';
 import {LightCardsStoreService} from 'app/business/services/lightcards/lightcards-store.service';
-import {OpfabEventStreamService} from 'app/business/services/events/opfabEventStream.service';
 import {SettingsService} from 'app/business/services/users/settings.service';
 import {UserService} from 'app/business/services/users/user.service';
 import {CurrentUserStore} from 'app/business/store/current-user.store';
@@ -68,7 +66,6 @@ describe('ActivityAreaView', () => {
 
     function mockLightCardStoreService() {
         lightCardsStoreService = new LightCardsStoreService(
-            new OpfabEventStreamService(new OpfabEventStreamServerMock()),
             null,
             null
         );

--- a/ui/main/src/app/business/view/dashboard/dashboard.view.spec.ts
+++ b/ui/main/src/app/business/view/dashboard/dashboard.view.spec.ts
@@ -27,7 +27,6 @@ import {Utilities} from 'app/business/common/utilities';
 import {FilterType} from '@ofModel/feed-filter.model';
 import {AcknowledgeService} from '../../services/acknowledge.service';
 import {LightCardsFeedFilterService} from 'app/business/services/lightcards/lightcards-feed-filter.service';
-import {SearchService} from 'app/business/services/lightcards/search-service';
 import {GroupedCardsService} from 'app/business/services/lightcards/grouped-cards.service';
 
 describe('Dashboard', () => {
@@ -57,7 +56,6 @@ describe('Dashboard', () => {
         lightCardsFeedFilterService = new LightCardsFeedFilterService(
             lightCardsStoreService,
             opfabEventStreamService,
-            new SearchService(),
             new GroupedCardsService()
         );
         lightCardsStoreService.initStore();

--- a/ui/main/src/app/business/view/dashboard/dashboard.view.spec.ts
+++ b/ui/main/src/app/business/view/dashboard/dashboard.view.spec.ts
@@ -43,13 +43,13 @@ describe('Dashboard', () => {
         UserService.setUserServer(userServerMock);
         processServerMock = new ProcessServerMock();
         ProcessesService.setProcessServer(processServerMock);
-        filterService = new FilterService();
+     
 
         opfabEventStreamServerMock = new OpfabEventStreamServerMock();
         const opfabEventStreamService = new OpfabEventStreamService(
-            opfabEventStreamServerMock,
-            null
+            opfabEventStreamServerMock
         );
+        filterService = new FilterService(opfabEventStreamService);
         acknowledgeService = new AcknowledgeService(null);
 
         lightCardsStoreService = new LightCardsStoreService(

--- a/ui/main/src/app/business/view/dashboard/dashboard.view.spec.ts
+++ b/ui/main/src/app/business/view/dashboard/dashboard.view.spec.ts
@@ -24,7 +24,6 @@ import {getOneRandomLightCard} from '@tests/helpers';
 import {firstValueFrom, skip} from 'rxjs';
 import {Severity} from '@ofModel/light-card.model';
 import {Utilities} from 'app/business/common/utilities';
-import {SortService} from 'app/business/services/lightcards/sort.service';
 import {FilterType} from '@ofModel/feed-filter.model';
 import {AcknowledgeService} from '../../services/acknowledge.service';
 import {LightCardsFeedFilterService} from 'app/business/services/lightcards/lightcards-feed-filter.service';
@@ -58,7 +57,6 @@ describe('Dashboard', () => {
         lightCardsFeedFilterService = new LightCardsFeedFilterService(
             lightCardsStoreService,
             opfabEventStreamService,
-            new SortService(),
             new SearchService(),
             new GroupedCardsService()
         );

--- a/ui/main/src/app/business/view/dashboard/dashboard.view.spec.ts
+++ b/ui/main/src/app/business/view/dashboard/dashboard.view.spec.ts
@@ -45,17 +45,16 @@ describe('Dashboard', () => {
         ProcessesService.setProcessServer(processServerMock);
 
         opfabEventStreamServerMock = new OpfabEventStreamServerMock();
-        const opfabEventStreamService = new OpfabEventStreamService(opfabEventStreamServerMock);
+
+        OpfabEventStreamService.setEventStreamServer(opfabEventStreamServerMock);
         acknowledgeService = new AcknowledgeService(null);
 
         lightCardsStoreService = new LightCardsStoreService(
-            opfabEventStreamService,
             new SelectedCardService(),
             acknowledgeService
         );
         lightCardsFeedFilterService = new LightCardsFeedFilterService(
             lightCardsStoreService,
-            opfabEventStreamService,
             new GroupedCardsService()
         );
         lightCardsStoreService.initStore();

--- a/ui/main/src/app/business/view/dashboard/dashboard.view.ts
+++ b/ui/main/src/app/business/view/dashboard/dashboard.view.ts
@@ -9,13 +9,13 @@
 
 import {Severity} from '@ofModel/light-card.model';
 import {Utilities} from 'app/business/common/utilities';
-import {FilterService} from 'app/business/services/lightcards/filter.service';
 import {LightCardsStoreService} from 'app/business/services/lightcards/lightcards-store.service';
 import {ProcessesService} from 'app/business/services/businessconfig/processes.service';
 import {UserService} from 'app/business/services/users/user.service';
 import moment from 'moment';
 import {combineLatest, Observable, ReplaySubject} from 'rxjs';
 import {DashboardPage, ProcessContent, StateContent, CardForDashboard, DashboardCircle} from './dashboardPage';
+import {LightCardsFeedFilterService} from 'app/business/services/lightcards/lightcards-feed-filter.service';
 
 export class Dashboard {
     private dashboardSubject = new ReplaySubject<DashboardPage>(1);
@@ -25,7 +25,7 @@ export class Dashboard {
 
     constructor(
         private lightCardsStoreService: LightCardsStoreService,
-        private filterService: FilterService
+        private lightCardsFeedFilterService: LightCardsFeedFilterService
     ) {
         this.loadProcesses();
         this.processLightCards();
@@ -69,7 +69,7 @@ export class Dashboard {
     }
 
     private processLightCards() {
-        combineLatest([this.filterService.getBusinessDateFilterChanges(),
+        combineLatest([this.lightCardsFeedFilterService.getBusinessDateFilterChanges(),
                        this.lightCardsStoreService.getLightCards()]).subscribe((results) => {
                 const cards = results[1].filter((card) => results[0].applyFilter(card));
                 this.loadProcesses();

--- a/ui/main/src/app/modules/calendar/calendar.component.ts
+++ b/ui/main/src/app/modules/calendar/calendar.component.ts
@@ -18,7 +18,6 @@ import {FilterType} from '@ofModel/feed-filter.model';
 import {HourAndMinutes, TimeSpan} from '@ofModel/card.model';
 import {ProcessesService} from 'app/business/services/businessconfig/processes.service';
 import {LightCardsStoreService} from 'app/business/services/lightcards/lightcards-store.service';
-import {FilterService} from 'app/business/services/lightcards/filter.service';
 import {ConfigService} from 'app/business/services/config.service';
 import {Frequency} from 'rrule';
 import dayGridPlugin from '@fullcalendar/daygrid';
@@ -27,6 +26,7 @@ import interactionPlugin from '@fullcalendar/interaction';
 import bootstrapPlugin from '@fullcalendar/bootstrap';
 import rrulePlugin from '@fullcalendar/rrule';
 import {SelectedCardService} from 'app/business/services/card/selectedCard.service';
+import {LightCardsFeedFilterService} from 'app/business/services/lightcards/lightcards-feed-filter.service';
 
 @Component({
     selector: 'of-calendar',
@@ -37,7 +37,7 @@ export class CalendarComponent implements OnInit, OnDestroy, AfterViewInit {
     constructor(
         private modalService: NgbModal,
         private lightCardsStoreService: LightCardsStoreService,
-        private filterService: FilterService,
+        private lightCardsFeedFilterService: LightCardsFeedFilterService,
         private selectedCardService: SelectedCardService
     ) {
         ProcessesService.getAllProcesses().forEach((process) => {
@@ -243,7 +243,7 @@ export class CalendarComponent implements OnInit, OnDestroy, AfterViewInit {
     }
 
     datesRangeChange(dateInfo) {
-        this.filterService.updateFilter(FilterType.BUSINESSDATE_FILTER, true, {
+        this.lightCardsFeedFilterService.updateFilter(FilterType.BUSINESSDATE_FILTER, true, {
             start: dateInfo.view.activeStart.getTime(),
             end: dateInfo.view.activeEnd.getTime()
         });

--- a/ui/main/src/app/modules/core/application-loading/app-loaded-in-another-tab/app-loaded-in-another-tab.component.ts
+++ b/ui/main/src/app/modules/core/application-loading/app-loaded-in-another-tab/app-loaded-in-another-tab.component.ts
@@ -46,7 +46,6 @@ export class AppLoadedInAnotherTabComponent extends ApplicationLoadingStep {
     private isApplicationActive = false;
 
     constructor(
-        private opfabEventStreamService: OpfabEventStreamService,
         private urlLockService: UrlLockService,
         private modalService: NgbModal,
         private soundNotificationService: SoundNotificationService
@@ -95,7 +94,7 @@ export class AppLoadedInAnotherTabComponent extends ApplicationLoadingStep {
             this.isDisconnectedByAnotherTab = true;
             this.isApplicationActive = false;
             this.soundNotificationService.stopService();
-            this.opfabEventStreamService.closeEventStream();
+            OpfabEventStreamService.closeEventStream();
             const login = UserService.getCurrentUserWithPerimeters().userData.login;
             logger.info(
                 'User ' + login + ' was disconnected by another browser tab having loaded the application',

--- a/ui/main/src/app/modules/core/application-loading/application-loading.component.ts
+++ b/ui/main/src/app/modules/core/application-loading/application-loading.component.ts
@@ -71,7 +71,6 @@ export class ApplicationLoadingComponent implements OnInit {
         private settingsService: SettingsService,
         private lightCardsStoreService: LightCardsStoreService,
         private opfabEventStreamServer: OpfabEventStreamServer,
-        private opfabEventStreamService: OpfabEventStreamService,
         private applicationUpdateService: ApplicationUpdateService,
         private systemNotificationService: SystemNotificationService,
         private opfabAPIService: OpfabAPIService,
@@ -96,7 +95,8 @@ export class ApplicationLoadingComponent implements OnInit {
             entitiesServer: this.entitiesServer,
             groupsServer: this.groupsServer,
             perimetersServer: this.perimetersServer,
-            processServer: this.processServer
+            processServer: this.processServer,
+            opfabEventStreamServer: this.opfabEventStreamServer
         });
 
 
@@ -243,7 +243,7 @@ export class ApplicationLoadingComponent implements OnInit {
 
     private finalizeApplicationLoading(): void {
         this.loadingInProgress = true;
-        this.opfabEventStreamService.initEventStream();
+        OpfabEventStreamService.initEventStream();
         this.opfabEventStreamServer.getStreamInitDone().subscribe(() => {
             this.applicationLoadedDone.next(true);
             this.applicationLoadedDone.complete();

--- a/ui/main/src/app/modules/core/reload-required/reload-required.component.ts
+++ b/ui/main/src/app/modules/core/reload-required/reload-required.component.ts
@@ -21,16 +21,13 @@ export class ReloadRequiredComponent implements OnInit {
 
     displayReloadRequired: boolean;
 
-    constructor(
-        private opfabEventStreamService: OpfabEventStreamService
-    ) {}
 
     ngOnInit(): void {
         this.detectReloadRequested();
     }
 
     private detectReloadRequested() {
-        this.opfabEventStreamService.getReloadRequests().subscribe(() => {
+        OpfabEventStreamService.getReloadRequests().subscribe(() => {
                 logger.info('Application reload requested', LogOption.LOCAL_AND_REMOTE);
                 this.displayReloadRequired = true;
         });

--- a/ui/main/src/app/modules/dashboard/dashboard.component.ts
+++ b/ui/main/src/app/modules/dashboard/dashboard.component.ts
@@ -13,7 +13,7 @@ import {Dashboard} from 'app/business/view/dashboard/dashboard.view';
 import {DashboardPage} from 'app/business/view/dashboard/dashboardPage';
 import {NgbModal, NgbModalOptions, NgbModalRef, NgbPopover} from '@ng-bootstrap/ng-bootstrap';
 import {SelectedCardService} from 'app/business/services/card/selectedCard.service';
-import {FilterService} from 'app/business/services/lightcards/filter.service';
+import {LightCardsFeedFilterService} from 'app/business/services/lightcards/lightcards-feed-filter.service';
 @Component({
     selector: 'of-dashboard',
     templateUrl: './dashboard.component.html',
@@ -32,10 +32,10 @@ export class DashboardComponent implements OnInit, OnDestroy {
     constructor(
         private lightCardsStoreService: LightCardsStoreService,
         private selectedCardService: SelectedCardService,
-        private filterService: FilterService,
+        private lightCardsFeedFilterService: LightCardsFeedFilterService,
         private modalService: NgbModal
     ) {
-        this.dashboard = new Dashboard(lightCardsStoreService, filterService);
+        this.dashboard = new Dashboard(lightCardsStoreService, lightCardsFeedFilterService);
     }
 
     ngOnInit(): void {

--- a/ui/main/src/app/modules/feed/components/card-list/card-list.component.ts
+++ b/ui/main/src/app/modules/feed/components/card-list/card-list.component.ts
@@ -22,10 +22,10 @@ import {EntitiesService} from 'app/business/services/users/entities.service';
 import {GroupedCardsService} from 'app/business/services/lightcards/grouped-cards.service';
 import {AlertMessageService} from 'app/business/services/alert-message.service';
 import {Router} from '@angular/router';
-import {SortService} from 'app/business/services/lightcards/sort.service';
 import {UserPreferencesService} from 'app/business/services/users/user-preference.service';
 import {LightCardsStoreService} from 'app/business/services/lightcards/lightcards-store.service';
 import {ServerResponseStatus} from 'app/business/server/serverResponse';
+import {LightCardsFeedFilterService} from 'app/business/services/lightcards/lightcards-feed-filter.service';
 
 @Component({
     selector: 'of-card-list',
@@ -59,7 +59,7 @@ export class CardListComponent implements AfterViewChecked, OnInit {
         private acknowledgeService: AcknowledgeService,
         private groupedCardsService: GroupedCardsService,
         private router: Router,
-        private sortService: SortService,
+        private lightCardsFeedFilterService: LightCardsFeedFilterService,
         private lightCardsStoreService: LightCardsStoreService,
     ) {
         this.currentUserWithPerimeters = UserService.getCurrentUserWithPerimeters();
@@ -68,7 +68,7 @@ export class CardListComponent implements AfterViewChecked, OnInit {
     ngOnInit(): void {
         this.defaultSorting = ConfigService.getConfigValue('feed.defaultSorting', 'unread');
 
-        this.sortService.setSortBy(this.defaultSorting);
+        this.lightCardsFeedFilterService.setSortBy(this.defaultSorting);
 
         this.defaultAcknowledgmentFilter = ConfigService.getConfigValue('feed.defaultAcknowledgmentFilter', 'notack');
         if (

--- a/ui/main/src/app/modules/feed/components/card-list/filters/feed-filter/feed-filter.component.ts
+++ b/ui/main/src/app/modules/feed/components/card-list/filters/feed-filter/feed-filter.component.ts
@@ -17,7 +17,6 @@ import {UserPreferencesService} from 'app/business/services/users/user-preferenc
 import {DateTimeNgb} from '@ofModel/datetime-ngb.model';
 import moment from 'moment';
 import {MessageLevel} from '@ofModel/message.model';
-import {FilterService} from 'app/business/services/lightcards/filter.service';
 import {LightCardsFeedFilterService} from 'app/business/services/lightcards/lightcards-feed-filter.service';
 import {Utilities} from 'app/business/common/utilities';
 import {AlertMessageService} from 'app/business/services/alert-message.service';
@@ -69,7 +68,6 @@ export class FeedFilterComponent implements OnInit, OnDestroy {
     private dateFilterType = FilterType.PUBLISHDATE_FILTER;
 
     constructor(
-        private filterService: FilterService,
         private lightCardsFeedFilterService: LightCardsFeedFilterService,
     ) {
         this.typeFilterForm = this.createFormGroup();
@@ -164,7 +162,7 @@ export class FeedFilterComponent implements OnInit, OnDestroy {
         this.typeFilterForm.get('compliant').setValue(!compliantUnset, {emitEvent: false});
         this.typeFilterForm.get('information').setValue(!informationUnset, {emitEvent: false});
 
-        this.filterService.updateFilter(
+        this.lightCardsFeedFilterService.updateFilter(
             FilterType.TYPE_FILTER,
             alarmUnset || actionUnset || compliantUnset || informationUnset,
             {alarm: !alarmUnset, action: !actionUnset, compliant: !compliantUnset, information: !informationUnset}
@@ -184,7 +182,7 @@ export class FeedFilterComponent implements OnInit, OnDestroy {
                 UserPreferencesService.setPreference('opfab.feed.filter.type.compliant', form.compliant);
                 UserPreferencesService.setPreference('opfab.feed.filter.type.information', form.information);
                 this.filterActiveChange.next(this.isFilterActive());
-                return this.filterService.updateFilter(
+                return this.lightCardsFeedFilterService.updateFilter(
                     FilterType.TYPE_FILTER,
                     !(form.alarm && form.action && form.compliant && form.information),
                     form
@@ -199,13 +197,13 @@ export class FeedFilterComponent implements OnInit, OnDestroy {
         this.responseFilterForm.get('responseControl').setValue(!responseUnset, {emitEvent: false});
 
         if (responseValue) {
-            this.filterService.updateFilter(FilterType.RESPONSE_FILTER, responseUnset, !responseUnset);
+            this.lightCardsFeedFilterService.updateFilter(FilterType.RESPONSE_FILTER, responseUnset, !responseUnset);
         }
 
         this.responseFilterForm.valueChanges.pipe(takeUntil(this.ngUnsubscribe$)).subscribe((form) => {
             UserPreferencesService.setPreference('opfab.feed.filter.response', form.responseControl);
             this.filterActiveChange.next(this.isFilterActive());
-            return this.filterService.updateFilter(
+            return this.lightCardsFeedFilterService.updateFilter(
                 FilterType.RESPONSE_FILTER,
                 !form.responseControl,
                 form.responseControl
@@ -240,7 +238,7 @@ export class FeedFilterComponent implements OnInit, OnDestroy {
             const ack = (!form.ackControl && !form.notAckControl) ? null : active && form.ackControl;
             UserPreferencesService.setPreference('opfab.feed.filter.ack', this.getAckPreference(form.ackControl, form.notAckControl));
             this.filterActiveChange.next(this.isFilterActive());
-            return this.filterService.updateFilter(FilterType.ACKNOWLEDGEMENT_FILTER, active, ack);
+            return this.lightCardsFeedFilterService.updateFilter(FilterType.ACKNOWLEDGEMENT_FILTER, active, ack);
         });
     }
 
@@ -249,22 +247,22 @@ export class FeedFilterComponent implements OnInit, OnDestroy {
             this.ackFilterForm.get('ackControl').setValue(true, {emitEvent: false});
             this.ackFilterForm.get('notAckControl').setValue(false, {emitEvent: false});
 
-            this.filterService.updateFilter(FilterType.ACKNOWLEDGEMENT_FILTER, true, true);
+            this.lightCardsFeedFilterService.updateFilter(FilterType.ACKNOWLEDGEMENT_FILTER, true, true);
         } else if (ackValue === 'notack') {
             this.ackFilterForm.get('ackControl').setValue(false, {emitEvent: false});
             this.ackFilterForm.get('notAckControl').setValue(true, {emitEvent: false});
 
-            this.filterService.updateFilter(FilterType.ACKNOWLEDGEMENT_FILTER, true, false);
+            this.lightCardsFeedFilterService.updateFilter(FilterType.ACKNOWLEDGEMENT_FILTER, true, false);
         } else  if (ackValue === 'all') {
             this.ackFilterForm.get('ackControl').setValue(true, {emitEvent: false});
             this.ackFilterForm.get('notAckControl').setValue(true, {emitEvent: false});
 
-            this.filterService.updateFilter(FilterType.ACKNOWLEDGEMENT_FILTER, false, false);
+            this.lightCardsFeedFilterService.updateFilter(FilterType.ACKNOWLEDGEMENT_FILTER, false, false);
         } else  if (ackValue === 'none'){
             this.ackFilterForm.get('ackControl').setValue(false, {emitEvent: false});
             this.ackFilterForm.get('notAckControl').setValue(false, {emitEvent: false});
 
-            this.filterService.updateFilter(FilterType.ACKNOWLEDGEMENT_FILTER, true, null);
+            this.lightCardsFeedFilterService.updateFilter(FilterType.ACKNOWLEDGEMENT_FILTER, true, null);
         }
     }
 
@@ -337,7 +335,7 @@ export class FeedFilterComponent implements OnInit, OnDestroy {
             };
         }
 
-        this.filterService.updateFilter(this.dateFilterType, true, status);
+        this.lightCardsFeedFilterService.updateFilter(this.dateFilterType, true, status);
         this.filterActiveChange.next(this.isFilterActive());
     }
 

--- a/ui/main/src/app/modules/feed/components/card-list/filters/feed-search/feed-search.component.ts
+++ b/ui/main/src/app/modules/feed/components/card-list/filters/feed-search/feed-search.component.ts
@@ -9,9 +9,9 @@
  */
 
 import {Component, Input, OnInit} from '@angular/core';
-import {SearchService} from 'app/business/services/lightcards/search-service';
 import {FormControl} from '@angular/forms';
 import {TranslateService} from '@ngx-translate/core';
+import {LightCardsFeedFilterService} from 'app/business/services/lightcards/lightcards-feed-filter.service';
 
 @Component({
     selector: 'of-feed-search',
@@ -25,15 +25,15 @@ export class FeedSearchComponent implements OnInit {
     placeholder : string;
 
     constructor(
-        private searchService: SearchService,
+        private lightCardsFeedFilterService: LightCardsFeedFilterService,
         private translateService: TranslateService
     ) {}
 
     ngOnInit() {
         this.placeholder = this.translateService.instant('feed.searchPlaceholderText');
-        this.searchService.getSearchTerm("");
+        this.lightCardsFeedFilterService.setSearchTermForTextFilter("");
         this.searchControl.valueChanges.subscribe(searchTerm => {
-            this.searchService.getSearchTerm(searchTerm);
+            this.lightCardsFeedFilterService.setSearchTermForTextFilter(searchTerm);
         })
     }
 }

--- a/ui/main/src/app/modules/feed/components/card-list/filters/feed-sort/feed-sort.component.ts
+++ b/ui/main/src/app/modules/feed/components/card-list/filters/feed-sort/feed-sort.component.ts
@@ -12,7 +12,7 @@ import {FormControl, FormGroup} from '@angular/forms';
 import {Subject} from 'rxjs';
 import {takeUntil} from 'rxjs/operators';
 import {UserPreferencesService} from 'app/business/services/users/user-preference.service';
-import {SortService} from 'app/business/services/lightcards/sort.service';
+import {LightCardsFeedFilterService} from 'app/business/services/lightcards/lightcards-feed-filter.service';
 
 @Component({
     selector: 'of-feed-sort',
@@ -27,7 +27,7 @@ export class FeedSortComponent implements OnInit, OnDestroy {
         sortControl: FormControl<string | null>;
     }>;
 
-    constructor(private sortService: SortService) {}
+    constructor(private lightCardsFeedFilterService: LightCardsFeedFilterService) {}
 
     ngOnInit() {
         this.sortForm = this.createFormGroup();
@@ -47,11 +47,11 @@ export class FeedSortComponent implements OnInit, OnDestroy {
     initSort() {
         const sortChoice = this.getInitialSort();
         this.sortForm.get('sortControl').setValue(sortChoice);
-        this.sortService.setSortBy(sortChoice);
+        this.lightCardsFeedFilterService.setSortBy(sortChoice);
 
         this.sortForm.valueChanges.pipe(takeUntil(this.ngUnsubscribe$)).subscribe((form) => {
             UserPreferencesService.setPreference('opfab.feed.sort.type', form.sortControl);
-            this.sortService.setSortBy(form.sortControl);
+            this.lightCardsFeedFilterService.setSortBy(form.sortControl);
         });
     }
 

--- a/ui/main/src/app/modules/feed/components/time-line/init-chart/init-chart.component.spec.ts
+++ b/ui/main/src/app/modules/feed/components/time-line/init-chart/init-chart.component.spec.ts
@@ -27,6 +27,8 @@ import {LightCardsFeedFilterService} from 'app/business/services/lightcards/ligh
 import {DateTimeFormatterService} from 'app/business/services/date-time-formatter.service';
 import {ConfigServer} from 'app/business/server/config.server';
 import {ConfigServerMock} from '@tests/mocks/configServer.mock';
+import {OpfabEventStreamServer} from 'app/business/server/opfabEventStream.server';
+import {OpfabEventStreamServerMock} from '@tests/mocks/opfab-event-stream.server.mock';
 
 describe('InitChartComponent', () => {
     let component: InitChartComponent;
@@ -64,7 +66,8 @@ describe('InitChartComponent', () => {
                 {provide: ConfigServer, useClass: ConfigServerMock},
                 {provide: HttpClient, useClass: HttpClient},
                 {provide: HttpHandler, useClass: HttpHandler},
-                {provide: LightCardsFeedFilterService, useClass: LightCardsServiceMock}
+                {provide: LightCardsFeedFilterService, useClass: LightCardsServiceMock},
+                {provide: OpfabEventStreamServer, useClass: OpfabEventStreamServerMock}
             ],
             schemas: [NO_ERRORS_SCHEMA]
         }).compileComponents();

--- a/ui/main/src/app/modules/monitoring/components/monitoring-filters/monitoring-filter-builder.ts
+++ b/ui/main/src/app/modules/monitoring/components/monitoring-filters/monitoring-filter-builder.ts
@@ -10,8 +10,8 @@
 import {Injectable} from '@angular/core';
 import {Filter} from '@ofModel/feed-filter.model';
 import {LightCard} from '@ofModel/light-card.model';
-import {FilterService} from 'app/business/services/lightcards/filter.service';
 import {ProcessesService} from 'app/business/services/businessconfig/processes.service';
+import {LightCardsFeedFilterService} from 'app/business/services/lightcards/lightcards-feed-filter.service';
 
 @Injectable({
     providedIn: 'root'
@@ -20,7 +20,7 @@ export class MonitoringFilterBuilder {
     private typeOfStatesFilter: Filter;
     private processFilter: Filter;
 
-    constructor(private filterService: FilterService) {}
+    constructor(private lightCardsFeedFilterService: LightCardsFeedFilterService) {}
 
     public setProcessList(processesId: string[]) {
         if (processesId.length > 0) {
@@ -72,7 +72,7 @@ export class MonitoringFilterBuilder {
     }
 
     public getFilters(): Array<Filter> {
-        const timelineFilter = this.filterService.getBusinessDateFilter();
+        const timelineFilter = this.lightCardsFeedFilterService.getBusinessDateFilter();
         return [timelineFilter, this.processFilter, this.typeOfStatesFilter];
     }
 }

--- a/ui/main/src/app/modules/share/timeline-buttons/timeline-buttons.component.ts
+++ b/ui/main/src/app/modules/share/timeline-buttons/timeline-buttons.component.ts
@@ -13,8 +13,8 @@ import moment from 'moment';
 import {FilterType} from '@ofModel/feed-filter.model';
 import {UserPreferencesService} from 'app/business/services/users/user-preference.service';
 import {DateTimeFormatterService} from 'app/business/services/date-time-formatter.service';
-import {FilterService} from 'app/business/services/lightcards/filter.service';
 import {LogOption, LoggerService as logger} from 'app/business/services/logs/logger.service';
+import {LightCardsFeedFilterService} from 'app/business/services/lightcards/lightcards-feed-filter.service';
 
 @Component({
     selector: 'of-timeline-buttons',
@@ -47,7 +47,7 @@ export class TimelineButtonsComponent implements OnInit, OnDestroy {
 
     constructor(
         private dateTimeFormatter: DateTimeFormatterService,
-        private filterService: FilterService
+        private lightCardsFeedFilterService: LightCardsFeedFilterService
     ) {}
 
     ngOnInit() {
@@ -235,7 +235,7 @@ export class TimelineButtonsComponent implements OnInit, OnDestroy {
         this.startDateForBusinessPeriodDisplay = this.getDateFormatting(startDomain);
         this.endDateForBusinessPeriodDisplay = this.getDateFormatting(endDomain);
 
-        this.filterService.updateFilter(FilterType.BUSINESSDATE_FILTER, true, {
+        this.lightCardsFeedFilterService.updateFilter(FilterType.BUSINESSDATE_FILTER, true, {
             start: startDomain,
             end: endDomain,
             domainId: this.currentDomainId

--- a/ui/main/src/tests/mocks/lightcards.service.mock.ts
+++ b/ui/main/src/tests/mocks/lightcards.service.mock.ts
@@ -1,4 +1,4 @@
-/* Copyright (c) 2021, RTE (http://www.rte-france.com)
+/* Copyright (c) 2021-2023, RTE (http://www.rte-france.com)
  * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -9,10 +9,15 @@
 
 import {Observable, of} from 'rxjs';
 import {Injectable} from '@angular/core';
+import {FilterType} from '@ofModel/feed-filter.model';
 
 @Injectable()
 export class LightCardsServiceMock {
     public getFilteredLightCardsForTimeLine(): Observable<any> {
         return of([]);
+    }
+
+    public updateFilter(filterType: FilterType, active: boolean, status: any) {
+       // not implemented
     }
 }


### PR DESCRIPTION
The idea behind this refacto is that access to filter/sort the feed light cards is done through the  lightcards-feed-filter.service.ts 

So : 
 - FilterService is not a service anymore, is  renamed LightCardsFilter and is only used by LightCardsFeedFilterService
 - SortService is not a service anymore, is  renamed LightCardsSorter and is only used by LightCardsFeedFilterService
 - SearchService is not a service anymore, is  renamed LightCardsTextFilter and is only used by LightCardsFeedFilterService

This way we avoid the need for angular service injections and external component/services have a centralized way to access/manipulate the filter/sorted lightcards 


Nothing in release note