### PR TITLE
Solve issue : Card reminder go in a loop under certain circumstances

### DIFF
--- a/node-services/cards-reminder/config/default.yml
+++ b/node-services/cards-reminder/config/default.yml
@@ -23,7 +23,7 @@ operatorfabric:
   logConfig:
     logFolder: "logs/"
     logFile: "%DATE%.log"
-    logLevel: "debug"
+    logLevel: "error" #set to error to avoid being polluted by logs in the CI/CD during unit tests
   cardsReminder:
     adminPort : 2107
     activeOnStartup : true

--- a/node-services/cards-reminder/package.json
+++ b/node-services/cards-reminder/package.json
@@ -7,8 +7,8 @@
     "start:dev": "npx nodemon",
     "build": "rimraf ./build && tsc",
     "start": "npm run build && node build/cardsReminder.js",
-    "test": "jest --coverage",
-    "test:watch": "jest --watch"
+    "test": "jest --coverage --verbose",
+    "test:watch": "jest --watch --verbose"
   },
   "author": "",
   "license": "ISC",

--- a/node-services/cards-reminder/src/cardsReminder.ts
+++ b/node-services/cards-reminder/src/cardsReminder.ts
@@ -17,7 +17,7 @@ import logger from './common/server-side/logger';
 
 import ReminderService from './domain/application/reminderService';
 import CardsReminderOpfabServicesInterface from './domain/server-side/cardsReminderOpfabServicesInterface';
-import CardsReminderService from './domain/client-side/cardsRemiderService';
+import CardsReminderService from './domain/client-side/cardsReminderService';
 import {RRuleReminderService} from './domain/application/rruleReminderService';
 import RemindDatabaseService from './domain/server-side/remindDatabaseService';
 import AuthorizationService from './common/server-side/authorizationService';
@@ -49,14 +49,14 @@ const activeOnStartUp = config.get('operatorfabric.cardsReminder.activeOnStartup
 
 const remindDatabaseService = new RemindDatabaseService()
     .setMongoDbConfiguration(config.get('operatorfabric.mongodb'))
-    .setRemindersCollection(ReminderService.REMINDERS_COLLECTION)
+    .setRemindersCollection('reminders')
     .setLogger(logger);
 
 const reminderService = new ReminderService().setLogger(logger).setDatabaseService(remindDatabaseService);
 
 const rRuleRemindDatabaseService = new RemindDatabaseService()
     .setMongoDbConfiguration(config.get('operatorfabric.mongodb'))
-    .setRemindersCollection(RRuleReminderService.REMINDERS_COLLECTION)
+    .setRemindersCollection('rrule_reminders')
     .setLogger(logger);
 
 const rruleReminderService = new RRuleReminderService()

--- a/node-services/cards-reminder/src/domain/application/reminderService.ts
+++ b/node-services/cards-reminder/src/domain/application/reminderService.ts
@@ -15,28 +15,12 @@ import {CardOperation} from '../model/card-operation.model';
 import RemindDatabaseService from '../server-side/remindDatabaseService';
 
 export default class ReminderService implements EventListener {
-    public static REMINDERS_COLLECTION = 'reminders';
-    private static MAX_MILLISECONDS_FOR_REMINDING_AFTER_EVENT_STARTS = 60000 * 15; // 15 minutes
-
     private databaseService: RemindDatabaseService;
-
-    logger: any;
+    private logger: any;
 
     public setLogger(logger: any) {
         this.logger = logger;
         return this;
-    }
-
-    async onMessage(message: any) {
-        let cardOperation: CardOperation;
-        try {
-            cardOperation = JSON.parse(message.content);
-            if (cardOperation.type === 'ADD' || cardOperation.type === 'UPDATE')
-                await this.addCardReminder(cardOperation.card);
-            else if (cardOperation.type === 'DELETE') await this.databaseService.removeReminder(cardOperation.cardId);
-        } catch (error) {
-            this.logger.error('Error on card operation received ' + error + ",cardOperation = " + JSON.stringify(cardOperation));
-        }
     }
 
     public setDatabaseService(databaseService: RemindDatabaseService) {
@@ -44,37 +28,92 @@ export default class ReminderService implements EventListener {
         return this;
     }
 
-    public async addCardReminder(card: Card, startingDate?: number): Promise<void> {
+    async onMessage(message: any) {
+        try {
+            const cardOperation: CardOperation = JSON.parse(message.content);
+
+            if (cardOperation.type === 'ADD' || cardOperation.type === 'UPDATE') {
+                this.logger.debug(
+                    `Reminder - ADD or UPDATE received from event bus for card ${cardOperation.card.id} (uid=${cardOperation.card.uid})`
+                );
+                await this.addCardReminder(cardOperation.card);
+            } else if (cardOperation.type === 'DELETE') {
+                this.logger.debug(`Reminder - DELETE received for card id=${cardOperation.cardId}`);
+                await this.databaseService.removeReminder(cardOperation.cardId);
+            }
+        } catch (error) {
+            this.logger.warn('Reminder - Error on card operation received ' + error);
+        }
+    }
+
+    public async addCardReminder(card: Card) {
         if (card) {
-            const cardId = card.id ? card.id : card._id;
-            if (card.secondsBeforeTimeSpanForReminder === undefined || card.secondsBeforeTimeSpanForReminder === null)
+            if (!card.secondsBeforeTimeSpanForReminder) {
+                this.logger.debug(`Reminder - Card ${card.id} (uid=${card.uid}) is not a card to remind`);
                 return;
-            const reminderItem = await this.databaseService.getReminder(cardId);
+            }
+            const reminderItem = await this.databaseService.getReminder(card.id);
             if (reminderItem) {
                 if (reminderItem.cardUid === card.uid) {
+                    // reminder exists , a remind has just occur , we need to set the reminder for next occurrence
+                    this.logger.debug(
+                        `Reminder - Card ${card.id} (uid=${card.uid}) reminder exist for this uid , it means a remind just occurs , set next remind date`
+                    );
+                    await this.setNextRemindWhenRecurrenceAndRemindHasBeenDone(card, reminderItem);
                     return;
                 } else {
-                    await this.databaseService.removeReminder(cardId);
+                    // card is updated , remove existing reminder
+                    this.logger.debug(
+                        `Reminder - Card ${card.id} (uid=${card.uid}) reminder exist with another uid remove it the card has been updated`
+                    );
+                    await this.databaseService.removeReminder(card.id);
                 }
             }
 
-            const dateForReminder: number = getNextTimeForRepeating(card, startingDate);
+            const dateForReminder: number = getNextTimeForRepeating(card);
             if (dateForReminder >= 0) {
                 const reminder = new Reminder(
-                    cardId,
+                    card.id,
                     card.uid,
-                    dateForReminder - card.secondsBeforeTimeSpanForReminder * 1000,
-                    false
+                    dateForReminder - card.secondsBeforeTimeSpanForReminder * 1000
                 );
 
                 this.logger.info(
-                    `Reminder Will remind card ${cardId} at
-                         ${new Date(dateForReminder - card.secondsBeforeTimeSpanForReminder * 1000)}`
+                    `Reminder - Will remind card ${card.id} (uid=${card.uid}) at ${new Date(
+                        dateForReminder - card.secondsBeforeTimeSpanForReminder * 1000
+                    )}`
                 );
                 await this.databaseService.persistReminder(reminder);
-            }
+            } else
+                this.logger.debug(
+                    `Reminder - Card ${card.id} (uid=${card.uid}) has no occurrence , no reminder to add`
+                );
         }
-        return Promise.resolve();
+    }
+
+    private async setNextRemindWhenRecurrenceAndRemindHasBeenDone(card: Card, reminderItem: any) {
+        this.logger.debug(`Reminder - Card ${card.id} (uid=${card.uid}) compute the next reminder date`);
+        const startingDate = reminderItem.timeForReminding + card.secondsBeforeTimeSpanForReminder * 1000 + 1;
+
+        const dateForReminder: number = getNextTimeForRepeating(card, startingDate);
+        if (dateForReminder >= 0) {
+            const reminder = new Reminder(
+                card.id,
+                card.uid,
+                dateForReminder - card.secondsBeforeTimeSpanForReminder * 1000
+            );
+            this.logger.info(
+                `Reminder - Will remind card ${card.id} (uid=${card.uid}) at ${new Date(
+                    dateForReminder - card.secondsBeforeTimeSpanForReminder * 1000
+                )}`
+            );
+            await this.databaseService.updateReminder(reminder);
+        } else {
+            this.logger.info(
+                `Reminder - Card ${card.id} (uid=${card.uid}) has no new occurrence , remove the reminder`
+            );
+            this.databaseService.removeReminder(card.id);
+        }
     }
 
     public async getCardsToRemindNow(): Promise<Card[]> {
@@ -87,27 +126,13 @@ export default class ReminderService implements EventListener {
                 cardsToRemind.push(card);
             } else {
                 // the card has been deleted in this case
+                this.logger.info(
+                    `Reminder - card with uid ${reminder.cardUid} does not exist anymore , remove reminder`
+                );
                 await this.databaseService.removeReminder(reminder.cardId);
             }
         }
         return cardsToRemind;
-    }
-
-    public async setCardHasBeenRemind(card: Card) {
-        const reminderItem = await this.databaseService.getReminder(card._id);
-        if (reminderItem) await this.setNextRemindWhenRecurrenceAndRemindHasBeenDone(card, reminderItem);
-    }
-
-    private async setNextRemindWhenRecurrenceAndRemindHasBeenDone(card: Card, reminderItem: any) {
-        const reminderDate: number = reminderItem.timeForReminding;
-        await this.databaseService.removeReminder(card._id);
-        this.addCardReminder(
-            card,
-            reminderDate +
-                card.secondsBeforeTimeSpanForReminder * 1000 +
-                ReminderService.MAX_MILLISECONDS_FOR_REMINDING_AFTER_EVENT_STARTS +
-                1
-        );
     }
 
     public async clearReminders() {

--- a/node-services/cards-reminder/src/domain/application/rrule-reminderUtils.ts
+++ b/node-services/cards-reminder/src/domain/application/rrule-reminderUtils.ts
@@ -28,14 +28,14 @@ export function getNextTimeForRepeating(card: Card, startingDate?: number): numb
 }
 
 export function getNextDateTimeFromRRule(startingDate: number, card: Card): number {
-    if (card?.rRule?.freq) {
-        const byhourSorted = card.rRule.byhour ? card.rRule.byhour : null;
+    if (card.rRule?.freq) {
+        const byhourSorted = card.rRule.byhour;
         if (byhourSorted) {
             byhourSorted.sort(function (a, b) {
                 return a - b;
             });
         }
-        const byminuteSorted = card.rRule.byminute ? card.rRule.byminute : null;
+        const byminuteSorted = card.rRule.byminute;
         if (byminuteSorted) {
             byminuteSorted.sort(function (a, b) {
                 return a - b;

--- a/node-services/cards-reminder/src/domain/application/rruleReminderService.ts
+++ b/node-services/cards-reminder/src/domain/application/rruleReminderService.ts
@@ -15,28 +15,12 @@ import {CardOperation} from '../model/card-operation.model';
 import RemindDatabaseService from '../server-side/remindDatabaseService';
 
 export class RRuleReminderService implements EventListener {
-    public static REMINDERS_COLLECTION = 'rrule_reminders';
-    private static MAX_MILLISECONDS_FOR_REMINDING_AFTER_EVENT_STARTS = 60000 * 15; // 15 minutes
-
     private databaseService: RemindDatabaseService;
-
-    logger: any;
+    private logger: any;
 
     public setLogger(logger: any) {
         this.logger = logger;
         return this;
-    }
-
-    async onMessage(message: any) {
-        try {
-            const cardOperation: CardOperation = JSON.parse(message.content);
-
-            if (cardOperation.type === 'ADD' || cardOperation.type === 'UPDATE')
-                await this.addCardReminder(cardOperation.card);
-            else if (cardOperation.type === 'DELETE') await this.databaseService.removeReminder(cardOperation.cardId);
-        } catch (error) {
-            this.logger.error('Error on card operation received ' + error);
-        }
     }
 
     public setDatabaseService(databaseService: RemindDatabaseService) {
@@ -44,70 +28,109 @@ export class RRuleReminderService implements EventListener {
         return this;
     }
 
-    public async addCardReminder(card: Card, startingDate?: number) {
-        if (card) {
-            const cardId = card.id ? card.id : card._id;
-            if (card.secondsBeforeTimeSpanForReminder === undefined || card.secondsBeforeTimeSpanForReminder === null)
-                return;
-            const reminderItem = await this.databaseService.getReminder(cardId);
-            if (reminderItem) {
-                if (reminderItem.cardUid === card.uid) {
-                    return;
-                } else {
-                    this.databaseService.removeReminder(cardId);
-                }
-            }
+    async onMessage(message: any) {
+        try {
+            const cardOperation: CardOperation = JSON.parse(message.content);
 
-            const dateForReminder: number = getNextTimeForRepeating(card, startingDate);
-            if (dateForReminder >= 0) {
-                const reminder = new Reminder(
-                    cardId,
-                    card.uid,
-                    dateForReminder - card.secondsBeforeTimeSpanForReminder * 1000,
-                    false
+            if (cardOperation.type === 'ADD' || cardOperation.type === 'UPDATE') {
+                this.logger.debug(
+                    `RRuleReminder - ADD or UPDATE received from event bus for card ${cardOperation.card.id} (uid=${cardOperation.card.uid})`
                 );
-
-                this.logger.info(
-                    `RRuleReminder Will remind card ${cardId} at
-                         ${new Date(dateForReminder - card.secondsBeforeTimeSpanForReminder * 1000)}`
-                );
-                await this.databaseService.persistReminder(reminder);
+                await this.addCardReminder(cardOperation.card);
+            } else if (cardOperation.type === 'DELETE') {
+                this.logger.debug(`RRuleReminder - DELETE received for card id=${cardOperation.cardId}`);
+                await this.databaseService.removeReminder(cardOperation.cardId);
             }
+        } catch (error) {
+            this.logger.warn('RRuleReminder - Error on card operation received ' + error);
         }
     }
 
+    public async addCardReminder(card: Card) {
+        if (card) {
+            if (!card.secondsBeforeTimeSpanForReminder) {
+                this.logger.debug(`RRuleReminder - Card ${card.id} (uid=${card.uid}) is not a card to remind`);
+                return;
+            }
+            const reminderItem = await this.databaseService.getReminder(card.id);
+            if (reminderItem) {
+                if (reminderItem.cardUid === card.uid) {
+                    // reminder exists , a remind has just occur , we need to set the reminder for next occurrence
+                    this.logger.debug(
+                        `RRuleReminder - Card ${card.id} (uid=${card.uid}) reminder exist for this uid , it means a remind just occurs , set next remind date`
+                    );
+                    this.setNextRemindWhenRecurrenceAndRemindHasBeenDone(card, reminderItem);
+                    return;
+                } else {
+                    // card is updated , remove existing reminder before recomputing the next remind date
+                    this.logger.debug(
+                        `RRuleReminder - Card ${card.id} (uid=${card.uid}) reminder exist with another uid remove it the card has been updated`
+                    );
+                    await this.databaseService.removeReminder(card.id);
+                }
+            }
+
+            const dateForReminder: number = getNextTimeForRepeating(card);
+            if (dateForReminder >= 0) {
+                const reminder = new Reminder(
+                    card.id,
+                    card.uid,
+                    dateForReminder - card.secondsBeforeTimeSpanForReminder * 1000
+                );
+
+                this.logger.info(
+                    `RRuleReminder - Will remind card ${card.id} (uid=${card.uid}) at ${new Date(
+                        dateForReminder - card.secondsBeforeTimeSpanForReminder * 1000
+                    )}`
+                );
+                await this.databaseService.persistReminder(reminder);
+            } else
+                this.logger.debug(
+                    `RRuleReminder - Card ${card.id} (uid=${card.uid}) has no occurrence , no reminder to add`
+                );
+        }
+    }
+
+    private async setNextRemindWhenRecurrenceAndRemindHasBeenDone(card: Card, reminderItem: any) {
+        this.logger.debug(`RRuleReminder - Card ${card.id} (uid=${card.uid}) compute the next reminder date`);
+        const startingDate = reminderItem.timeForReminding + card.secondsBeforeTimeSpanForReminder * 1000 + 1;
+        const dateForReminder: number = getNextTimeForRepeating(card, startingDate);
+        if (dateForReminder >= 0) {
+            const reminder = new Reminder(
+                card.id,
+                card.uid,
+                dateForReminder - card.secondsBeforeTimeSpanForReminder * 1000
+            );
+            this.logger.info(
+                `RRuleReminder - Will remind card ${card.id} (uid=${card.uid}) at ${new Date(
+                    dateForReminder - card.secondsBeforeTimeSpanForReminder * 1000
+                )}`
+            );
+            await this.databaseService.updateReminder(reminder);
+        } else {
+            this.logger.debug(
+                `RRuleReminder - Card ${card.id} (uid=${card.uid}) has no new occurrence , remove the reminder`
+            );
+            this.databaseService.removeReminder(card.id);
+        }
+    }
+    
     public async getCardsToRemindNow(): Promise<Card[]> {
         const cardsToRemind = [];
         const reminders = await this.databaseService.getItemsToRemindNow();
-
         for (const reminder of reminders) {
             const card = await this.databaseService.getCardByUid(reminder.cardUid);
             if (card) {
                 cardsToRemind.push(card);
             } else {
                 // the card has been deleted in this case
+                this.logger.info(
+                    `RRuleReminder - card with uid ${reminder.cardUid} does not exist anymore , remove reminder`
+                );
                 await this.databaseService.removeReminder(reminder.cardId);
             }
         }
-
         return cardsToRemind;
-    }
-
-    public async setCardHasBeenRemind(card: Card) {
-        const reminderItem = await this.databaseService.getReminder(card._id);
-        if (reminderItem) await this.setNextRemindWhenRecurrenceAndRemindHasBeenDone(card, reminderItem);
-    }
-
-    private async setNextRemindWhenRecurrenceAndRemindHasBeenDone(card: Card, reminderItem: any) {
-        const reminderDate: number = reminderItem.timeForReminding;
-        await this.databaseService.removeReminder(card._id); // Await is mandatory to wait remove is done in mongoDB before proceed
-        this.addCardReminder(
-            card,
-            reminderDate +
-                card.secondsBeforeTimeSpanForReminder * 1000 +
-                RRuleReminderService.MAX_MILLISECONDS_FOR_REMINDING_AFTER_EVENT_STARTS +
-                1
-        );
     }
 
     public async clearReminders() {

--- a/node-services/cards-reminder/src/domain/model/card.model.ts
+++ b/node-services/cards-reminder/src/domain/model/card.model.ts
@@ -7,7 +7,6 @@
  * This file is part of the OperatorFabric project.
  */
 
-
 export class Card {
     constructor(
         public uid: string,
@@ -16,9 +15,7 @@ export class Card {
         public endDate?: number,
         public secondsBeforeTimeSpanForReminder?: number,
         public timeSpans?: TimeSpan[],
-        public rRule?: RRule,
-        public _id?: string,
-
+        public rRule?: RRule
     ) {}
 }
 
@@ -31,7 +28,6 @@ export class Recurrence {
         public hoursAndMinutes: HourAndMinutes,
         public daysOfWeek?: number[],
         public timeZone?: string,
-        public durationInMinutes?: number,
         public months?: number[]
     ) {}
 }
@@ -52,8 +48,7 @@ export class RRule {
         public byminute?: number[],
         public bysetpos?: number[],
         public bymonthday?: number[],
-        public tzid?: string,
-        public durationInMinutes?: number
+        public tzid?: string
     ) {}
 }
 

--- a/node-services/cards-reminder/src/domain/model/reminder.model.ts
+++ b/node-services/cards-reminder/src/domain/model/reminder.model.ts
@@ -8,5 +8,5 @@
  */
 
 export class Reminder  {
-    constructor(public cardId: string, public cardUid: string, public timeForReminding: number, public hasBeenRemind: boolean) {}
+    constructor(public cardId: string, public cardUid: string, public timeForReminding: number) {}
 };

--- a/node-services/cards-reminder/src/domain/server-side/cardsReminderOpfabServicesInterface.ts
+++ b/node-services/cards-reminder/src/domain/server-side/cardsReminderOpfabServicesInterface.ts
@@ -74,8 +74,6 @@ export default class CardsReminderOpfabServicesInterface extends OpfabServicesIn
 
     }
     public async sendCardReminderRequest(cardId: string) {
-
-        this.logger.info("sendCardReminder for card " + cardId);
         return this.sendRequest({
             method: 'post',
             url: this.opfabCardsPublicationUrl + '/cards/resetReadAndAcks/' + cardId,

--- a/node-services/cards-reminder/tests/cardsReminderControl.test.ts
+++ b/node-services/cards-reminder/tests/cardsReminderControl.test.ts
@@ -8,259 +8,247 @@
  */
 
 import 'jest';
-
-import GetResponse from '../src/common/server-side/getResponse';
 import logger from '../src/common/server-side/logger';
-import CardsReminderOpfabServicesInterface from '../src/domain/server-side/cardsReminderOpfabServicesInterface';
-import RemindDatabaseService from '../src/domain/server-side/remindDatabaseService';
 import ReminderService from '../src/domain/application/reminderService';
 import {RRuleReminderService} from '../src/domain/application/rruleReminderService';
-import {HourAndMinutes, RRule, Recurrence, TimeSpan,Day, Frequency} from '../src/domain/model/card.model';
+import {HourAndMinutes, RRule, Recurrence, TimeSpan, Day, Frequency} from '../src/domain/model/card.model';
 import CardsReminderControl from '../src/domain/application/cardsReminderControl';
 import {CardOperation, CardOperationType} from '../src/domain/model/card-operation.model';
+import {RemindDatabaseServiceStub} from './remindDataBaseServiceStub';
+import {OpfabServicesInterfaceStub} from './opfabServicesInterfaceStub';
 
-let cards: Array<any> = new Array();
 
-class OpfabServicesInterfaceStub extends CardsReminderOpfabServicesInterface {
-    sentReminders: Array<any> = new Array();
 
-    public async sendCardReminder(cardId: string) {
-        this.sentReminders.push(cardId);
-        return new GetResponse(null, true);
-    }
+let rruleRemindDatabaseServiceStub = new RemindDatabaseServiceStub();
+let remindDatabaseServiceStub = new RemindDatabaseServiceStub();
+
+let reminderService = new ReminderService().setLogger(logger).setDatabaseService(remindDatabaseServiceStub);
+let rruleReminderService = new RRuleReminderService()
+    .setLogger(logger)
+    .setDatabaseService(rruleRemindDatabaseServiceStub);
+
+
+let opfabServicesInterfaceStub = new OpfabServicesInterfaceStub(reminderService,rruleReminderService,remindDatabaseServiceStub);
+
+let cardsReminderControl = new CardsReminderControl()
+    .setOpfabServicesInterface(opfabServicesInterfaceStub)
+    .setRruleReminderService(rruleReminderService)
+    .setReminderService(reminderService)
+    .setRemindDatabaseService(remindDatabaseServiceStub)
+    .setLogger(logger);
+
+
+function setCurrentTime(dateTime: string) {
+    jest.setSystemTime(new Date(dateTime));
 }
 
-class RemindDatabaseServiceStub extends RemindDatabaseService {
-    private reminders: Array<any> = new Array();
+async function checkNoReminderIsSent() {
+    await cardsReminderControl.checkCardsReminder();
+    expect(opfabServicesInterfaceStub.sentReminders.length).toEqual(0);
+    expect(opfabServicesInterfaceStub.sentReminders).toEqual([]);
+}
 
-    public async getItemsToRemindNow(): Promise<any[]> {
-        let toRemind = this.reminders.filter(
-            (reminder) => !reminder.hasBeenRemind && reminder.timeForReminding <= new Date().valueOf()
-        );
-        return Promise.resolve(toRemind);
-    }
+async function checkOneReminderIsSent(cardUid: string = 'uid1') {
+    await cardsReminderControl.checkCardsReminder();
+    expect(opfabServicesInterfaceStub.sentReminders.length).toEqual(1);
+    expect(opfabServicesInterfaceStub.sentReminders).toEqual([cardUid]);
+    opfabServicesInterfaceStub.clean();
+}
 
-    public async getAllCardsWithReminder(): Promise<any[]> {
-        let toRemind = cards.filter(
-            (card) => card.secondsBeforeTimeSpanForReminder && (!card.endDate || card.endDate >= new Date().valueOf())
-        );
-        return Promise.resolve(toRemind);
-    }
+async function checkRemindersAreSent(uids: string[]) {
+    await cardsReminderControl.checkCardsReminder();
+    expect(opfabServicesInterfaceStub.sentReminders).toEqual(uids);
+    opfabServicesInterfaceStub.clean();
+}
 
-    public getReminder(id: string) {
-        const res = this.reminders.find((reminder) => reminder.cardId === id);
-        return Promise.resolve(res);
-    }
+async function sendCard(card) {
+    remindDatabaseServiceStub.addCard(card);
 
-    public async persistReminder(reminder: any) {
-        this.reminders.push(reminder);
-    }
+    const cardOperation = {
+        number: 1,
+        publicationDate: 1,
+        card: card,
+        type: CardOperationType.ADD
+    };
 
-    public async removeReminder(id: string) {
-        const toRemove = this.reminders.findIndex((reminder) => reminder.cardId === id);
-        this.reminders.splice(toRemove, 1);
-    }
-
-    public getCardByUid(uid: string) {
-        let card = cards.find((card) => card.uid === uid);
-        card._id = card.id;
-        return Promise.resolve(card);
-    }
-
-    public async clearReminders() {
-        this.reminders = new Array();
-    }
-
-    public getNbReminder() {
-        return this.reminders.length;
-    }
+    const message = {
+        content: JSON.stringify(cardOperation)
+    };
+    await reminderService.onMessage(message);
+    await rruleReminderService.onMessage(message);
 }
 
 describe('Cards reminder with rrule structure', function () {
-    let opfabServicesInterfaceStub = new OpfabServicesInterfaceStub();
-    let rruleRemindDatabaseServiceStub = new RemindDatabaseServiceStub();
-    let remindDatabaseServiceStub = new RemindDatabaseServiceStub();
-
-    let reminderService = new ReminderService().setLogger(logger).setDatabaseService(remindDatabaseServiceStub);
-
-    let rruleReminderService = new RRuleReminderService()
-        .setLogger(logger)
-        .setDatabaseService(rruleRemindDatabaseServiceStub);
-
-    let cardsReminderControl = new CardsReminderControl()
-        .setOpfabServicesInterface(opfabServicesInterfaceStub)
-        .setRruleReminderService(rruleReminderService)
-        .setReminderService(reminderService)
-        .setRemindDatabaseService(remindDatabaseServiceStub)
-        .setLogger(logger);
-
-    let rRule = new RRule(
-        Frequency.DAILY,
-        1,
-        1,
-        Day.MO,
-        [Day.MO, Day.TU, Day.WE, Day.TH, Day.FR, Day.SA, Day.SU],
-        [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
-        [12],
-        [23],
-        [],
-        [],
-        'Europe/Paris',
-        15
-    );
-
-    beforeEach(() => {
-        opfabServicesInterfaceStub.sentReminders = new Array();
-        jest.useFakeTimers();
-        jest.setSystemTime(new Date('2017-01-01 01:00'));
+    function getTestCard(): any {
         const startDate = new Date('2017-01-01 01:00').valueOf();
+        const rRule = new RRule(
+            Frequency.DAILY,
+            1,
+            1,
+            Day.MO,
+            [Day.MO, Day.TU, Day.WE, Day.TH, Day.FR, Day.SA, Day.SU],
+            [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+            [12],
+            [23],
+            [],
+            [],
+            'Europe/Paris'
+        );
         rRule.byhour = [2];
         rRule.byminute = [10];
-        const card = {
+
+        return {
             uid: 'uid1',
-            id: 'defaultProcess.process1',
+            id: 'id1',
             secondsBeforeTimeSpanForReminder: 300,
             rRule: rRule,
             startDate: startDate
         };
-        cards = [card];
+    }
+
+    beforeEach(() => {
+        opfabServicesInterfaceStub.clean();
+        rruleRemindDatabaseServiceStub.clean();
+
+        jest.useFakeTimers();
+        setCurrentTime('2017-01-01 01:00');
     });
 
     afterAll(() => {
         jest.useRealTimers();
     });
 
-    it('it should not remind if current date is before remind date - secondsBeforeTimeSpanForReminder (02:05)', async function () {
-        await cardsReminderControl.resetReminderDatabase();
-
-        jest.setSystemTime(new Date('2017-01-01 02:04'));
-        await cardsReminderControl.checkCardsReminder();
-        expect(opfabServicesInterfaceStub.sentReminders.length).toEqual(0);
-        expect(opfabServicesInterfaceStub.sentReminders).toEqual([]);
+    it('GIVEN a card was sent  WHEN current date (02:04) < remind date - secondsBeforeTimeSpanForReminder (02:05) THEN no remind is sent', async function () {
+        await sendCard(getTestCard());
+        setCurrentTime('2017-01-01 02:04');
+        await checkNoReminderIsSent();
     });
 
-    it('it should remind if current date is after  remind date - secondsBeforeTimeSpanForReminder (02:05) ', async function () {
-        await cardsReminderControl.resetReminderDatabase();
-
-        jest.setSystemTime(new Date('2017-01-01 02:06'));
-        await cardsReminderControl.checkCardsReminder();
-        expect(opfabServicesInterfaceStub.sentReminders.length).toEqual(1);
-        expect(opfabServicesInterfaceStub.sentReminders).toEqual(['uid1']);
+    it('GIVEN a card was sent WHEN current date (02:06) > remind date - secondsBeforeTimeSpanForReminder (02:05) THEN remind is sent', async function () {
+        await sendCard(getTestCard());
+        setCurrentTime('2017-01-01 02:06');
+        await checkOneReminderIsSent();
     });
 
-    it('it should not remind if remind date is after end date ', async function () {
-        cards[0].endDate = new Date('2017-01-01 01:20').valueOf();
-        await cardsReminderControl.resetReminderDatabase();
-
-        jest.setSystemTime(new Date('2017-01-01 02:06'));
-        await cardsReminderControl.checkCardsReminder();
-        expect(opfabServicesInterfaceStub.sentReminders.length).toEqual(0);
-        expect(opfabServicesInterfaceStub.sentReminders).toEqual([]);
+    it('GIVEN a card was sent WHEN current date (02:06) > remind date +  (02:05) THEN no remind is sent', async function () {
+        await sendCard(getTestCard());
+        setCurrentTime('2017-01-01 02:06');
+        await checkOneReminderIsSent();
     });
 
-    it('it should remind if remind date is before end date ', async function () {
-        cards[0].endDate = new Date('2017-01-01 02:20').valueOf();
-        await cardsReminderControl.resetReminderDatabase();
+    it('GIVEN two cards were sent WHEN current date is after reminds date THEN two reminds are sent', async function () {
+        const card1 = getTestCard();
+        const card2 = getTestCard();
+        card2.id = 'id2';
+        card2.uid = 'uid2';
+        await sendCard(card1);
+        await sendCard(card2);
 
-        jest.setSystemTime(new Date('2017-01-01 02:06'));
-        await cardsReminderControl.checkCardsReminder();
-        expect(opfabServicesInterfaceStub.sentReminders.length).toEqual(1);
-        expect(opfabServicesInterfaceStub.sentReminders).toEqual(['uid1']);
+        setCurrentTime('2017-01-01 02:06');
+        await checkRemindersAreSent(['uid1', 'uid2']);
     });
 
-    it('it should send the card the first day and the second day', async function () {
+    it('GIVEN reminder service was reset WHEN current date is after reminds date of two cards THEN two reminds are sent', async function () {
+        const card1 = getTestCard();
+        const card2 = getTestCard();
+        card2.id = 'id2';
+        card2.uid = 'uid2';
+        rruleRemindDatabaseServiceStub.addCard(card1);
+        rruleRemindDatabaseServiceStub.addCard(card2);
         await cardsReminderControl.resetReminderDatabase();
+
+        setCurrentTime('2017-01-01 02:04');
+        await checkNoReminderIsSent();
+
+        setCurrentTime('2017-01-01 02:06');
+        await checkRemindersAreSent(['uid1', 'uid2']);
+    });
+
+    it('GIVEN a card was sent WHEN remind date > card endDate THEN no remind is sent', async function () {
+        const card = getTestCard();
+        card.endDate = new Date('2017-01-01 01:20').valueOf();
+        await sendCard(card);
+
+        setCurrentTime('2017-01-01 02:06');
+        await checkNoReminderIsSent();
+    });
+
+    it('GIVEN a card was sent WHEN remind date < card endDate THEN remind is sent', async function () {
+        const card = getTestCard();
+        card.endDate = new Date('2017-01-01 02:20').valueOf();
+        await sendCard(card);
+
+        setCurrentTime('2017-01-01 02:06');
+        await checkOneReminderIsSent();
+    });
+
+    it('GIVEN a card was sent WHEN remind is every day THEN remind is sent the first day and the second day', async function () {
+        await sendCard(getTestCard());
 
         // First remind
-        jest.setSystemTime(new Date('2017-01-01 02:06'));
-        await cardsReminderControl.checkCardsReminder();
-        expect(opfabServicesInterfaceStub.sentReminders.length).toEqual(1);
-        expect(opfabServicesInterfaceStub.sentReminders).toEqual(['uid1']);
+        setCurrentTime('2017-01-01 02:06');
+        await checkOneReminderIsSent();
 
         // No new remind one hour later
-        jest.setSystemTime(new Date('2017-01-01 03:06'));
-        await cardsReminderControl.checkCardsReminder();
-        expect(opfabServicesInterfaceStub.sentReminders.length).toEqual(1);
-        expect(opfabServicesInterfaceStub.sentReminders).toEqual(['uid1']);
+        setCurrentTime('2017-01-01 03:06');
+        await checkNoReminderIsSent();
 
         // Second remind the day after
-        jest.setSystemTime(new Date('2017-01-02 02:06'));
-        await cardsReminderControl.checkCardsReminder();
-        expect(opfabServicesInterfaceStub.sentReminders.length).toEqual(2);
-        expect(opfabServicesInterfaceStub.sentReminders).toEqual(['uid1', 'uid1']);
+        setCurrentTime('2017-01-02 02:06');
+        await checkOneReminderIsSent();
     });
 
+    it('GIVEN a card was sent WHEN second remind date is after end date THEN only one remind is sent', async function () {
+        const card = getTestCard();
+        card.endDate = new Date('2017-01-02 01:00').valueOf();
+        await sendCard(card);
 
+        // First remind
+        setCurrentTime('2017-01-01 02:06');
+        await checkOneReminderIsSent();
 
-    it('it should take into account card update received via Event Bus ', async function () {
-        const cardOperation = {
-            number: 1,
-            publicationDate: 1,
-            card: cards[0],
-            type: 'ADD'
-        };
-        const message = {
-            content: JSON.stringify(cardOperation)
-        };
+        // No remind 1 minutes later
+        setCurrentTime('2017-01-01 02:07');
+        await checkNoReminderIsSent();
 
-        await rruleReminderService.onMessage(message);
-
-        jest.setSystemTime(new Date('2017-01-01 02:00'));
-        await cardsReminderControl.checkCardsReminder();
-        expect(opfabServicesInterfaceStub.sentReminders.length).toEqual(0);
-        expect(opfabServicesInterfaceStub.sentReminders).toEqual([]);
-
-        cards[0].startDate = new Date('2017-01-02 01:00').valueOf();
-        cards[0].uid = '0002';
-        const cardOperation2 = {
-            number: 1,
-            publicationDate: 1,
-            card: cards[0],
-            type: CardOperationType.ADD
-        }
-
-        const message2 = {
-            content: JSON.stringify(cardOperation2)
-        };
-        await rruleReminderService.onMessage(message2);
-
-        jest.setSystemTime(new Date('2017-01-01 02:06'));
-        await cardsReminderControl.checkCardsReminder();
-        expect(opfabServicesInterfaceStub.sentReminders.length).toEqual(0);
-        expect(opfabServicesInterfaceStub.sentReminders).toEqual([]);
-
-        jest.setSystemTime(new Date('2017-01-02 02:06'));
-        await cardsReminderControl.checkCardsReminder();
-        expect(opfabServicesInterfaceStub.sentReminders.length).toEqual(1);
-        expect(opfabServicesInterfaceStub.sentReminders).toEqual(['0002']);
+        // No remind the day after
+        setCurrentTime('2017-01-02 02:06');
+        await checkNoReminderIsSent();
     });
 
-   it('it should not remind if secondsBeforeTimeSpanForReminder is null ', async function () {
-        cards[0].secondsBeforeTimeSpanForReminder = null;
-        const cardOperation = {
-            card: cards[0],
-            type: CardOperationType.ADD
-        };
-        const message = {
-            content: JSON.stringify(cardOperation)
-        };
-        await rruleReminderService.onMessage(message);
+    it('GIVEN a card was send WHEN a new card version is sent THEN reminder is updated', async function () {
+        await sendCard(getTestCard());
 
+        setCurrentTime('2017-01-01 02:00');
+        await checkNoReminderIsSent();
 
-        jest.setSystemTime(new Date('2017-01-01 02:06'));
-        await cardsReminderControl.checkCardsReminder();
-        expect(opfabServicesInterfaceStub.sentReminders.length).toEqual(0);
-        expect(opfabServicesInterfaceStub.sentReminders).toEqual([]);
+        const updatedCard = getTestCard();
+        updatedCard.startDate = new Date('2017-01-02 01:00').valueOf();
+        updatedCard.uid = '0002';
+        await sendCard(updatedCard);
+
+        setCurrentTime('2017-01-01 02:06');
+        await checkNoReminderIsSent();
+
+        setCurrentTime('2017-01-02 02:06');
+        await checkOneReminderIsSent('0002');
     });
 
-    
-    it('it should remove reminder when card is deleted ', async function () {
+    it('GIVEN a card was sent WHEN secondsBeforeTimeSpanForReminder is not set THEN no reminder is sent', async function () {
+        const card = getTestCard();
+        card.secondsBeforeTimeSpanForReminder = null;
+        await sendCard(card);
 
-        await cardsReminderControl.resetReminderDatabase();
+        setCurrentTime('2017-01-01 02:06');
+        await checkNoReminderIsSent();
+    });
+
+    it('GIVEN a card WHEN card is deleted THEN reminder is removed', async function () {
+        await sendCard(getTestCard());
         expect(rruleRemindDatabaseServiceStub.getNbReminder()).toBe(1);
 
         const cardOperation = {
-            card: cards[0],
+            card: getTestCard(),
             type: CardOperationType.DELETE
         };
         const message = {
@@ -268,174 +256,177 @@ describe('Cards reminder with rrule structure', function () {
         };
         await rruleReminderService.onMessage(message);
         expect(rruleRemindDatabaseServiceStub.getNbReminder()).toBe(0);
-        
     });
 
+    it('GIVEN a card is to be reminded WHEN card is not existing in database THEN reminder is removed', async function () {
+        await sendCard(getTestCard());
+        expect(rruleRemindDatabaseServiceStub.getNbReminder()).toBe(1);
+        rruleRemindDatabaseServiceStub.cleanCards();
+
+        setCurrentTime('2017-01-01 02:06');
+        await cardsReminderControl.checkCardsReminder();
+        expect(rruleRemindDatabaseServiceStub.getNbReminder()).toBe(0);
+    });
+
+    it('GIVEN a card  WHEN card has invalid freq value  THEN no reminder is save', async function () {
+        const card = getTestCard();
+        card.rRule.freq = undefined;
+        await sendCard(card);
+        expect(rruleRemindDatabaseServiceStub.getNbReminder()).toBe(0);
+    });
 });
 
 describe('Cards reminder with recurrence structure', function () {
-    let opfabServicesInterfaceStub = new OpfabServicesInterfaceStub();
-    let rruleRemindDatabaseServiceStub = new RemindDatabaseServiceStub();
-    let remindDatabaseServiceStub = new RemindDatabaseServiceStub();
-
-    let reminderService = new ReminderService().setLogger(logger).setDatabaseService(remindDatabaseServiceStub);
-
-    let rruleReminderService = new RRuleReminderService()
-        .setLogger(logger)
-        .setDatabaseService(rruleRemindDatabaseServiceStub);
-
-    let cardsReminderControl = new CardsReminderControl()
-        .setOpfabServicesInterface(opfabServicesInterfaceStub)
-        .setRruleReminderService(rruleReminderService)
-        .setReminderService(reminderService)
-        .setRemindDatabaseService(remindDatabaseServiceStub)
-        .setLogger(logger);
-
-    let recurrence = new Recurrence(
-        new HourAndMinutes(2, 10),
-        [1, 2, 3, 4, 5, 6, 7],
-        'Europe/Paris',
-        15,
-        [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
-    );
-
-    beforeEach(() => {
-        opfabServicesInterfaceStub.sentReminders = new Array();
-        cards = new Array();
-
-        jest.useFakeTimers();
-        jest.setSystemTime(new Date('2017-01-01 01:00'));
-
+    function getTestCard(): any {
         const startDate = new Date('2017-01-01 01:00').valueOf();
+
+        let recurrence = new Recurrence(
+            new HourAndMinutes(2, 10),
+            [1, 2, 3, 4, 5, 6, 7],
+            'Europe/Paris',
+            [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
+        );
 
         let timespans = [new TimeSpan(startDate, null, recurrence)];
 
-        const card = {
+        return {
             uid: 'uid1',
-            id: 'defaultProcess.process2',
+            id: 'id1',
             secondsBeforeTimeSpanForReminder: 300,
             timeSpans: timespans,
             startDate: startDate
         };
+    }
 
-        cards = [card];
+    beforeEach(() => {
+        opfabServicesInterfaceStub.clean();
+        remindDatabaseServiceStub.clean();
+
+        jest.useFakeTimers();
+        setCurrentTime('2017-01-01 01:00');
     });
 
     afterAll(() => {
         jest.useRealTimers();
     });
 
-    it('it should not remind if current date is before remind date - secondsBeforeTimeSpanForReminder (02:05)', async function () {
-        await cardsReminderControl.resetReminderDatabase();
-
-        jest.setSystemTime(new Date('2017-01-01 02:04'));
-        await cardsReminderControl.checkCardsReminder();
-        expect(opfabServicesInterfaceStub.sentReminders.length).toEqual(0);
-        expect(opfabServicesInterfaceStub.sentReminders).toEqual([]);
+    it('GIVEN a card was sent WHEN current date (02:04) < remind date - secondsBeforeTimeSpanForReminder (02:05) THEN no remind is sent', async function () {
+        await sendCard(getTestCard());
+        setCurrentTime('2017-01-01 02:04');
+        await checkNoReminderIsSent();
     });
 
-    it('it should remind if current date is after  remind date - secondsBeforeTimeSpanForReminder (02:05)', async function () {
-        await cardsReminderControl.resetReminderDatabase();
-
-        jest.setSystemTime(new Date('2017-01-01 02:06'));
-        await cardsReminderControl.checkCardsReminder();
-        expect(opfabServicesInterfaceStub.sentReminders.length).toEqual(1);
-        expect(opfabServicesInterfaceStub.sentReminders).toEqual(['uid1']);
+    it('GIVEN a card was sent WHEN current date (02:06) > remind date - secondsBeforeTimeSpanForReminder (02:05) THEN remind is sent', async function () {
+        await sendCard(getTestCard());
+        setCurrentTime('2017-01-01 02:06');
+        await checkOneReminderIsSent();
     });
 
+    it('GIVEN two cards were sent WHEN current date is after reminds date THEN two reminds are sent', async function () {
+        const card1 = getTestCard();
+        const card2 = getTestCard();
+        card2.id = 'id2';
+        card2.uid = 'uid2';
+        await sendCard(card1);
+        await sendCard(card2);
 
-    it('it should not remind if remind date is after end date ', async function () {
-        cards[0].endDate = new Date('2017-01-01 01:20').valueOf();
-        await cardsReminderControl.resetReminderDatabase();
-
-        jest.setSystemTime(new Date('2017-01-01 02:06'));
-        await cardsReminderControl.checkCardsReminder();
-        expect(opfabServicesInterfaceStub.sentReminders.length).toEqual(0);
-        expect(opfabServicesInterfaceStub.sentReminders).toEqual([]);
+        setCurrentTime('2017-01-01 02:06');
+        await checkRemindersAreSent(['uid1', 'uid2']);
     });
 
-    it('it should remind if remind date is before end date ', async function () {
-        cards[0].endDate = new Date('2017-01-01 02:20').valueOf();
+    it('GIVEN reminder service was reset WHEN current date is after reminds date of two cards THEN two reminds are sent', async function () {
+        const card1 = getTestCard();
+        const card2 = getTestCard();
+        card2.id = 'id2';
+        card2.uid = 'uid2';
+        rruleRemindDatabaseServiceStub.addCard(card1);
+        rruleRemindDatabaseServiceStub.addCard(card2);
         await cardsReminderControl.resetReminderDatabase();
 
-        jest.setSystemTime(new Date('2017-01-01 02:06'));
-        await cardsReminderControl.checkCardsReminder();
-        expect(opfabServicesInterfaceStub.sentReminders.length).toEqual(1);
-        expect(opfabServicesInterfaceStub.sentReminders).toEqual(['uid1']);
+        setCurrentTime('2017-01-01 02:04');
+        await checkNoReminderIsSent();
+
+        setCurrentTime('2017-01-01 02:06');
+        await checkRemindersAreSent(['uid1', 'uid2']);
     });
 
-    it('it should send the card the first day and the second day', async function () {
-        await cardsReminderControl.resetReminderDatabase();
+    it('GIVEN a card was sent WHEN remind date > card endDate THEN no remind is sent', async function () {
+        const card = getTestCard();
+        card.endDate = new Date('2017-01-01 01:20').valueOf();
+        await sendCard(card);
+
+        setCurrentTime('2017-01-01 02:06');
+        await checkNoReminderIsSent();
+    });
+
+    it('GIVEN a card was sent WHEN remind date < card endDate THEN remind is sent', async function () {
+        const card = getTestCard();
+        card.endDate = new Date('2017-01-01 02:20').valueOf();
+        await sendCard(card);
+
+        setCurrentTime('2017-01-01 02:06');
+        await checkOneReminderIsSent();
+    });
+
+    it('GIVEN a card was sent WHEN remind is every day THEN remind is sent the first day and the second day', async function () {
+        await sendCard(getTestCard());
 
         // First remind
-        jest.setSystemTime(new Date('2017-01-01 02:06'));
-        await cardsReminderControl.checkCardsReminder();
-        expect(opfabServicesInterfaceStub.sentReminders.length).toEqual(1);
-        expect(opfabServicesInterfaceStub.sentReminders).toEqual(['uid1']);
+        setCurrentTime('2017-01-01 02:06');
+        await checkOneReminderIsSent();
 
         // No new remind one hour later
-        jest.setSystemTime(new Date('2017-01-01 03:06'));
-        await cardsReminderControl.checkCardsReminder();
-        expect(opfabServicesInterfaceStub.sentReminders.length).toEqual(1);
-        expect(opfabServicesInterfaceStub.sentReminders).toEqual(['uid1']);
+        setCurrentTime('2017-01-01 03:06');
+        await checkNoReminderIsSent();
 
         // Second remind the day after
-        jest.setSystemTime(new Date('2017-01-02 02:06'));
-        await cardsReminderControl.checkCardsReminder();
-        expect(opfabServicesInterfaceStub.sentReminders.length).toEqual(2);
-        expect(opfabServicesInterfaceStub.sentReminders).toEqual(['uid1', 'uid1']);
+        setCurrentTime('2017-01-02 02:06');
+        await checkOneReminderIsSent();
     });
 
-    it('it should take into account card update received via Event Bus ', async function () {
-        const cardOperation = {
-            number: 1,
-            publicationDate: 1,
-            card: cards[0],
-            type: CardOperationType.ADD
-        };
-        const message = {
-            content: JSON.stringify(cardOperation)
-        };
+    it('GIVEN a card was sent WHEN second remind date is after end date THEN only one remind is sent', async function () {
+        const card = getTestCard();
+        card.endDate = new Date('2017-01-02 01:00').valueOf();
+        await sendCard(card);
 
-        await reminderService.onMessage(message);
+        // First remind
+        setCurrentTime('2017-01-01 02:06');
+        await checkOneReminderIsSent();
 
-        jest.setSystemTime(new Date('2017-01-01 02:00'));
-        await cardsReminderControl.checkCardsReminder();
-        expect(opfabServicesInterfaceStub.sentReminders.length).toEqual(0);
-        expect(opfabServicesInterfaceStub.sentReminders).toEqual([]);
+        // No remind 1 minutes later
+        setCurrentTime('2017-01-01 02:07');
+        await checkNoReminderIsSent();
 
-        cards[0].timeSpans =  [new TimeSpan(new Date('2017-01-02 01:00').valueOf(), null, recurrence)];
-        cards[0].uid = '0002';
-        const cardOperation2 = {
-            number: 1,
-            publicationDate: 1,
-            card: cards[0],
-            type: CardOperationType.ADD
-        }
-
-        const message2 = {
-            content: JSON.stringify(cardOperation2)
-        };
-        await reminderService.onMessage(message2);
-
-        jest.setSystemTime(new Date('2017-01-01 02:06'));
-        await cardsReminderControl.checkCardsReminder();
-        expect(opfabServicesInterfaceStub.sentReminders.length).toEqual(0);
-        expect(opfabServicesInterfaceStub.sentReminders).toEqual([]);
-
-        jest.setSystemTime(new Date('2017-01-02 02:06'));
-        await cardsReminderControl.checkCardsReminder();
-        expect(opfabServicesInterfaceStub.sentReminders.length).toEqual(1);
-        expect(opfabServicesInterfaceStub.sentReminders).toEqual(['0002']);
+        // No remind the day after
+        setCurrentTime('2017-01-02 02:06');
+        await checkNoReminderIsSent();
     });
 
-    it('it should remove reminder when card is deleted ', async function () {
+    it('GIVEN a card was send WHEN a new card version is sent THEN reminder is updated', async function () {
+        await sendCard(getTestCard());
 
-        await cardsReminderControl.resetReminderDatabase();
+        setCurrentTime('2017-01-01 02:00');
+        await checkNoReminderIsSent();
+
+        const card = getTestCard();
+        card.uid = '0002';
+        card.timeSpans[0].start = new Date('2017-01-02 01:00').valueOf();
+
+        await sendCard(card);
+
+        setCurrentTime('2017-01-01 02:06');
+        await checkNoReminderIsSent();
+
+        setCurrentTime('2017-01-02 02:06');
+        await checkOneReminderIsSent('0002');
+    });
+
+    it('GIVEN a card WHEN card is deleted THEN reminder is removed', async function () {
+        await sendCard(getTestCard());
         expect(remindDatabaseServiceStub.getNbReminder()).toBe(1);
 
         const cardOperation: CardOperation = {
-            card: cards[0],
+            card: getTestCard(),
             type: CardOperationType.DELETE
         };
         const message = {
@@ -443,164 +434,136 @@ describe('Cards reminder with recurrence structure', function () {
         };
         await reminderService.onMessage(message);
         expect(remindDatabaseServiceStub.getNbReminder()).toBe(0);
-        
     });
 
+    it('GIVEN a card is to be reminded WHEN card is not existing in database THEN reminder is removed', async function () {
+        await sendCard(getTestCard());
+        expect(remindDatabaseServiceStub.getNbReminder()).toBe(1);
+        remindDatabaseServiceStub.cleanCards();
+
+        setCurrentTime('2017-01-01 02:06');
+        await cardsReminderControl.checkCardsReminder();
+        expect(remindDatabaseServiceStub.getNbReminder()).toBe(0);
+    });
+
+    it('GIVEN a card WHEN card has no timezone value  THEN reminder proceed with default value', async function () {
+        const card = getTestCard();
+        card.timeSpans[0].recurrence.timeZone = undefined;
+        await sendCard(card);
+        setCurrentTime('2017-01-01 02:06');
+        await checkOneReminderIsSent();
+    });
 });
 
 describe('Cards reminder with timespans and no recurrence', function () {
-    let opfabServicesInterfaceStub = new OpfabServicesInterfaceStub();
-    let rruleRemindDatabaseServiceStub = new RemindDatabaseServiceStub();
-    let remindDatabaseServiceStub = new RemindDatabaseServiceStub();
-
-    let reminderService = new ReminderService().setLogger(logger).setDatabaseService(remindDatabaseServiceStub);
-
-    let rruleReminderService = new RRuleReminderService()
-        .setLogger(logger)
-        .setDatabaseService(rruleRemindDatabaseServiceStub);
-
-    let cardsReminderControl = new CardsReminderControl()
-        .setOpfabServicesInterface(opfabServicesInterfaceStub)
-        .setRruleReminderService(rruleReminderService)
-        .setReminderService(reminderService)
-        .setRemindDatabaseService(remindDatabaseServiceStub)
-        .setLogger(logger);
-
-    beforeEach(() => {
-        opfabServicesInterfaceStub.sentReminders = new Array();
-        cards = new Array();
-
-        jest.useFakeTimers();
-        jest.setSystemTime(new Date('2017-01-01 01:00'));
-
+    function getTestCard(): any {
         const startDate = new Date('2017-01-01 02:00').valueOf();
-
         const timespans = [new TimeSpan(startDate, null)];
-
-        const card = {
+        return {
             uid: 'uid1',
-            id: 'defaultProcess.process2',
+            id: 'id1',
             secondsBeforeTimeSpanForReminder: 300,
             timeSpans: timespans,
-            startDate: startDate,
+            startDate: startDate
         };
+    }
 
-        cards = [card];
+    beforeEach(() => {
+        opfabServicesInterfaceStub.clean();
+        remindDatabaseServiceStub.clean();
+        jest.useFakeTimers();
+        setCurrentTime('2017-01-01 01:00');
     });
 
     afterAll(() => {
         jest.useRealTimers();
     });
 
-    it('it should not remind if current date is before timespan startDate - secondsBeforeTimeSpanForReminder', async function () {
-        await cardsReminderControl.resetReminderDatabase();
-
-        // No remind
-        jest.setSystemTime(new Date('2017-01-01 01:30'));
-        await cardsReminderControl.checkCardsReminder();
-        expect(opfabServicesInterfaceStub.sentReminders.length).toEqual(0);
-        expect(opfabServicesInterfaceStub.sentReminders).toEqual([]);
+    it('GIVEN a card was sent WHEN  current date (01:30) < timeSpan startDate - secondsBeforeTimeSpanForReminder (01:55)  THEN no remind is sent', async function () {
+        await sendCard(getTestCard());
+        setCurrentTime('2017-01-01 01:30');
+        await checkNoReminderIsSent();
     });
 
-    it('it should remind if current date is after   timespan startDate  - secondsBeforeTimeSpanForReminder ', async function () {
-        await cardsReminderControl.resetReminderDatabase();
-
-        jest.setSystemTime(new Date('2017-01-01 01:56'));
-        await cardsReminderControl.checkCardsReminder();
-        expect(opfabServicesInterfaceStub.sentReminders.length).toEqual(1);
-        expect(opfabServicesInterfaceStub.sentReminders).toEqual(['uid1']);
+    it('GIVEN a card was sent WHEN  current date (01:56) > timeSpan startDate - secondsBeforeTimeSpanForReminder (01:55)  THEN remind is sent', async function () {
+        await sendCard(getTestCard());
+        setCurrentTime('2017-01-01 01:56');
+        await checkOneReminderIsSent();
     });
 
-    it('it should not remind if time span is after end date ', async function () {
-        cards[0].endDate = new Date('2017-01-01 01:20').valueOf();
-        await cardsReminderControl.resetReminderDatabase();
+    it('GIVEN two cards were sent WHEN current date is after reminds date THEN two reminds are sent', async function () {
+        const card1 = getTestCard();
+        const card2 = getTestCard();
+        card2.id = 'id2';
+        card2.uid = 'uid2';
+        await sendCard(card1);
+        await sendCard(card2);
 
-        jest.setSystemTime(new Date('2017-01-01 01:56'));
-        await cardsReminderControl.checkCardsReminder();
-        expect(opfabServicesInterfaceStub.sentReminders.length).toEqual(0);
-        expect(opfabServicesInterfaceStub.sentReminders).toEqual([]);
+        setCurrentTime('2017-01-01 02:06');
+        await checkRemindersAreSent(['uid1', 'uid2']);
     });
 
-    it('it should remind if time span  is before end date ', async function () {
-        cards[0].endDate = new Date('2017-01-01 02:20').valueOf();
+    it('GIVEN reminder service was reset WHEN current date is after reminds date of two cards THEN two reminds are sent', async function () {
+        const card1 = getTestCard();
+        const card2 = getTestCard();
+        card2.id = 'id2';
+        card2.uid = 'uid2';
+        remindDatabaseServiceStub.addCard(card1);
+        remindDatabaseServiceStub.addCard(card2);
         await cardsReminderControl.resetReminderDatabase();
 
-        jest.setSystemTime(new Date('2017-01-01 01:56'));
-        await cardsReminderControl.checkCardsReminder();
-        expect(opfabServicesInterfaceStub.sentReminders.length).toEqual(1);
-        expect(opfabServicesInterfaceStub.sentReminders).toEqual(['uid1']);
+        setCurrentTime('2017-01-01 01:30');
+        await checkNoReminderIsSent();
+
+        setCurrentTime('2017-01-01 01:56');
+        await checkRemindersAreSent(['uid1', 'uid2']);
     });
 
-    it('it should send the card the first day and the second day', async function () {
+    it('GIVEN a card was sent WHEN remind date > card endDate THEN no remind is sent', async function () {
+        const card = getTestCard();
+        card.endDate = new Date('2017-01-01 01:20').valueOf();
+        await sendCard(card);
+
+        setCurrentTime('2017-01-01 01:56');
+        await checkNoReminderIsSent();
+    });
+
+    it('GIVEN a card was sent WHEN remind date < card endDate THEN remind is sent', async function () {
+        const card = getTestCard();
+        card.endDate = new Date('2017-01-01 02:20').valueOf();
+        await sendCard(card);
+
+        setCurrentTime('2017-01-01 01:56');
+        await checkOneReminderIsSent();
+    });
+
+    it('GIVEN a card was sent WHEN remind is every day THEN remind is sent the first day and the second day', async function () {
         const span1 = new Date('2017-01-01 02:00').valueOf();
         const span2 = new Date('2017-01-02 05:00').valueOf();
-
+        const card = getTestCard();
         const timespans = [new TimeSpan(span1, null), new TimeSpan(span2, null)];
-        cards[0].timeSpans = timespans;
-
-        await cardsReminderControl.resetReminderDatabase();
+        card.timeSpans = timespans;
+        await sendCard(card);
 
         // First remind
-        jest.setSystemTime(new Date('2017-01-01 02:00'));
-        await cardsReminderControl.checkCardsReminder();
-        expect(opfabServicesInterfaceStub.sentReminders.length).toEqual(1);
-        expect(opfabServicesInterfaceStub.sentReminders).toEqual(['uid1']);
+        setCurrentTime('2017-01-01 02:00');
+        await checkOneReminderIsSent();
 
         // No new remind one hour later
-        jest.setSystemTime(new Date('2017-01-01 03:06'));
-        await cardsReminderControl.checkCardsReminder();
-        expect(opfabServicesInterfaceStub.sentReminders.length).toEqual(1);
-        expect(opfabServicesInterfaceStub.sentReminders).toEqual(['uid1']);
+        setCurrentTime('2017-01-01 03:06');
+        await checkNoReminderIsSent();
 
         // Second remind the day after
-        jest.setSystemTime(new Date('2017-01-02 04:58'));
-        await cardsReminderControl.checkCardsReminder();
-        expect(opfabServicesInterfaceStub.sentReminders.length).toEqual(2);
-        expect(opfabServicesInterfaceStub.sentReminders).toEqual(['uid1', 'uid1']);
+        setCurrentTime('2017-01-02 04:58');
+        await checkOneReminderIsSent();
     });
 
-    it('it should remind when card came via Event Bus', async function () {
- 
-        const cardOperation = {
-            number: 1,
-            publicationDate: 1,
-            card: cards[0],
-            type: 'ADD'
-        };
-        const message = {
-            content: JSON.stringify(cardOperation)
-        };
-        await reminderService.onMessage(message);
+    it('GIVEN a card was sent WHEN secondsBeforeTimeSpanForReminder is not set THEN no reminder is sent', async function () {
+        const card = getTestCard();
+        card.secondsBeforeTimeSpanForReminder = null;
+        await sendCard(card);
 
-        jest.setSystemTime(new Date('2017-01-01 01:12'));
-        await cardsReminderControl.checkCardsReminder();
-        expect(opfabServicesInterfaceStub.sentReminders.length).toEqual(0);
-        expect(opfabServicesInterfaceStub.sentReminders).toEqual([]);
-
-        jest.setSystemTime(new Date('2017-01-01 01:56'));
-        await cardsReminderControl.checkCardsReminder();
-        expect(opfabServicesInterfaceStub.sentReminders.length).toEqual(1);
-        expect(opfabServicesInterfaceStub.sentReminders).toEqual(['uid1']);
-    });
-
-
-    it('it should not remind if secondsBeforeTimeSpanForReminder is null ', async function () {
-        cards[0].secondsBeforeTimeSpanForReminder = null;
-        const cardOperation = {
-            number: 1,
-            publicationDate: 1,
-            card: cards[0],
-            type: 'ADD'
-        };
-        const message = {
-            content: JSON.stringify(cardOperation)
-        };
-        await reminderService.onMessage(message);
-
-
-        jest.setSystemTime(new Date('2017-01-01 01:56'));
-        await cardsReminderControl.checkCardsReminder();
-        expect(opfabServicesInterfaceStub.sentReminders.length).toEqual(0);
-        expect(opfabServicesInterfaceStub.sentReminders).toEqual([]);
+        setCurrentTime('2017-01-01 01:56');
+        await checkNoReminderIsSent();
     });
 });

--- a/node-services/cards-reminder/tests/cardsReminderService.test.ts
+++ b/node-services/cards-reminder/tests/cardsReminderService.test.ts
@@ -1,0 +1,207 @@
+/* Copyright (c) 2023, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
+ */
+
+import 'jest';
+import logger from '../src/common/server-side/logger';
+import ReminderService from '../src/domain/application/reminderService';
+import {RRuleReminderService} from '../src/domain/application/rruleReminderService';
+import {RRule, Day, Frequency} from '../src/domain/model/card.model';
+import {CardOperationType} from '../src/domain/model/card-operation.model';
+import {RemindDatabaseServiceStub} from './remindDataBaseServiceStub';
+import {OpfabServicesInterfaceStub} from './opfabServicesInterfaceStub';
+import CardsReminderService from '../src/domain/client-side/cardsReminderService';
+import GetResponse from '../src/common/server-side/getResponse';
+
+let rruleRemindDatabaseServiceStub = new RemindDatabaseServiceStub();
+let remindDatabaseServiceStub = new RemindDatabaseServiceStub();
+
+let reminderService = new ReminderService().setLogger(logger).setDatabaseService(remindDatabaseServiceStub);
+let rruleReminderService = new RRuleReminderService()
+    .setLogger(logger)
+    .setDatabaseService(rruleRemindDatabaseServiceStub);
+
+let opfabServicesInterfaceStub = new OpfabServicesInterfaceStub(
+    reminderService,
+    rruleReminderService,
+    remindDatabaseServiceStub
+);
+
+let cardsReminderService: CardsReminderService = new CardsReminderService(
+    opfabServicesInterfaceStub,
+    rruleReminderService,
+    reminderService,
+    remindDatabaseServiceStub,
+    5,
+    logger
+);
+
+function setCurrentTime(dateTime: string) {
+    jest.setSystemTime(new Date(dateTime));
+}
+function checkNoReminderIsSent() {
+    expect(opfabServicesInterfaceStub.sentReminders.length).toEqual(0);
+    expect(opfabServicesInterfaceStub.sentReminders).toEqual([]);
+}
+
+function checkOneReminderIsSent(cardUid: string = 'uid1') {
+    expect(opfabServicesInterfaceStub.sentReminders.length).toEqual(1);
+    expect(opfabServicesInterfaceStub.sentReminders).toEqual([cardUid]);
+    opfabServicesInterfaceStub.clean();
+}
+
+
+async function sendCard(card) {
+    remindDatabaseServiceStub.addCard(card);
+
+    const cardOperation = {
+        number: 1,
+        publicationDate: 1,
+        card: card,
+        type: CardOperationType.ADD
+    };
+
+    const message = {
+        content: JSON.stringify(cardOperation)
+    };
+    await reminderService.onMessage(message);
+    await rruleReminderService.onMessage(message);
+}
+
+describe('Cards reminder with rrule structure', function () {
+    function getTestCard(): any {
+        const startDate = new Date('2017-01-01 01:00').valueOf();
+        const rRule = new RRule(
+            Frequency.DAILY,
+            1,
+            1,
+            Day.MO,
+            [Day.MO, Day.TU, Day.WE, Day.TH, Day.FR, Day.SA, Day.SU],
+            [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+            [12],
+            [23],
+            [],
+            [],
+            'Europe/Paris'
+        );
+        rRule.byhour = [2];
+        rRule.byminute = [10];
+
+        return {
+            uid: 'uid1',
+            id: 'id1',
+            secondsBeforeTimeSpanForReminder: 300,
+            rRule: rRule,
+            startDate: startDate
+        };
+    }
+
+    beforeEach(() => {
+        opfabServicesInterfaceStub.clean();
+        rruleRemindDatabaseServiceStub.clean();
+
+        jest.useFakeTimers();
+        setCurrentTime('2017-01-01 01:00');
+        cardsReminderService.start();
+    });
+
+    afterAll(() => {
+        jest.useRealTimers();
+        cardsReminderService.stop();
+    });
+
+    it('GIVEN a card was sent WHEN current date (02:06) > remind date - secondsBeforeTimeSpanForReminder (02:05) THEN remind is sent', async function () {
+        expect(cardsReminderService.isActive()).toBeTruthy();
+        await jest.advanceTimersByTimeAsync(6000);
+        await jest.advanceTimersByTimeAsync(6000);
+        await sendCard(getTestCard());
+        setCurrentTime('2017-01-01 02:06');
+        await jest.advanceTimersByTimeAsync(6000);
+        checkOneReminderIsSent();
+        await jest.advanceTimersByTimeAsync(6000);
+        await jest.advanceTimersByTimeAsync(6000);
+        checkNoReminderIsSent();
+    });
+
+    it('GIVEN a card was sent WHEN an error occur THEN try to send remind until possible', async function () {
+        await jest.advanceTimersByTimeAsync(6000);
+        await jest.advanceTimersByTimeAsync(6000);
+        await sendCard(getTestCard());
+
+        // simulate error when sending card
+        opfabServicesInterfaceStub.setResponse(new GetResponse(null, false));
+        setCurrentTime('2017-01-01 02:06');
+        await jest.advanceTimersByTimeAsync(6000);
+        checkNoReminderIsSent();
+        await jest.advanceTimersByTimeAsync(6000);
+        checkNoReminderIsSent();
+
+        // do not simulate error anymore
+        opfabServicesInterfaceStub.setResponse(new GetResponse(null, true));
+        await jest.advanceTimersByTimeAsync(6000);
+        checkOneReminderIsSent();
+        await jest.advanceTimersByTimeAsync(6000);
+        checkNoReminderIsSent();
+    });
+
+    it('GIVEN a card is to be remind WHEN a database error occur THEN program continue and send remind until possible', async function () {
+        await jest.advanceTimersByTimeAsync(6000);
+        await jest.advanceTimersByTimeAsync(6000);
+        await sendCard(getTestCard());
+        remindDatabaseServiceStub.setSimulateError(true);
+        setCurrentTime('2017-01-01 02:06');
+        await jest.advanceTimersByTimeAsync(6000);
+        checkNoReminderIsSent();
+        await jest.advanceTimersByTimeAsync(6000);
+        checkNoReminderIsSent();
+        remindDatabaseServiceStub.setSimulateError(false);
+        await jest.advanceTimersByTimeAsync(6000);
+        checkOneReminderIsSent();
+    });
+
+    it('GIVEN reminder service was reset WHEN current date is after reminds date of a cards THEN a remind sent', async function () {
+        const card = getTestCard();
+        rruleRemindDatabaseServiceStub.addCard(card);
+        await cardsReminderService.reset();
+        await jest.advanceTimersByTimeAsync(6000);
+
+        setCurrentTime('2017-01-01 02:06');
+        await jest.advanceTimersByTimeAsync(6000);
+        await checkOneReminderIsSent();
+    });
+
+    it('GIVEN reset id called WHEN  a database error occur THEN program continue', async function () {
+        const card = getTestCard();
+
+        // database error
+        rruleRemindDatabaseServiceStub.addCard(card);
+        remindDatabaseServiceStub.setSimulateError(true);
+        await cardsReminderService.reset();
+        remindDatabaseServiceStub.setSimulateError(false);
+        rruleRemindDatabaseServiceStub.clean();
+
+        // no more error , a new card is to be remind
+        await sendCard(getTestCard());
+        setCurrentTime('2017-01-01 02:06');
+        await jest.advanceTimersByTimeAsync(6000);
+        checkOneReminderIsSent()
+    });
+
+    it('GIVEN an invalid message is received via  Event Bus THEN program ignore it and continue', async function () {
+        await reminderService.onMessage("invalid message");
+        await rruleReminderService.onMessage("invalid message");
+
+        // no more error , a new card is to be remind
+        await sendCard(getTestCard());
+        setCurrentTime('2017-01-01 02:06');
+        await jest.advanceTimersByTimeAsync(6000);
+        checkOneReminderIsSent()
+    });
+
+
+});

--- a/node-services/cards-reminder/tests/opfabServicesInterfaceStub.ts
+++ b/node-services/cards-reminder/tests/opfabServicesInterfaceStub.ts
@@ -1,0 +1,53 @@
+/* Copyright (c) 2023, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
+ */
+
+import GetResponse from "../src/common/server-side/getResponse";
+import ReminderService from "../src/domain/application/reminderService";
+import {RRuleReminderService} from "../src/domain/application/rruleReminderService";
+import {CardOperationType} from "../src/domain/model/card-operation.model";
+import CardsReminderOpfabServicesInterface from "../src/domain/server-side/cardsReminderOpfabServicesInterface";
+import RemindDatabaseService from "../src/domain/server-side/remindDatabaseService";
+
+
+export class OpfabServicesInterfaceStub extends CardsReminderOpfabServicesInterface {
+    sentReminders: Array<any> = new Array();
+    private response = new GetResponse(null,true);
+
+    constructor(private reminderService: ReminderService, private rruleReminderService: RRuleReminderService,private remindDatabaseServiceStub: RemindDatabaseService) {
+        super();
+    }
+    public async sendCardReminder(cardId: string) {
+        if (!this.response.isValid()) return this.response;
+        this.sentReminders.push(cardId);
+      
+        // simulate return of the card via event bus
+        const cardOperation = {
+            number: 1,
+            publicationDate: 1,
+            card: await this.remindDatabaseServiceStub.getCardByUid('uid1'),
+            type: CardOperationType.UPDATE
+        };
+        const message = {
+            content: JSON.stringify(cardOperation)
+        };
+        await this.reminderService.onMessage(message);
+        await this.rruleReminderService.onMessage(message);
+        return this.response;
+    }
+
+    public clean() {
+        this.sentReminders = new Array();
+        this.response = new GetResponse(null,true);
+    }
+
+    public setResponse(response:GetResponse) {
+        this.response = response;
+    }
+
+}

--- a/node-services/cards-reminder/tests/remindDataBaseServiceStub.ts
+++ b/node-services/cards-reminder/tests/remindDataBaseServiceStub.ts
@@ -1,0 +1,82 @@
+/* Copyright (c) 2023, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
+ */
+
+import RemindDatabaseService from "../src/domain/server-side/remindDatabaseService";
+
+export class RemindDatabaseServiceStub extends RemindDatabaseService {
+    private reminders: Array<any> = new Array();
+    private static cards: Map<string,any> = new Map(); // card is static as database is common between reminder and rRuleReminder
+    private static simulateError: boolean = false;
+
+    public async getItemsToRemindNow(): Promise<any[]> {
+        if (RemindDatabaseServiceStub.simulateError) throw new Error("error test");
+        let toRemind = this.reminders.filter(
+            (reminder) => reminder.timeForReminding <= new Date().valueOf()
+        );
+        return Promise.resolve(toRemind);
+    }
+
+    public async getAllCardsWithReminder(): Promise<any[]> {
+        let toRemind = Array.from(RemindDatabaseServiceStub.cards.values()).filter(
+            (card) => card.secondsBeforeTimeSpanForReminder && (!card.endDate || card.endDate >= new Date().valueOf())
+        );
+        return Promise.resolve(toRemind);
+    }
+
+    public getReminder(id: string) {
+        const res = this.reminders.find((reminder) => reminder.cardId === id);
+        return Promise.resolve(res);
+    }
+
+    public async persistReminder(reminder: any) {
+        this.reminders.push(reminder);
+    }
+
+    public async updateReminder(reminder: any) {
+        this.removeReminder(reminder.cardId);
+        this.reminders.push(reminder);
+    }
+
+    public async removeReminder(id: string) {
+        const toRemove = this.reminders.findIndex((reminder) => reminder.cardId === id);
+        this.reminders.splice(toRemove, 1);
+    }
+
+    public async getCardByUid(uid: string) {
+        let card = Array.from(RemindDatabaseServiceStub.cards.values()).find((card) => card.uid === uid);
+        return Promise.resolve(card);
+    }
+
+    public async clearReminders() {
+        if (RemindDatabaseServiceStub.simulateError) throw new Error("error test");
+        this.reminders = new Array();
+    }
+
+    public getNbReminder() {
+        return this.reminders.length;
+    }
+
+    public addCard(card) {
+        RemindDatabaseServiceStub.cards.set(card.uid,card);
+    }
+
+    public setSimulateError(simulateError:boolean) {
+        RemindDatabaseServiceStub.simulateError = simulateError;
+    }
+
+    public clean() {
+        RemindDatabaseServiceStub.simulateError = false;;
+        this.reminders = new Array();
+        RemindDatabaseServiceStub.cards = new Map();
+    }
+
+    public cleanCards() {
+        RemindDatabaseServiceStub.cards = new Map();
+    }
+}

--- a/node-services/cards-reminder/tests/reminderUtils.test.ts
+++ b/node-services/cards-reminder/tests/reminderUtils.test.ts
@@ -864,16 +864,6 @@ describe('ReminderUtils:getNextTimeForRepeating without or invalid recurrence ',
         expect(dateForRepeating).toEqual(-1);
     });
 
-    it('No recurrence , date for remind is startdate ,  currentDate is 14 minutes after startDate , should return startDate ', () => {
-        const date = moment.tz('2000-01-01 10:00', 'Europe/Paris').valueOf();
-        const cardStartdate = moment.tz('2000-01-01 09:46', 'Europe/Paris').valueOf();
-        testCard.timeSpans = [new TimeSpan(cardStartdate)];
-
-        const expectedResponseDate = moment.tz('2000-01-01 09:46', 'Europe/Paris').valueOf();
-        const dateForRepeating = getNextTimeForRepeating(testCard, date);
-        expect(dateForRepeating).toEqual(expectedResponseDate);
-    });
-
     it('Invalid recurrence days of week should return -1 ', () => {
         const date = moment.tz('2000-01-01 10:00', 'Europe/Paris').valueOf();
         recurrence.hoursAndMinutes = {hours: 10, minutes: 30};
@@ -883,6 +873,7 @@ describe('ReminderUtils:getNextTimeForRepeating without or invalid recurrence ',
         const dateForRepeating = getNextTimeForRepeating(testCard, date);
         expect(dateForRepeating).toEqual(-1);
     });
+
 
     it('Invalid recurrence days of week for one of two timespan  should return -1 ', () => {
         const date = moment.tz('2000-01-01 10:00', 'Europe/Paris').valueOf();
@@ -896,4 +887,27 @@ describe('ReminderUtils:getNextTimeForRepeating without or invalid recurrence ',
         const dateForRepeating = getNextTimeForRepeating(testCard, date);
         expect(dateForRepeating).toEqual(expectedResponseDate);
     });
+
+    it('Invalid recurrence month 12 should return -1 ', () => {
+        const date = moment.tz('2000-01-01 10:00', 'Europe/Paris').valueOf();
+        recurrence.hoursAndMinutes = {hours: 10, minutes: 30};
+        recurrence.months = [12,3];
+        testCard.timeSpans = [new TimeSpan(0, null, recurrence)];
+
+        const dateForRepeating = getNextTimeForRepeating(testCard, date);
+        expect(dateForRepeating).toEqual(-1);
+    });
+
+    it('Invalid recurrence month -1 should return -1 ', () => {
+        const date = moment.tz('2000-01-01 10:00', 'Europe/Paris').valueOf();
+        recurrence.hoursAndMinutes = {hours: 10, minutes: 30};
+        recurrence.months = [-1,3];
+        testCard.timeSpans = [new TimeSpan(0, null, recurrence)];
+
+        const dateForRepeating = getNextTimeForRepeating(testCard, date);
+        expect(dateForRepeating).toEqual(-1);
+    });
+
+
+
 });

--- a/services/cards-publication/src/main/java/org/opfab/cards/publication/model/RecurrencePublicationData.java
+++ b/services/cards-publication/src/main/java/org/opfab/cards/publication/model/RecurrencePublicationData.java
@@ -1,4 +1,4 @@
-/* Copyright (c) 2018-2022, RTE (http://www.rte-france.com)
+/* Copyright (c) 2018-2023, RTE (http://www.rte-france.com)
  * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -6,8 +6,6 @@
  * SPDX-License-Identifier: MPL-2.0
  * This file is part of the OperatorFabric project.
  */
-
-
 
 package org.opfab.cards.publication.model;
 
@@ -26,14 +24,13 @@ public class RecurrencePublicationData implements Recurrence {
     private Integer durationInMinutes;
     private List<Integer> months;
 
-
     public  RecurrencePublicationData(String timeZone,
                                       List<Integer> daysOfWeek,
                                       HoursAndMinutes hoursAndMinutes,
                                       Integer durationInMinutes,
                                       List<Integer> months)
     {
-        if (this.timeZone != null) this.timeZone = timeZone ;
+        if (timeZone != null) this.timeZone = timeZone ;
         this.daysOfWeek = daysOfWeek;
         this.hoursAndMinutes = hoursAndMinutes; 
         this.durationInMinutes = durationInMinutes;


### PR DESCRIPTION
In release note :
  -  In chapter :  Bugs 
  -  Text : #5368 Card reminder go in a loop under certain circumstances


**Content of the PR :** 

**Change the logic for processing the next date to remind the card :**

Previous solution was : Send remind --> Delete old remind --> Compute next remind date and store in db --> Receive a card update from eventBus and ignore the update as it is a consequence of the remind

This solution may end up, in certain circumstances, to processed two times or more the next remind date computing resulting in loosing one or more occurrence of reminds.

New solution : Send Remind --> Received a card update from eventBus --> Compute next remind and update remind in bd 

---> see node-services/cards-reminder/src/domain/application/reminderService.ts & node-services/cards-reminder/src/domain/application/rruleReminderService.ts

Adapt  tests to the new logic 


**Other improvements :** 


- Add tests to increase code coverage in node-services/cards-reminder/tests/cardsReminderControl.test.ts  and new tests at the service level (node-services/cards-reminder/tests/cardsReminderService.test.ts)


- Externalize stubs  from from node-services/cards-reminder/tests/cardsReminderControl.test.ts resulting in 
  -  node-services/cards-reminder/tests/remindDataBaseServiceStub.ts
  -  node-services/cards-reminder/tests/opfabServicesInterfaceStub.ts


- node-services/cards-reminder/package.json : add the list of test executed on the logs 

- node-services/cards-reminder/src/cardsReminder.ts : no need to have the name of the collection inside the service class 

- node-services/cards-reminder/src/domain/application/cardsReminderControl.ts : add catch only if necessary , some of the catch never arises 


- MAX_MILLISECONDS_FOR_REMINDING_AFTER_EVENT_STARTS was needed when the code was in the front because the user could be disconnected for a long period  but now as reminder is on the back and running all the time it does not need to check if it is too late to remind (in node-services/cards-reminder/src/domain/application/reminderService.ts, node-services/cards-reminder/src/domain/application/reminderUtils.ts, node-services/cards-reminder/src/domain/application/rruleReminderService.ts) . Remove corresponding test in node-services/cards-reminder/tests/reminderUtils.test.ts 
 

- services/cards-publication/src/main/java/org/opfab/cards/publication/model/RecurrencePublicationData.java : with the existing code , timezone was set to null in rabbitMQ when sending the remind causing problem when receiving back the card . Add a control of the field in node-services/cards-reminder/src/domain/application/reminderUtils.ts as a complement (Line 53)

- Add logs debug to be able to track the detail behavior if necessary in production 


- node-services/cards-reminder/src/domain/server-side/remindDatabaseService.ts add mongo projection to avoid manipluating _id in the code in // of id (internal mongoDB id equal to the id of the card) 


- remove unnecessary month validity check in node-services/cards-reminder/src/domain/application/reminderUtils.ts  (Line 122) and add two tests to check behavior in case of invalid month (node-services/cards-reminder/tests/reminderUtils.test.ts) 

- remove unused fields in node-services/cards-reminder/src/domain/model/card.model.ts
remove unnecessary boolean hasBeenRemind that was always false (node-services/cards-reminder/src/domain/model/reminder.model.ts) 
  