### PR TITLE
Allow to delete card with id containing special characters (#5295)

### DIFF
--- a/services/cards-publication/src/main/java/org/opfab/cards/publication/configuration/SecurityFilterConfiguration.java
+++ b/services/cards-publication/src/main/java/org/opfab/cards/publication/configuration/SecurityFilterConfiguration.java
@@ -1,0 +1,27 @@
+/* Copyright (c) 2023, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
+ */
+package org.opfab.cards.publication.configuration;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.web.firewall.StrictHttpFirewall;
+
+@Configuration
+public class SecurityFilterConfiguration {
+
+    @Bean
+    public StrictHttpFirewall httpFirewall() {
+
+        StrictHttpFirewall firewall = new StrictHttpFirewall();
+        firewall.setAllowSemicolon(true);
+        return firewall;
+    }
+
+}
+

--- a/src/test/api/karate/cardTests.txt
+++ b/src/test/api/karate/cardTests.txt
@@ -26,4 +26,5 @@
       cards/cardsWithRepresentative.feature       \
       cards/externalRecipentErrors.feature        \
       cards/postCardWithRRuleRecurrence.feature   \
-      cards/cardsReminder.feature
+      cards/cardsReminder.feature                 \
+      cards/cardIdWithSpecialCharacters.feature

--- a/src/test/api/karate/cards/cardIdWithSpecialCharacters.feature
+++ b/src/test/api/karate/cards/cardIdWithSpecialCharacters.feature
@@ -1,0 +1,85 @@
+Feature: Cards with special character in id
+
+  Background:
+
+    * def signIn = callonce read('../common/getToken.feature') { username: 'operator1_fr'}
+    * def authToken = signIn.authToken
+    * def signInAdmin = callonce read('../common/getToken.feature') { username: 'admin'}
+    * def authTokenAdmin = signInAdmin.authToken
+
+  Scenario: Post a card with semicolon in processInstanceId
+
+    * def card =
+"""
+{
+	"publisher" : "api_test",
+	"processVersion" : "1",
+	"process"  :"api_test",
+	"processInstanceId" : "process;semicolon",
+	"state": "messageState",
+	"groupRecipients": ["Dispatcher"],
+	"severity" : "INFORMATION",
+	"startDate" : 1553186770681,
+	"summary" : {"key" : "defaultProcess.summary"},
+	"title" : {"key" : "defaultProcess.title"},
+	"data" : {"message":"a message with fields representative and representativeType"},
+	"representative" : "ENTITY1_FR",
+	"representativeType" : "ENTITY"
+}
+"""
+
+    * def perimeter =
+"""
+{
+  "id" : "perimeter",
+  "process" : "api_test",
+  "stateRights" : [
+      {
+        "state" : "messageState",
+        "right" : "ReceiveAndWrite"
+      }
+    ]
+}
+"""
+    * def perimeterArray =
+"""
+[   "perimeter"
+]
+"""
+
+#Create new perimeter
+    Given url opfabUrl + 'users/perimeters'
+    And header Authorization = 'Bearer ' + authTokenAdmin
+    And request perimeter
+    When method post
+    Then status 201
+
+#Attach perimeter to group
+    Given url opfabUrl + 'users/groups/ReadOnly/perimeters'
+    And header Authorization = 'Bearer ' + authTokenAdmin
+    And request perimeterArray
+    When method patch
+    Then status 200
+
+# Push card
+    Given url opfabPublishCardUrl + 'cards'
+    And header Authorization = 'Bearer ' + authToken
+    And request card
+    When method post
+    Then status 201
+
+
+  Scenario: Delete the card
+
+
+ #delete card
+    Given url opfabPublishCardUrl + 'cards/api_test.process%3Bsemicolon'
+    And header Authorization = 'Bearer ' + authToken
+    When method delete
+    Then status 200
+
+  #delete perimeter created previously
+    Given url opfabUrl + 'users/perimeters/perimeter'
+    And header Authorization = 'Bearer ' + authTokenAdmin
+    When method delete
+    Then status 200


### PR DESCRIPTION
Permitted to delete a card with id contaianing a semicolon.
Still not possible to get/view the card in the UI due to spring webflux truncating path variables containing semicolon.


Fix #5295

- In release note :
  -  In chapter :  Bugs 
  -  Text : #5295 :  Allow to delete card with id containing special characters 