### PR TITLE
Add an index on mongoDB archivedCards collection for field processInstanceId (#5440)

### DIFF
--- a/services/cards-publication/src/main/java/org/opfab/cards/publication/model/ArchivedCardPublicationData.java
+++ b/services/cards-publication/src/main/java/org/opfab/cards/publication/model/ArchivedCardPublicationData.java
@@ -11,7 +11,6 @@
 
 package org.opfab.cards.publication.model;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.Singular;
@@ -56,6 +55,7 @@ public class ArchivedCardPublicationData implements Card {
     @Indexed
     private String process;
     
+    @Indexed
     private String processInstanceId;
     
     @Indexed


### PR DESCRIPTION
Fix #5440

- In release note :
  -  In chapter : Tasks
  -  Text : #5440 : Add an index on mongoDB archivedCards collection for field processInstanceId