### PR TITLE
Solve deprecated sonar gradle task dependency on compile task (#5456)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -39,4 +39,4 @@ reactor=3.6.0
 swagger=2.4.37
 swaggerUI=5.9.0
 
-
+systemProp.sonar.gradle.skipCompile=true


### PR DESCRIPTION
Fix #5456

- In release note :
  -  In chapter :   Tasks
  -  Text : #5456 : Solve deprecated sonar gradle task dependency on compile task