### PR TITLE
Fix rich text editor default color in base message example (#5472)

### DIFF
--- a/src/test/resources/bundles/defaultProcess_V1/css/style.css
+++ b/src/test/resources/bundles/defaultProcess_V1/css/style.css
@@ -7,7 +7,6 @@
  * This file is part of the OperatorFabric project.
  */
 .template-style{
-	color:#2784FF;
 	font-size: 16px;
 	width:100%;
 }


### PR DESCRIPTION
Fix #5472 

Nothing in release notes
