### PR TITLE
Avoid empty line in ag-grid tables (#5485)

### DIFF
--- a/ui/main/src/scss/styles.scss
+++ b/ui/main/src/scss/styles.scss
@@ -582,6 +582,10 @@ body {
     .ag-header-cell-menu-button {
         cursor: pointer;
     }
+
+    .ag-center-cols-viewport {
+        min-height: unset !important;
+    }
 }
 
 .opfab-monitoring-ag-grid-row {


### PR DESCRIPTION
Fix #5485

- In release note :
  -  In chapter :  Bugs 
  -  Text : #5485 : Avoid empty line in ag-grid tables 