### PR TITLE
Remove default value https://quiljs.com in link edition in rich text editor (#5489)

### DIFF
--- a/ui/main/src/assets/js/opfab.js
+++ b/ui/main/src/assets/js/opfab.js
@@ -202,7 +202,7 @@ class QuillEditor extends HTMLElement {
             theme: 'snow',
             sanitize: true
         });
-
+        this.setDefaultLinkPlaceholder('');
     }
 
     init() {
@@ -228,6 +228,12 @@ class QuillEditor extends HTMLElement {
           }
           
           Quill.register(CustomLinkSanitizer, true);
+    }
+
+    setDefaultLinkPlaceholder(placeholder) {
+        const tooltip = this.quill.theme.tooltip;
+        const input = tooltip.root.querySelector("input[data-link]");
+        input.dataset.link = placeholder;
     }
 
     setContents(value) {


### PR DESCRIPTION
Fix #5489

- In release note :
  -  In chapter :  Bugs 
  -  Text : #5489 : Remove default value https://quiljs.com in link edition in rich text editor 