### PR TITLE
Revert node upgrade for reminder service due to rrule incompatibility with node 21.3

### DIFF
--- a/node-services/cards-reminder/docker/Dockerfile
+++ b/node-services/cards-reminder/docker/Dockerfile
@@ -1,4 +1,5 @@
-FROM node:21.3-alpine
+# Do not upgrade version of node because rrule is not compatible with 21.3 
+FROM node:21.2-alpine
 RUN apk add --no-cache tzdata
 WORKDIR /usr/app
 RUN chown node:node /usr/app


### PR DESCRIPTION
Nothing in release note , bug was not present in previous release 