### PR TITLE
Task advanced : missing translation on number/weekday and "nth day of the month" (#5493)

### DIFF
--- a/src/test/cypress/cypress/integration/TaskAdvanced.spec.js
+++ b/src/test/cypress/cypress/integration/TaskAdvanced.spec.js
@@ -226,7 +226,7 @@ describe('Task Advanced', function () {
 
       cy.get('#radioButtonNthWeekday').click();
 
-      opfab.selectOptionsFromMultiselect('#occurrence-number-select', 'First');
+      opfab.selectOptionsFromMultiselect('#occurrence-number-select', 'first');
       opfab.selectOptionsFromMultiselect('#weekday-select', 'Wednesday');
 
       cy.get('#time').type('19:00');
@@ -266,7 +266,7 @@ describe('Task Advanced', function () {
 
       cy.get('#radioButtonNthWeekday').should('be.checked');
 
-      cy.get('#occurrence-number-select').find('.vscomp-value-tag-content').should('have.text', 'First');
+      cy.get('#occurrence-number-select').find('.vscomp-value-tag-content').should('have.text', 'first');
       cy.get('#weekday-select').find('.vscomp-value').should('have.text', 'Wednesday');
 
       cy.get('#time').should('have.value', '19:00');

--- a/ui/main/src/app/business/buildInTemplates/task/usercard/taskUserCardTemplate.ts
+++ b/ui/main/src/app/business/buildInTemplates/task/usercard/taskUserCardTemplate.ts
@@ -143,7 +143,7 @@ export class TaskUserCardTemplate extends BaseUserCardTemplate {
                     <tr>
                         <td><label class="opfab-checkbox" style="padding-left:25px"> ${opfab.utils.getTranslation("buildInTemplate.taskUserCard.firstDayOfTheMonth")} <input type="checkbox" id="firstDay">   <span class="opfab-checkbox-checkmark"> </span>   </label> </td>
                         <td><label class="opfab-checkbox" style="padding-left:25px"> ${opfab.utils.getTranslation("buildInTemplate.taskUserCard.lastDayOfTheMonth")} <input type="checkbox" id="lastDay">   <span class="opfab-checkbox-checkmark"> </span>   </label> </td>
-                        <td style="width: 35px;font-size: 13px"> The </td>
+                        <td style="width: 35px;font-size: 13px"> ${opfab.utils.getTranslation("buildInTemplate.taskUserCard.the")} </td>
                         <td style="width: 90px">
                             <div class="opfab-input">
                                 <label> ${opfab.utils.getTranslation("buildInTemplate.taskUserCard.dayNumber")} </label>
@@ -272,11 +272,11 @@ export class TaskUserCardTemplate extends BaseUserCardTemplate {
         this.occurrenceNumberSelect = opfab.multiSelect.init({
             id: "occurrence-number-select",
             options : [
-                { label: 'First', value: 1 },
-                { label: 'Second', value: 2 },
-                { label: 'Third', value: 3 },
-                { label: 'Fourth', value: 4},
-                { label: 'Last', value: -1 }
+                { label: opfab.utils.getTranslation('buildInTemplate.taskCard.first'), value: 1 },
+                { label: opfab.utils.getTranslation('buildInTemplate.taskCard.second'), value: 2 },
+                { label: opfab.utils.getTranslation('buildInTemplate.taskCard.third'), value: 3 },
+                { label: opfab.utils.getTranslation('buildInTemplate.taskCard.fourth'), value: 4},
+                { label: opfab.utils.getTranslation('buildInTemplate.taskCard.last'), value: -1 }
             ],
             multiple: true,
             search: true
@@ -286,13 +286,13 @@ export class TaskUserCardTemplate extends BaseUserCardTemplate {
             id: "weekday-select",
             options : [
                 { label: '', value: ''},    //to clear the selection
-                { label: 'Monday', value: 'MO' },
-                { label: 'Tuesday', value: 'TU' },
-                { label: 'Wednesday', value: 'WE' },
-                { label: 'Thursday', value: 'TH'},
-                { label: 'Friday', value: 'FR' },
-                { label: 'Saturday', value: 'SA'},
-                { label: 'Sunday', value: 'SU' }
+                { label: opfab.utils.getTranslation('shared.calendar.monday'), value: 'MO' },
+                { label: opfab.utils.getTranslation('shared.calendar.tuesday'), value: 'TU' },
+                { label: opfab.utils.getTranslation('shared.calendar.wednesday'), value: 'WE' },
+                { label: opfab.utils.getTranslation('shared.calendar.thursday'), value: 'TH'},
+                { label: opfab.utils.getTranslation('shared.calendar.friday'), value: 'FR' },
+                { label: opfab.utils.getTranslation('shared.calendar.saturday'), value: 'SA'},
+                { label: opfab.utils.getTranslation('shared.calendar.sunday'), value: 'SU' }
             ],
             multiple: false,
             search: true

--- a/ui/main/src/assets/i18n/en.json
+++ b/ui/main/src/assets/i18n/en.json
@@ -683,7 +683,8 @@
       "youMustProvideAnOccurrenceNumberAndAWeekday": "You must provide an occurrence number and a weekday.",
       "youMustProvideAtLeastOneNthDay": "You must provide at least one nth day.",
       "youMustProvideAtLeastOneWeekday": "You must provide at least one weekday.",
-      "youMustProvideAtLeastOneMonth": "You must provide at least one month."
+      "youMustProvideAtLeastOneMonth": "You must provide at least one month.",
+      "the": "The"
     }, 
     "message-or-question-listCard": {
       "answers": "Answers",

--- a/ui/main/src/assets/i18n/fr.json
+++ b/ui/main/src/assets/i18n/fr.json
@@ -685,7 +685,8 @@
       "youMustProvideAnOccurrenceNumberAndAWeekday": "Vous devez fournir un numéro d'ocurrence et un jour de la semaine.",
       "youMustProvideAtLeastOneNthDay": "Vous devez fournir au moins un numéro de jour.",
       "youMustProvideAtLeastOneWeekday": "Vous devez fournir au moins un jour de la semaine.",
-      "youMustProvideAtLeastOneMonth": "Vous devez fournir au moins un mois."
+      "youMustProvideAtLeastOneMonth": "Vous devez fournir au moins un mois.",
+      "the": "Le"
     }, 
     "message-or-question-listCard": {
       "answers": "Réponses",

--- a/ui/main/src/assets/i18n/nl.json
+++ b/ui/main/src/assets/i18n/nl.json
@@ -684,7 +684,8 @@
       "youMustProvideAnOccurrenceNumberAndAWeekday": "U moet een nummer van voorkomen en een weekdag opgeven.",
       "youMustProvideAtLeastOneNthDay": "U dient minimaal één dagnummer op te geven.",
       "youMustProvideAtLeastOneWeekday": "U dient minimaal één dag van de week op te geven.",
-      "youMustProvideAtLeastOneMonth": "U dient minimaal één maand op te geven."
+      "youMustProvideAtLeastOneMonth": "U dient minimaal één maand op te geven.",
+      "the": "De"
     },
     "message-or-question-listCard": {
       "answers": "Antwoorden",


### PR DESCRIPTION
- In release note :
  -  In chapter : Bugs
  -  Text : #5493 : Task advanced : missing translation on number/weekday and "nth day of the month"