### PR TITLE
Cards reminder error when Task advanced card has nth day of month greater than month number of days (#5617)

### DIFF
--- a/node-services/cards-reminder/src/domain/application/rrule-reminderUtils.ts
+++ b/node-services/cards-reminder/src/domain/application/rrule-reminderUtils.ts
@@ -75,14 +75,12 @@ export function getNextDateTimeFromRRule(startingDate: number, card: Card): numb
                 dateObjectToYYYYMMDDTHHmmss(new Date(startingDate + NB_MILLISECONDS_IN_ONE_MINUTE))
         );
 
-        const nextDateTimeFromRRule = rule.all(function (date, i) {
-            return i < 1;
-        })[0];
+        const nextDateTimeFromRRule = rule.all(function (date, i) {return i < 1;})[0];
 
         // It is necessary to do this addition to have the right hour, maybe a bug of rrule.js here too...
-        return (
-            nextDateTimeFromRRule.valueOf() + nextDateTimeFromRRule.getTimezoneOffset() * NB_MILLISECONDS_IN_ONE_MINUTE
-        );
+        if (nextDateTimeFromRRule) {
+            return (nextDateTimeFromRRule.valueOf() + nextDateTimeFromRRule.getTimezoneOffset() * NB_MILLISECONDS_IN_ONE_MINUTE);
+        }
     }
     return -1;
 }

--- a/ui/main/src/app/business/buildInTemplates/task/usercard/taskUserCardTemplate.ts
+++ b/ui/main/src/app/business/buildInTemplates/task/usercard/taskUserCardTemplate.ts
@@ -30,7 +30,7 @@ export class TaskUserCardTemplate extends BaseUserCardTemplate {
         <br/>
         <div class="opfab-input">
             <label for="taskDescription"> ${opfab.utils.getTranslation('buildInTemplate.taskUserCard.taskDescriptionLabel')}</label>
-            <input size="50" type="text" id="taskDescription" value='${this.view.getTaskDescription()}'> </input> 
+            <input size="50" type="text" id="taskDescription" value='${this.view.getTaskDescription()}'> 
         </div>
         <br/>
         
@@ -147,7 +147,7 @@ export class TaskUserCardTemplate extends BaseUserCardTemplate {
                         <td style="width: 90px">
                             <div class="opfab-input">
                                 <label> ${opfab.utils.getTranslation("buildInTemplate.taskUserCard.dayNumber")} </label>
-                                <input size="1" maxlength="2" type="number" id="nthDay" min="1" max="31">
+                                <input size="1" maxlength="2" type="number" id="nthDay" min="1" max="31" oninput="if (this.value > 31) this.value = '';">
                             </div>
                         </td>
                         <td style="font-size:13px"> &nbsp; ${opfab.utils.getTranslation("buildInTemplate.taskUserCard.dayOfTheMonth")} </td>
@@ -304,9 +304,11 @@ export class TaskUserCardTemplate extends BaseUserCardTemplate {
 
         if (freq === 'MONTHLY') {
             this.displayMonthlyFrequency();
-            if (opfab.currentUserCard.getEditionMode() !== 'CREATE')  this.selectValuesInEditModeForMonthlyFreq();
-        } else {
-            if (opfab.currentUserCard.getEditionMode() !== 'CREATE')  this.selectValuesInEditModeForDailyFreq();
+            if (opfab.currentUserCard.getEditionMode() !== 'CREATE') {
+                this.selectValuesInEditModeForMonthlyFreq();
+            }
+        } else if (opfab.currentUserCard.getEditionMode() !== 'CREATE') {
+            this.selectValuesInEditModeForDailyFreq();
         }
     }
 
@@ -326,9 +328,13 @@ export class TaskUserCardTemplate extends BaseUserCardTemplate {
         const byweekday = this.view.getWeekDay();
         const bymonth = this.view.getMonth();
 
-        if (byweekday) this.checkWeekDay(byweekday);
+        if (byweekday) {
+            this.checkWeekDay(byweekday);
+        }
 
-        if (bymonth) this.checkMonthDaily(bymonth);
+        if (bymonth) {
+            this.checkMonthDaily(bymonth);
+        }
     }
    
     checkWeekDay(byweekday) {
@@ -455,9 +461,15 @@ export class TaskUserCardTemplate extends BaseUserCardTemplate {
             bymonth = this.fetchMonths();
 
             if ((<HTMLInputElement>document.getElementById("radioButtonNthDay")).checked === true) {
-                if ((<HTMLInputElement>document.getElementById("nthDay")).value)            bymonthday.push((<HTMLInputElement>document.getElementById("nthDay")).value);
-                if ((<HTMLInputElement>document.getElementById("firstDay")).checked === true) bymonthday.push("1");
-                if ((<HTMLInputElement>document.getElementById("lastDay")).checked === true)  bymonthday.push("-1");
+                if ((<HTMLInputElement>document.getElementById("nthDay")).value) {
+                    bymonthday.push((<HTMLInputElement>document.getElementById("nthDay")).value);
+                }
+                if ((<HTMLInputElement>document.getElementById("firstDay")).checked === true) {
+                    bymonthday.push("1");
+                }
+                if ((<HTMLInputElement>document.getElementById("lastDay")).checked === true) {
+                    bymonthday.push("-1");
+                }
 
                 if (bymonthday.length === 0) {
                     return {valid: false , errorMsg: opfab.utils.getTranslation('buildInTemplate.taskUserCard.youMustProvideAtLeastOneNthDay')};


### PR DESCRIPTION
I added a control to forbid numbers greater than 31. I also added a check to avoid doing valueOf() on an undefined object.
But I think this is normal to not have reminder if the user create a card with, for example, "30th day of month" and "february". 
The user must be careful when he creates his card.

- In release note :
  -  In chapter : Bugs
  -  Text : #5617 : Cards reminder error when Task advanced card has "nth day of month" field greater than month number of days