### PR TITLE
Archives/loggging screen : disable admin mode shall reset the search result if admin has no processes (#5652)

### DIFF
--- a/ui/main/src/app/modules/share/archives-logging-filters/archives-logging-filters.component.ts
+++ b/ui/main/src/app/modules/share/archives-logging-filters/archives-logging-filters.component.ts
@@ -215,6 +215,7 @@ export class ArchivesLoggingFiltersComponent implements OnInit, OnDestroy, After
     toggleAdminMode() {
         this.isAdminModeChecked = !this.isAdminModeChecked;
         UserPreferencesService.setPreference('opfab.seeOnlyCardsForWhichUserIsRecipient', String(!this.isAdminModeChecked));
+        this.reset.emit(null);
         this.loadValuesForFilters();
     }
 


### PR DESCRIPTION
- In release note :
  -  In chapter : Bugs
  -  Text : #5652 : Archives/loggging screen : disable admin mode shall reset the search result if admin has no processes