### PR TITLE
Use entity role in usercards #5434

### DIFF
--- a/config/docker/users.yml
+++ b/config/docker/users.yml
@@ -94,70 +94,80 @@ operatorfabric.users.default:
      description: Control Center FR North
      parents : ["ENTITY_FR"]
      labels: ["FR1 label"]
+     roles: ["CARD_SENDER", "CARD_RECEIVER"]
    - id: ENTITY2_FR
      name: Control Center FR South
      description: Control Center FR South
      parents : ["ENTITY_FR"]
+     roles: ["CARD_SENDER", "CARD_RECEIVER"]
    - id: ENTITY3_FR
      name: Control Center FR East
      description: Control Center FR East
      parents : ["ENTITY_FR"]
+     roles: ["CARD_SENDER", "CARD_RECEIVER"]
    - id: ENTITY4_FR
      name: Control Center FR West
      description: Control Center FR West
      parents : ["ENTITY_FR"]
+     roles: ["CARD_SENDER", "CARD_RECEIVER"]
    - id: ENTITY_FR
      name: French Control Centers
      description: French Control Centers
-     roles: ["ACTIVITY_AREA_GROUP"]
+     roles: ["CARD_RECEIVER", "ACTIVITY_AREA_GROUP"]
      entityAllowedToSendCard: false
    - id: EUROPEAN_SUPERVISION_CENTERS
      name: European Supervision Centers
      description: European Supervision Centers
-     roles: ["ACTIVITY_AREA_GROUP"]  
      entityAllowedToSendCard: false
+     roles: ["CARD_RECEIVER", "ACTIVITY_AREA_GROUP"]
    - id: IT_SUPERVISOR_ENTITY
      name: IT SUPERVISION CENTER
      description: IT SUPERVISION CENTER
      parents : ["EUROPEAN_SUPERVISION_CENTERS"]
+     roles: ["CARD_SENDER", "CARD_RECEIVER"]
    - id: ENTITY1_IT
      name: Control Center IT North
      description: Control Center IT North
      parents : ["ENTITY_IT"]
+     roles: ["CARD_SENDER", "CARD_RECEIVER"]
    - id: ENTITY2_IT
      name: Control Center IT Center
      description: Control Center IT Center
      parents : ["ENTITY_IT"]
+     roles: ["CARD_SENDER", "CARD_RECEIVER"]
    - id: ENTITY3_IT
      name: Control Center IT South
      description: Control Center IT South
      parents : ["ENTITY_IT"]
+     roles: ["CARD_SENDER", "CARD_RECEIVER"]
    - id: ENTITY_IT
      name: Italian Control Centers
      description: Italian Control Centers
      entityAllowedToSendCard: false
-     roles: ["ACTIVITY_AREA_GROUP"]
+     roles: ["CARD_RECEIVER", "ACTIVITY_AREA_GROUP"]
    - id: ENTITY1_NL
      name: Control Center NL North
      description: Control Center NL North
      parents : ["ENTITY_NL"]
+     roles: ["CARD_SENDER", "CARD_RECEIVER"]
    - id: ENTITY2_NL
      name: Control Center NL South
      description: Control Center NL South
      parents : ["ENTITY_NL"]
+     roles: ["CARD_SENDER", "CARD_RECEIVER"]
    - id: ENTITY_NL
      name: Dutch Control Centers
      description: Dutch Control Centers
      entityAllowedToSendCard: false
-     roles: ["ACTIVITY_AREA_GROUP"]
+     roles: ["CARD_RECEIVER", "ACTIVITY_AREA_GROUP"]
    - id: ENTITY1_EU
      name: North Europe Control Center
      description: North Europe Control Center
-     entityAllowedToSendCard: true
+     roles: ["CARD_SENDER", "CARD_RECEIVER"]
    - id: ENTITY2_EU
      name: South Europe Control Center
      description: South Europe Control Center
-     entityAllowedToSendCard: true
+     roles: ["CARD_SENDER", "CARD_RECEIVER"]
   user-settings:
     - login: operator3_fr
       description: Da Operator Rulez

--- a/src/docs/asciidoc/reference_doc/users_management.adoc
+++ b/src/docs/asciidoc/reference_doc/users_management.adoc
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2023 RTE (http://www.rte-france.com)
+// Copyright (c) 2018-2024 RTE (http://www.rte-france.com)
 // See AUTHORS.txt
 // This document is subject to the terms of the Creative Commons Attribution 4.0 International license.
 // If a copy of the license was not distributed with this
@@ -59,7 +59,7 @@ ifndef::single-page-doc[<</documentation/current/deployment/index.adoc#opfab_spe
 The notion of entity is loose and can be used to model organizations structures(examples : control center, company , department... ).
 Entities are used to send cards to several users without a name specifically. The information about membership to an
 entity is stored in the user's data (`entities` field of the `user` object). In Entity objects, the `parents` property (array) expresses the fact that this entity is a part of one or several other entities. This feature allows cards to be sent to a group of entities without having to repeat the detailed list of entities for each card.
-The boolean property `entityAllowedToSendCard` (default value `true`) can be used to mark an Entity as not eligible as card publisher. This can be useful for a group of entities where only child entities should be used as card publishers while the parent is just a logical group usable as card recipient. The `labels` property (array) allows to associate string labels to an Entity object.
+The roles attribute allows to set the utility of an entity. It determines if an entity can send or receive cards and if it's part of an activity area. This can be useful for a group of entities where only child entities should be used as card publishers while the parent is just a logical group usable as a card recipient. The `labels` property (array) allows to associate string labels to an Entity object.
 
 Examples using entities can be found 
 ifdef::single-page-doc[<<_send_to_several_users, here>>]

--- a/ui/main/src/app/modules/usercard/recipientForm/usercard-recipients-form.component.ts
+++ b/ui/main/src/app/modules/usercard/recipientForm/usercard-recipients-form.component.ts
@@ -1,4 +1,4 @@
-/* Copyright (c) 2022-2023, RTE (http://www.rte-france.com)
+/* Copyright (c) 2022-2024, RTE (http://www.rte-france.com)
  * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -15,6 +15,7 @@ import {Entity} from '@ofModel/entity.model';
 import {FormControl, FormGroup} from '@angular/forms';
 import {MultiSelectConfig, MultiSelectOption} from '@ofModel/multiselect.model';
 import {OpfabAPIService} from 'app/business/services/opfabAPI.service';
+import { RolesEnum } from '@ofModel/roles.model';
 
 @Component({
     selector: 'of-usercard-recipients-form',
@@ -85,8 +86,11 @@ export class UserCardRecipientsFormComponent implements OnInit, OnChanges {
         this.recipientsOptions = [];
         EntitiesService
             .getEntities()
-            .forEach((entity) =>
-                this.recipientsOptions.push(new MultiSelectOption(entity.id, this.getEntityLabel(entity)))
+            .forEach((entity) => {
+                if (entity.roles.includes(RolesEnum.CARD_RECEIVER)) {
+                    this.recipientsOptions.push(new MultiSelectOption(entity.id, this.getEntityLabel(entity)))
+                }
+            }
             );
     }
 
@@ -94,8 +98,11 @@ export class UserCardRecipientsFormComponent implements OnInit, OnChanges {
         this.recipientsForInformationOptions = [];
         EntitiesService
             .getEntities()
-            .forEach((entity) =>
+            .forEach((entity) => {
+                if (entity.roles.includes(RolesEnum.CARD_RECEIVER)) {
                 this.recipientsForInformationOptions.push(new MultiSelectOption(entity.id, this.getEntityLabel(entity)))
+                }
+            }
             );
     }
 
@@ -103,8 +110,10 @@ export class UserCardRecipientsFormComponent implements OnInit, OnChanges {
         this.recipientsOptions = [];
         EntitiesService
             .resolveEntities(recipients)
-            .forEach((entity) =>
-                this.recipientsOptions.push(new MultiSelectOption(entity.id, this.getEntityLabel(entity)))
+            .forEach((entity) => {
+                if (entity.roles.includes(RolesEnum.CARD_RECEIVER)) {
+                    this.recipientsOptions.push(new MultiSelectOption(entity.id, this.getEntityLabel(entity)))                }
+            }  
             );
     }
 
@@ -112,8 +121,10 @@ export class UserCardRecipientsFormComponent implements OnInit, OnChanges {
         this.recipientsForInformationOptions = [];
         EntitiesService
             .resolveEntities(recipientsForInformation)
-            .forEach((entity) =>
-                this.recipientsForInformationOptions.push(new MultiSelectOption(entity.id, this.getEntityLabel(entity)))
+            .forEach((entity) => {
+                if (entity.roles.includes(RolesEnum.CARD_RECEIVER)) {
+                    this.recipientsForInformationOptions.push(new MultiSelectOption(entity.id, this.getEntityLabel(entity)))                }
+            }  
             );
     }
 

--- a/ui/main/src/app/modules/usercard/usercard.component.ts
+++ b/ui/main/src/app/modules/usercard/usercard.component.ts
@@ -1,4 +1,4 @@
-/* Copyright (c) 2018-2023, RTE (http://www.rte-france.com)
+/* Copyright (c) 2018-2024, RTE (http://www.rte-france.com)
  * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -38,6 +38,7 @@ import {ServerResponseStatus} from 'app/business/server/serverResponse';
 import {SystemNotificationService} from '../../business/services/notifications/system-notification.service';
 import {Observable} from 'rxjs';
 import {OpfabAPIService} from 'app/business/services/opfabAPI.service';
+import { RolesEnum } from '@ofModel/roles.model';
 
 @Component({
     selector: 'of-usercard',
@@ -332,7 +333,7 @@ export class UserCardComponent implements OnInit, OnDestroy {
 
         allowedUserEntities.forEach((userEntityId) => {
             const entity = EntitiesService.getEntities().find((e) => e.id === userEntityId);
-            if (entity.entityAllowedToSendCard) entitiesList.push({value: entity.id, label: entity.name});
+            if (entity.roles.includes(RolesEnum.CARD_SENDER)) entitiesList.push({value: entity.id, label: entity.name});
         });
         return entitiesList;
     }


### PR DESCRIPTION
- In release note :
  -  In chapter :  Features 
  -  Text : #5434 Entities need the CARD_SENDER role to send a card and the CARD_RECEIVER role to receive a card