### PR TITLE
Add the option to configure rich text in config file for message or question list build-in template (#5738)

### DIFF
--- a/src/test/resources/businessData/message-and-question-list
+++ b/src/test/resources/businessData/message-and-question-list
@@ -17,7 +17,7 @@
         "id": "Warning",
         "title": "Warning about the state of the grid",
         "summary": "Warning about the state of the grid : a problem has been detected",
-        "message": "A problem has been detected, please put maintenance work on hold and be on stand by",
+        "richMessage": {"ops":[{"attributes":{"color":"#e60000","bold":true},"insert":"A problem has been detected"},{"insert":", please put maintenance work on hold and be on stand by"},{"attributes":{"header":2},"insert":"\n"}]},
         "question": false,
         "severity": "ALARM",
         "publishers":  [

--- a/ui/main/src/app/business/buildInTemplates/message-or-question-list/usercard/message-or-question-listUserCardTemplate.ts
+++ b/ui/main/src/app/business/buildInTemplates/message-or-question-list/usercard/message-or-question-listUserCardTemplate.ts
@@ -78,7 +78,7 @@ export class MessageOrQuestionListUserCardTemplate extends BaseUserCardTemplate 
 
         if ( this.previousTitleId != messageId || opfab.currentUserCard.getEditionMode() == 'CREATE') {
             const quill =  document.getElementById("message");
-            this.setRichTextContent(quill, message?.message);
+            this.view.setRichTextContent(quill, message);
 
             const summaryArea =  document.getElementById("summary") as HTMLTextAreaElement;
             summaryArea.value = message?.summary ?? '';
@@ -87,10 +87,6 @@ export class MessageOrQuestionListUserCardTemplate extends BaseUserCardTemplate 
             this.previousTitleId = messageId;
         } 
         
-    }
-
-    private setRichTextContent(quillEditor: any, message: string) {
-        quillEditor.setContents(opfab.richTextEditor.getDeltaFromText(opfab.utils.escapeHtml(message)));
     }
 
     private listenToEntityUsedForSendingCardChange() {

--- a/ui/main/src/app/business/buildInTemplates/message-or-question-list/usercard/message-or-question-listUserCardTemplateView.spec.ts
+++ b/ui/main/src/app/business/buildInTemplates/message-or-question-list/usercard/message-or-question-listUserCardTemplateView.spec.ts
@@ -238,4 +238,42 @@ describe('MessageOrQuestionList UserCard template', () => {
         expect(messages[0].value).toEqual('id3');
         expect(messages[1].value).toEqual('id4');
     });
+
+    it('GIVEN a message list WHEN selected message has richMessage field THEN quill editor content is the richMessage', () => {
+        const view = new MessageOrQuestionListUserCardTemplateView();
+        const messageOrQuestionList = {
+            messagesList: [{
+                id: 'id1',
+                richMessage: {"ops":[{"attributes":{"color":"#e60000","bold":true}},{"insert":"Rich message"}]},
+            }]
+        };
+
+        view.messageOrQuestionList = messageOrQuestionList;
+
+        const selectedMessage = messageOrQuestionList.messagesList[0];
+
+        const quillEditor = new QuillEditorMock();
+        view.setRichTextContent(quillEditor, selectedMessage)
+
+        expect(quillEditor.getContents()).toEqual("{\"ops\":[{\"attributes\":{\"color\":\"#e60000\",\"bold\":true}},{\"insert\":\"Rich message\"}]}");
+    });
+
+    it('GIVEN a message list WHEN selected message does not have richMessage field THEN quill editor content is the message in delta format', () => {
+        const view = new MessageOrQuestionListUserCardTemplateView();
+        const messageOrQuestionList = {
+            messagesList: [{
+                id: 'id2',
+                message: 'message2',
+            }]
+        };
+
+        view.messageOrQuestionList = messageOrQuestionList;
+
+        const selectedMessage = messageOrQuestionList.messagesList[0];
+
+        const quillEditor = new QuillEditorMock();
+        view.setRichTextContent(quillEditor, selectedMessage);
+
+        expect(quillEditor.getContents()).toEqual("{\"ops\":[{\"insert\":\"message2\"}]}");
+    });
 });

--- a/ui/main/src/app/business/buildInTemplates/message-or-question-list/usercard/message-or-question-listUserCardTemplateView.ts
+++ b/ui/main/src/app/business/buildInTemplates/message-or-question-list/usercard/message-or-question-listUserCardTemplateView.ts
@@ -149,4 +149,8 @@ export class MessageOrQuestionListUserCardTemplateView {
         return selectedOption;
     }
 
+    setRichTextContent(quillEditor: any, message: any) {
+        const delta = message.richMessage ? JSON.stringify(message.richMessage) : opfab.richTextEditor.getDeltaFromText(opfab.utils.escapeHtml(message.message));
+        quillEditor.setContents(delta);
+    }
 }


### PR DESCRIPTION
Fix #5738

- In release note :
  -  In chapter :  Features
  -  Text : #5738 : Add the option to configure rich text in config file for message or question list build-in template 