### PR TITLE
Fix ui-menu entries (#5888)

### DIFF
--- a/config/docker/ui-config/ui-menu.json
+++ b/config/docker/ui-config/ui-menu.json
@@ -62,7 +62,7 @@
       "label": "title.admin",
       "entries": [
         {
-          "customMenuId": "uid_test_3",
+          "customMenuId": "uid_test_4",
           "url": "https://opfab.github.io/",
           "label": "entry.admin",
           "linkType": "BOTH",


### PR DESCRIPTION
Fix #5888 

- In release note :
  -  In chapter :  Bugs 
  -  Text : #5888: Fix linked navbar menus when logged as admin