### PR TITLE
Remove unneeded types/moment deprecated dependency

### DIFF
--- a/ui/main/package-lock.json
+++ b/ui/main/package-lock.json
@@ -66,7 +66,6 @@
         "@types/geojson": "^7946.0.10",
         "@types/handlebars": "4.0.40",
         "@types/jasmine": "5.1.4",
-        "@types/moment": "2.13.0",
         "@typescript-eslint/eslint-plugin": "6.21.0",
         "@typescript-eslint/parser": "6.21.0",
         "eslint": "8.56.0",
@@ -4759,16 +4758,6 @@
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
       "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
       "dev": true
-    },
-    "node_modules/@types/moment": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@types/moment/-/moment-2.13.0.tgz",
-      "integrity": "sha512-DyuyYGpV6r+4Z1bUznLi/Y7HpGn4iQ4IVcGn8zrr1P4KotKLdH0sbK1TFR6RGyX6B+G8u83wCzL+bpawKU/hdQ==",
-      "deprecated": "This is a stub types definition for Moment (https://github.com/moment/moment). Moment provides its own type definitions, so you don't need @types/moment installed!",
-      "dev": true,
-      "dependencies": {
-        "moment": "*"
-      }
     },
     "node_modules/@types/node": {
       "version": "20.5.0",

--- a/ui/main/package.json
+++ b/ui/main/package.json
@@ -73,7 +73,6 @@
     "@types/geojson": "^7946.0.10",
     "@types/handlebars": "4.0.40",
     "@types/jasmine": "5.1.4",
-    "@types/moment": "2.13.0",
     "@typescript-eslint/eslint-plugin": "6.21.0",
     "@typescript-eslint/parser": "6.21.0",
     "eslint": "8.56.0",


### PR DESCRIPTION
Solve message during build :

npm WARN deprecated @types/moment@2.13.0: This is a stub types definition for Moment (https://github.com/moment/moment). Moment provides its own type definitions, so you don't need @types/moment installed!

Nothing in release note