### PR TITLE
Add the possibility to launch manually the scorecard github workflow

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -11,6 +11,7 @@ on:
   # https://github.com/ossf/scorecard/blob/main/docs/checks.md#maintained
   schedule:
     - cron: '28 5 * * *'
+  workflow_dispatch:
 
 # Declare default permissions as read only.
 permissions: read-all


### PR DESCRIPTION
Nothing in release note