### PR TITLE
Solve issue : usercard error appears only once (#6104)

### DIFF
--- a/ui/main/src/assets/js/opfab.js
+++ b/ui/main/src/assets/js/opfab.js
@@ -186,7 +186,7 @@ class QuillEditor extends HTMLElement {
     constructor() {
         super();
         this.init();
-        this.EMPTY_REGEXP = /^<p>(<br>|<br\/>|<br\s\/>|\s+|)<\/p>$/gm;
+        this.EMPTY_REGEXP = /^<p>(<br>|<br\/>|<br\s\/>|\s+|)<\/p>$/m;
 
         const toolbarOptions = [
             [{ 'header': [1, 2, 3, 4, 5, 6, false] }],


### PR DESCRIPTION
This commit resolves an issue where the usercard error would only appear once due to the use of the global flag (/g) in a JavaScript regular expression.
The issue was that calling this.EMPTY_REGEXP.test(this.quill.root.innerHTML) on the same string would return true the first time and false subsequently.

The global flag causes the RegExp.test() method to alternate between matching and not matching the regex,
as explained in the official MDN documentation: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/test#using_test_on_a_regex_with_the_global_flag

Norhing in release note for 4.3.0 , will be in release note 4.2.0
