### PR TITLE
Use npm ci for migration entity role script

### DIFF
--- a/src/tooling/migration-entity-roles/Dockerfile
+++ b/src/tooling/migration-entity-roles/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:20.11.0-alpine@sha256:2f46fd49c767554c089a5eb219115313b72748d8f62f5eccb58ef52bc36db4ad
 WORKDIR /usr/app
 COPY ./ ./
-RUN npm install 
+RUN npm ci
 COPY migration-entity-roles.js /
 COPY migration-entity-roles-entrypoint.sh /
 ENTRYPOINT ["/migration-entity-roles-entrypoint.sh"]


### PR DESCRIPTION
This way we use pin dependencies defined in package-lock.json

Nothing in release note