### PR TITLE
Refine Release Process Workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,7 +47,7 @@ permissions: read-all
 jobs:
   build:
     runs-on: ubuntu-latest
-    if: ${{ github.event.inputs.dockerPush  != 'true' && github.event.inputs.dockerPushLatest  != 'true' &&  github.event.inputs.doc  != 'true' && github.event.inputs.docLatest  != 'true' && github.event_name != 'schedule' && github.ref_name != 'master' }}
+    if: ${{ github.event.inputs.dockerPush  != 'true' && github.event.inputs.dockerPushLatest  != 'true' &&  github.event.inputs.doc  != 'true' && github.event.inputs.docLatest  != 'true' && github.event_name != 'schedule' }}
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       
@@ -107,7 +107,7 @@ jobs:
     environment: publishVersion
     permissions:
       contents: write
-    if: ${{ github.event.inputs.dockerPush  == 'true' || github.event.inputs.dockerPushLatest  == 'true'  ||  github.event.inputs.doc  == 'true' || github.event.inputs.docLatest  == 'true' || github.event_name == 'schedule' || github.ref_name == 'master' }}
+    if: ${{ github.event.inputs.dockerPush  == 'true' || github.event.inputs.dockerPushLatest  == 'true'  ||  github.event.inputs.doc  == 'true' || github.event.inputs.docLatest  == 'true' || github.event_name == 'schedule' }}
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
     
@@ -175,7 +175,7 @@ jobs:
           GH_DOC_TOKEN: ${{ secrets.GH_DOC_TOKEN}}
 
       - name : Publish Documentation (latest)
-        if : ${{ github.event.inputs.docLatest  == 'true' || github.ref_name == 'master'}}
+        if : ${{ github.event.inputs.docLatest  == 'true' }}
         run: |
           source $HOME/.sdkman/bin/sdkman-init.sh;
           export NVM_DIR="$HOME/.nvm"
@@ -188,7 +188,7 @@ jobs:
           GH_DOC_TOKEN: ${{ secrets.GH_DOC_TOKEN}}
 
       - name : Push images to dockerhub 
-        if: ${{ github.event.inputs.dockerPush  == 'true' || github.event_name == 'schedule' || github.ref_name == 'master' }}
+        if: ${{ github.event.inputs.dockerPush  == 'true' || github.event_name == 'schedule' }}
         run: |
           echo ${{ secrets.DOCKER_TOKEN }} | docker login --username opfabtravis --password-stdin
           docker images --format "{{.Repository}}:{{.Tag}}" | grep lfe | while read image; do 
@@ -197,7 +197,7 @@ jobs:
           done
 
       - name : Push images latest to dockerhub 
-        if: ${{ github.event.inputs.dockerPushLatest  == 'true'  || github.ref_name == 'master'  }}
+        if: ${{ github.event.inputs.dockerPushLatest  == 'true' }}
         run: |
           echo ${{ secrets.DOCKER_TOKEN }} | docker login --username opfabtravis --password-stdin
           docker images --format "{{.Repository}}:{{.Tag}}" | grep lfe | while read image; do 

--- a/CICD/prepare_release_version.sh
+++ b/CICD/prepare_release_version.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright (c) 2018-2022, RTE (http://www.rte-france.com)
+# Copyright (c) 2018-2024, RTE (http://www.rte-france.com)
 # See AUTHORS.txt
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -39,7 +39,7 @@ display_usage
 esac
 done
 
-# Get current version from VERSION file (can be SNAPSHOT or X.X.X.RELEASE in the case of a hotfix)
+# Get current version from VERSION file (can be SNAPSHOT or X.X.X.RELEASE in the case of a fix)
 oldVersion=$(cat VERSION)
 echo "Current version is $oldVersion (based on VERSION file)"
 

--- a/src/docs/asciidoc/CICD/release_process.adoc
+++ b/src/docs/asciidoc/CICD/release_process.adoc
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2023 RTE (http://www.rte-france.com)
+// Copyright (c) 2018-2024 RTE (http://www.rte-france.com)
 // See AUTHORS.txt
 // This document is subject to the terms of the Creative Commons Attribution 4.0 International license.
 // If a copy of the license was not distributed with this
@@ -13,7 +13,7 @@
 
 == Version numbers
 
-We work with two types of versions:
+We work with three types of versions:
 
 * X.Y.Z.RELEASE versions are stable versions
 * X.Y.Z-RC.RELEASE versions are release candidates for the next stable version
@@ -28,21 +28,22 @@ the same major version.
 
 == Releasing a Release Candidate 
 
-
-IMPORTANT: To release a version we use some GitHub Actions dedicated jobs. These jobs are triggered when pushing a commit in branches 
-containing the keyword release at the end (**release) and rely on the VERSION file at the root of this repository to 
-know which version is being produced. It is thus crucial to double-check the content of this file before any push 
-(triggering the GitHub Actions jobs) is made.
-
 Before releasing a version, you need to prepare the release.
 
 === Creating a release branch and preparing the release candidate
 
 . On the link:{opfab_core_repo}[operatorfabric-core repository], create a branch off the `develop` branch named
-`X.X.X.release` (note the lowercase `release` to distinguish it from `X.X.X.RELEASE` tags).
+`X.X.release` if it does not exist  (note the lowercase `release` to distinguish it from `X.X.X.RELEASE` tags).
 +
 ----
-git checkout -b X.X.X.release
+git checkout -b X.X.release
+git push --set-upstream origin X.X.release
+----
++
+Create a working branch for the release candidate. This branch will be used to prepare the release candidate :
++
+----
+git checkout -b FE-X.X.X-RC.release.draft
 ----
 +
 . Use the ./CICD/prepare_release_version.sh script to automatically perform all the necessary changes:
@@ -83,24 +84,19 @@ git commit -s -m "[RELEASE] X.X.X-RC.RELEASE"
 . Push the commit
 +
 ----
-git push --set-upstream origin X.X.X.release
+git push --set-upstream origin X.X.X-RC.release.draft
 ----
 +
-. Create the tag for the release candidate:
+. Create a pull request from the `X.X.X-RC.release.draft` branch to the `X.X.release` branch and ask for a review.
++
+. Once the pull request is approved and merge, create the tag for the release candidate:
 +
 ----
+git checkout X.X.release
+git pull  
 git tag X.X.X-RC.RELEASE
 git push origin X.X.X-RC.RELEASE
 ----
-+
-. Check that the build is correctly triggered
-+
-You can check the status of the GitHub Actions triggered by the commit on
-link:https://github.com/opfab/operatorfabric-core/actions[Github Actions].
-
-. Wait for the build to complete (around 50 minutes) and check that all jobs have been successful.
-This ensures that the code builds, tests are OK and there is no error preventing documentation or Docker images
-generation.
 
 === Publish the release candidate on docker hub and documentation
 
@@ -120,7 +116,7 @@ To do so:
 ifdef::single-page-doc[<<client_lib_pub_conf, documentation for the publishing task>>]
 ifndef::single-page-doc[<</documentation/current/dev_env/index.adoc#client_lib_pub_conf, documentation for the publishing task>>]
 
-. Run the following command from the project root:
+. Run the following command from the project root on the release branch:
 +
 ----
 ./gradlew publish
@@ -236,20 +232,15 @@ in case there is an issue.
 
 == Releasing a Major or Minor Version
 
-IMPORTANT: To release a version we use some GitHub Actions dedicated jobs. These jobs are triggered when pushing a commit in branches 
-containing the keyword release at the end (**release) and rely on the VERSION file at the root of this repository to 
-know which version is being produced. It is thus crucial to double-check the content of this file before any push 
-(triggering the GitHub Actions jobs) is made.
-
 Before releasing a version, you need to prepare the release.
-
 
 === Move Release Candidate to Release
 
-. Checkout release branch
+. Create a branch to prepare the release from the release candidate branch:
 +
 ----
-git checkout X.X.X.release
+git checkout X.X.release
+git checkout -b X.X.X.release.draft
 ----
 +
 . Use the ./CICD/prepare_release_version.sh script to automatically perform all the necessary changes:
@@ -290,56 +281,39 @@ git commit -s -m "[RELEASE] X.X.X.RELEASE"
 . Push the commit
 +
 ----
-git push 
+git push --set-upstream origin X.X.X.release.draft
 ----
 +
-. Check that the build is correctly triggered
+. Create a pull request from the 'X.X.X.release.draft` branch to the `X.X.release` branch and ask for a review.
 +
-You can check the status of the GitHub Actions triggered by the commit on
-link:https://github.com/opfab/operatorfabric-core/actions[Github Actions].
+. Once the pull request is approved and merge, create the tag for the release candidate:
 +
-Wait for the build to complete (around 50 minutes) and check that all jobs have been successful.
-This ensures that the code builds, tests are OK and there is no error preventing documentation or Docker images
-generation.
+----
+git checkout X.X.release
+git pull  
+git tag X.X.X.RELEASE
+git push origin X.X.X.RELEASE
+----
 
-=== Merging the release branch into `master`
+[[publish_release_on_docker_hub_and_documentation]]
+=== Publish the release on docker hub and documentation
 
-Once the release branch build is passing, you should merge the release branch into `master` to bring the new
-developments into `master` and trigger the CICD tasks associated with a release (Docker images for DockerHub and
+Once the release branch build is passing, you should trigger the CICD tasks associated with a release (Docker images for DockerHub and
 documentation).
 
-----
-git checkout master <1>
-git pull <2>
-git merge X.X.X.release <3>
-----
-<1> Check out the `master` branch
-<2> Make sure your local copy is up to date
-<3> Merge the `X.X.X.release` branch into `master`, accepting changes from X.X.X.release in case of conflicts.
-
-----
-git tag X.X.X.RELEASE <1>
-git push <2>
-git push origin X.X.X.RELEASE <3>
-----
-<1> Tag the commit with the `X.X.X.RELEASE` tag
-<2> Push the commits to update the remote `master` branch
-<3> Push the tag
-
-. Check that the build is correctly triggered
-+
-You can check the status of the GitHub Action workflow triggered by the commit on
+To do so , go to 
 link:https://github.com/opfab/operatorfabric-core/actions[Github Actions].
-The Github Actions workflow should have the following six jobs executed :
-- Build
-- Karate tests
-- Cypress tests 
-- Publish Documentation (latest)
-- Push images to dockerhub 
-- Push images latest to dockerhub 
+and launch the workflow on X.X.release branch with the following options :
+- Build : true 
+- Karate tests : false
+- Cypress tests : false 
+- Build and publish documentation : true
+- Build and publish documentation - Latest : true if it is the last major/minor version
+- Docker Push : true
+- Docker Push - Latest : true if it is the last major/minor version
 
 
-Wait for the build to complete (around 50 minutes) and check that all jobs have been successful.
+Wait for the build to complete and check that all jobs have been successful.
 
 . Check that the `X.X.X.RELEASE` images have been generated and pushed to DockerHub.
 
@@ -403,7 +377,7 @@ the External Devices API is displayed on the website.
 [[checking_docker_compose]]
 === Checking the docker-compose files
 
-While the docker-compose files should always point to the SNAPSHOT images while on the `develop` branch, on the `master`
+While the docker-compose files should always point to the SNAPSHOT images while on the `develop` branch, on the `X.X.release`
 branch they should rely on the latest RELEASE version available on DockerHub. Once the CI pipeline triggered by the
 previous steps has completed successfully, and you can see X.X.X.RELEASE images for all services on DockerHub, you should:
 
@@ -451,55 +425,31 @@ in case there is an issue.
 
 === Preparing the next version
 
-==== On the release-notes repository
-
 Remove the release_notes.X.X.X.md file corresponding to the release's version.
 
-==== On the operatorfabric-core repository
 
-Now that the release branch has served its purpose, it should be deleted so as not to clutter the repository and to
-avoid confusion with the actual release commit tagged on `master`.
+== Releasing a Patch Version
 
-----
-git branch -d X.X.X.release <1>
-----
-<1> Delete the branch locally
+Let's say fixes that will be released as X.X.X.RELEASE. 
 
-NOTE: You should also delete the branch on GitHub.
+Follow the process described
+ifdef::single-page-doc[<<working_on_fix, here>>]
+ifndef::single-page-doc[<</documentation/current/community/index.adoc#working_on_fix, here>>]
+to create feature branches, work on fixes and merge them back into `X.X.release`.
 
-You should also close the project for this version, and create one for the next version if it doesn't already exist
-(use the "Automated Kanban" template).
 
-== Releasing a Patch (Hotfixes) Version
-
-Let's say fixes are needed on version X.X.0.RELEASE, and will be released as X.X.X.RELEASE. If it's the first patch 
-version to be released for this minor version (i.e. version X.X.1.RELEASE), you will need to create the `X.X.hotfixes` 
-branch.
-To do so:
-
-[source,bash]
-----
-git checkout X.X.0.RELEASE <1>
-git checkout -b X.X.hotfixes <2>
-----
-<1> Checkout X.X.0.RELEASE tag
-<2> Create (and checkout) branch `X.X.hotfixes` from this commit
-
-If branch `X.X.hotfixes` already exists, you can just check it out.
-
-[source,bash]
-----
-git checkout X.X.hotfixes
-----
-
-Then, follow the process described
-
-ifdef::single-page-doc[<<working_on_hotfix, here>>]
-ifndef::single-page-doc[<</documentation/current/community/index.adoc#working_on_hotfix, here>>]
-to create feature branches, work on fixes and merge them back into `X.X.hotfixes`.
-
-Once all the big fixes that need to go into the version X.X.X.RELEASE have been merged into branch `X.X.hotfix`, you
+Once all the big fixes that need to go into the version X.X.X.RELEASE have been merged into branch `X.X.release`, you
 can release the patch version. To do so:
+
+Create a branch to prepare the release from the release branch:
+
+[source,bash]
+----
+git pull X.X.release
+git checkout X.X.release
+git checkout -b X.X.X.release.draft
+----
+
 
 . Use the ./CICD/prepare_release_version.sh script to automatically perform all the necessary changes:
 +
@@ -507,30 +457,30 @@ can release the patch version. To do so:
 ./CICD/prepare_release_version.sh -v X.X.X.RELEASE
 ----
 +
-. Commit the changes, tag them and push both to GitHub:
+. Commit the changes and push to GitHub:
 +
 ----
 git add .
-git commit -m "[RELEASE] X.X.X.RELEASE " <1>
-git tag X.X.X.RELEASE <2>
-git push --set-upstream origin X.X.hotfixes <3>
-git push origin X.X.X.RELEASE <4>
+git commit -m "[RELEASE] X.X.X.RELEASE "
+git push --set-upstream origin X.X.X.release.draft 
+
 ----
-<1> Commit the changes
-<2> Tag the release
-<3> Push the commit
-<4> Push the tag
++
+. Create a pull request from the 'X.X.X.release.draft` branch to the `X.X.release` branch and ask for a review.
++
+. Once the pull request is approved and merge, create the tag for the release candidate:
++
+----
+git checkout X.X.release
+git pull  
+git tag X.X.X.RELEASE
+git push origin X.X.X.RELEASE
+----
 
-
-This will trigger the build and tests in GitHub Actions.
-
-If the build and tests are successful, launch manually GitHubActions with jobs : `Build` , `Docker Push` and `Build and publish documentation` 
-
-IMPORTANT: In the case of a patch on the last major/minor version tagged on master, this version will become the
-`latest` version. In this case, add the jobs `Docker Push - Latest` and  `Build and publish documentation - Latest` instead of `Build and publish documentation` to also update the `latest` docker images on DockerHub and the `current` documentation on the website.
 
 You then have to follow the following steps as for a classic release:
 
+* <<publish_release_on_docker_hub_and_documentation, Publish the release on docker hub and documentation>>
 * <<update_version_list_on_website, Updating the version list on the website>>.
 * <<checking_docker_compose, Checking the docker-compose files>>.
 * <<publishing_release_on_github, Publishing the release on GitHub>>.

--- a/src/docs/asciidoc/community/documentation.adoc
+++ b/src/docs/asciidoc/community/documentation.adoc
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2020 RTE (http://www.rte-france.com)
+// Copyright (c) 2018-2024 RTE (http://www.rte-france.com)
 // See AUTHORS.txt
 // This document is subject to the terms of the Creative Commons Attribution 4.0 International license.
 // If a copy of the license was not distributed with this
@@ -143,7 +143,7 @@ include::../../../../build.gradle[tag=asciidoctor_gradle_task_config]
 ----
 +
 In particular, the version and revision date are set automatically from the version defined in the
-link:https://github.com/opfab/operatorfabric-core/blob/master/VERSION[VERSION] file at the root of the project and
+VERSION file at the root of the project and
 the current date.
 
 * All files are created starting with level 0 titles so:

--- a/src/docs/asciidoc/community/workflow.adoc
+++ b/src/docs/asciidoc/community/workflow.adoc
@@ -6,75 +6,42 @@
 // SPDX-License-Identifier: CC-BY-4.0
 
 
-:git_flow_post: https://nvie.com/posts/a-successful-git-branching-model/
-
 = Contribution Workflow
-
-The project started out using a
-link:https://www.atlassian.com/git/tutorials/comparing-workflows/feature-branch-workflow[Feature Branch workflow], but
-as the project team grew and we needed to manage support to previous releases we decided to switch to a workflow
-based on the
-link:{git_flow_post}[Git Flow workflow], starting after version 1.3.0.RELEASE.
-
-The principles for this workflow were first described in the blog post linked above, and this document attempts to
-summarize how we adapted it to our project. Statements in quotes are from the original blog post.
-
-NOTE: In this document, *"repository version"* refers to the version defined in the VERSION file at the root of the
-project, which is a parameter for certain build tasks and for our CICD pipeline.
 
 == Principles
 
+=== Release names 
+
+We use the following naming convention for our releases:
+
+ - `X.0.0.RELEASE` for major release (e.g. 1.0.0.RELEASE)
+ - `X.X.0.RELEASE` for minor release (e.g. 1.2.0.RELEASE)
+ - `X.X.X.RELEASE` for patch releases (e.g. 3.2.1.RELEASE)
+
+
 === `develop` branch
 
-The role of the `develop` branch is quite similar to that of the `master` branch in our previous "Feature Branch"
-workflow.
-
 The `develop` branch is where feature branches are branched off from, and where they're merged back to. This way,
-the HEAD of the `develop` branch _"always reflects a state with the latest delivered development changes for the next
-release"_.
+the HEAD of the `develop` branch always reflects a state with the latest delivered development changes for the next
+release.
 
 The repository version on the `develop` branch should always be `SNAPSHOT`.
 
-The daily CRON GitHub Action generating the documentation and docker images for the `SNAPSHOT` version are run from
-this branch (see our
-ifdef::single-page-doc[<<CICD, CICD documentation>>]
-ifndef::single-page-doc[<</documentation/current/CICD/index.adoc#CICD, CICD documentation>>]
-for details).
+A daily CRON GitHub Action generating the documentation and docker images for the `SNAPSHOT` version is run from
+this branch.
 
-=== `master` branch
+=== `X.X.release` branch
 
-_"When the source code in the develop branch reaches a stable point and is ready to be released, all the changes
-should be merged back into master somehow and then tagged with a release number."_
+When the source code in the develop branch reaches a stable point and is ready to be released, all the changes
+should be integrated in a release branch named X.X.release.
 
-This means that any commit on master is a production-ready release, be it a minor or a major version.
-
-Any commit on `master` triggers a GitHub Action build generating and pushing documentation and docker images for the
-corresponding release version. As a version released from master is also by design the latest version, it will also
-update the `latest` docker images and the `current` documentation folder on the website.
-
-=== Hotfix branches
-
-While minor and major versions are tagged in increasing and linear order on the `master` branch, it might be necessary
-to create patches on previous releases.
-
-To do so, we create hotfix branches branching off version commits on the `master` branch.
-
-For example, the `1.8.hotfixes` branch branches off the commit tagged `1.8.0.RELEASE` on the `master` branch, and will
-contain tags for `1.8.1.RELEASE`, `1.8.2.RELEASE` and so on.
-
-*Naming convention:* Hotfix branches names should always start with the two digits representing the minor version
-they're patching, followed by ".hotfixes".
-
-.Examples of valid hotfix branch names:
-* 1.8.hotfixes
-* 2.0.hotfixes
 
 === Feature branches
 
 Feature branches are used to develop new features or fix bugs described in GitHub issues.
 They have two distinct use cases with similar workflows.
 
-==== Feature branches for the next release
+==== Feature branches for major/minor version
 
 These feature branches are used to develop new features or fix bugs *for the next release*.
 
@@ -89,15 +56,15 @@ link:https://help.github.com/en/github/collaborating-with-issues-and-pull-reques
 features (comments, proposed changes, etc.) to make changes to the PR until it meets the project requirements.
 . Once it is ready to be included in the next version, the pull request is then merged back into `develop`.
 
-==== Feature branches for hotfixes
+==== Feature branches for patch versions
 
 These feature branches fix bugs in existing releases and give rise to new patches.
 
 Their lifecycle is similar to regular feature branches, except they should be branched off (and merged back to) the
-`X.X.hotfixes` branch corresponding to the release they are fixing.
+`X.X.release` branch corresponding to the release they are fixing.
 
 Example: A feature branch working on bug 1234 affecting version 1.8.0.RELEASE should be branched off
-branch `1.8.hotfixes`.
+branch `1.8.release`.
 
 ==== Common conventions
 
@@ -118,55 +85,11 @@ Commit messages should also contain the GitHub issue reference: ` My commit mess
 
 This allows the branch, PR and commits to be directly accessible from the GitHub issue.
 
-=== Release branches
-
-
-==== Release candidate
-Once developments are in a release-ready state and have been tested on the `develop` branch, a release candidate branch should
-be created off `develop` . 
-
-NOTE: _"All features that are targeted for the release-to-be-built must be merged in to develop at this point in time.
-All features targeted at future releases may not—they must wait until after the release branch is branched off."_
-
-IMPORTANT: By contrast to what is described in the link:{git_flow_post}[original blog post], for now we have chosen to
-only create the release branch once the developments are completely ready and tested on the develop branch, so that no
-fixes should be made on the release branch. This simplifies things because it means that release branches don't have to
-be merged back into `develop`.
-
-Once the `X.X.X.release` branch has been created, a new commit should be made on this branch to change the repository
-version from `SNAPSHOT` to `X.X.X-RC.RELEASE`.
-
-==== Release
-
-When release candidate is ready to be released, a new commit should be made on the `X.X.X.release` branch to change the repository version from `X.X.X-RC.RELEASE` to `X.X.X.RELEASE`.
-
-
-Then, pushing the branch will trigger a build and a "dry-run" generation of docker images. The aim
-is to detect any issue with this generation before moving to master.
-
-
-Finally, the `X.X.X.release` can be merged into `master`, triggering
-The resulting merge commit on `master` should then be tagged with `X.X.X.RELEASE`.
-
-All commits on `master` should be merged commits from `release` branches, direct pushes on master are disabled .
-
-*Naming convention:* The name of a release branch should match the repository version it is meant to merge into
-`master` but in lower case to avoid confusion with release tags on master.
-
-Example: The valid branch name for the branch bringing 1.3.0.RELEASE into `master` is 1.3.0.release
 
 == Examples and commands
 
 The aim of this section is to illustrate how our workflow works on a concrete example, complete with the required
 `git` commands.
-
-=== Initial state
-
-In the initial state of our example, only `develop` and `master` exist.
-
-The repository version in `master` is `1.3.0.RELEASE`, and the `develop` branch has just been branched off it. Commits
-have been added to `develop` to change the repository version to `SNAPSHOT` and implement the changes necessary for
-Git flow.
 
 === Starting work on a new feature for the next version
 
@@ -213,17 +136,6 @@ git push --set-upstream origin FE-123
 You can re-work, squash your commits and push as many times as you want on a feature branch.
 Force pushes are allowed on feature branches.
 
-To see your branch:
-
-. Go to the https://github.com/opfab/operatorfabric-core[operatorfabric-core repository on GitHub]
-. Click the `branches` tab
-
-[NOTE]
-====
-Feel free to add or update a copyright header (on top of the existing ones) to files you create or amend.
-See src/main/headers for examples.
-====
-
 === Submitting a pull request to develop
 
 Once you are satisfied with the state of your developments, you can submit it as a pull request.
@@ -240,8 +152,7 @@ ifdef::single-page-doc[<<review_checklist, review checklist>>]
 ifndef::single-page-doc[<</documentation/current/community/index.adoc#review_checklist, review checklist>>]
 below to make sure your branch meets its criteria.
 
-Once you feel your branch is ready, submit a pull request. Open pull requests are then reviewed by the core maintainers
-to assign a reviewer to each of them.
+Open pull requests are then reviewed by the core maintainers to assign a reviewer to each of them.
 
 To do so, go to the `branches` tab of the repository as described above.
 Click the "New Pull Request" button for your branch.
@@ -263,72 +174,11 @@ Make sure that the base branch for the PR is `develop`, because feature branches
 it in the base branch dropdown list.
 ====
 
-At this point, GitHub will tell you whether your branch could be automatically merged into `develop` or whether
-there are conflicts to be fixed.
 
-==== Case 1: GitHub is able to automatically merge your branch
-
-This means that either your branch was up to date with develop or there were no conflicts.
-In this case, just go ahead and fill in the PR title and message, then click "Create pull request".
-
-==== Case 2: GitHub can't merge your branch automatically
-
-This means that there are conflicts with the current state of the `develop` branch on GitHub.
-To fix these conflicts, you need to update your local copy of the develop branch and merge it into your feature branch.
-
-----
-git checkout develop <1>
-git pull <2>
-git checkout FE-123 <3>
-git merge develop <4>
-----
-<1> Check out the `develop` branch
-<2> Make sure it is up to date with the remote (=GitHub repository)
-<3> Check out the `FR-123` branch
-<4> Merge the new commits from `develop` into the feature branch
-
-Then, handle any conflicts from the merge. For example, let's say there is a conflict on file `dummy1.txt`:
-
-----
-Auto-merging dummy1.txt
-CONFLICT (add/add): Merge conflict in dummy1.txt
-Automatic merge failed; fix conflicts and then commit the result.
-----
-
-Open file `dummy1.txt`:
-
-.dummy1.txt
-----
- <<<<<<< HEAD
- Some content from FE-123.
- =======
- Some content that has been changed on develop since FE-123 branched off.
- >>>>>>> develop
-----
-
-Update the content to reflect the changes that you want to keep:
-
-.dummy1.txt
-----
-Some content from FE-123 and some content that has been changed on develop since FE-123 branched off.
-----
-
-----
-git add dummy1.txt <1>
-git commit <2>
-git push <3>
-----
-<1> Add the manually merged file to the changes to be committed
-<2> Commit the changes to finish the merge
-<3> Push the changes to GitHub
-
-Now, if you go back to GitHub and try to create a pull request again, GitHub should indicate that it is able to merge
-automatically.
-
-[[working_on_hotfix]]
+[[working_on_fix]]
 === Working on a fix for a previous version
 
-To work on a fix for an existing version, the steps are similar to those described above, substituting `X.X.hotfix` for
+To work on a fix for an existing version, the steps are similar to those described above, substituting `X.X.release` for
 `develop`.
 
 === Reviewing a Pull Request
@@ -387,7 +237,7 @@ To automate build and API testing, you can use `${OF_HOME}/src/test/api/karate/b
 Once the pull request meets all the criteria from the above check list, you can merge it into the `develop` branch.
 
 . Go to the pull request page on GitHub
-. Check that the base branch for the pull request is `develop` (or `X.X.hotfixes`). This information is visible at the
+. Check that the base branch for the pull request is `develop` (or `X.X.release`). This information is visible at the
 top of the page.
 +
 image::existing_PR_check_base.png[]
@@ -402,7 +252,7 @@ visible under the "Done" column. If not, add it to the project and put it there 
 . Go to the link:https://github.com/opfab/release-notes/[release-notes repository] and add the issue to the list with
 the information provided in the PR comments.
 
-=== Creating a release or hotfix
+=== Creating a release
 
 See the
 ifdef::single-page-doc[<<release_process, release process>>]


### PR DESCRIPTION
- Remove usage of unecessary 'master' branch in workflow.
- Substitute 'hotfix' terminology with 'patch'.
- Introduce PR review mechanism for release-related commits.
- Omit conflict resolution documentation (readily available online, not project-specific).
- Implement various minor documentation enhancements.

Nothing in release note