### PR TITLE
Add an option to refuse login of a user without groups (#6240)

### DIFF
--- a/config/docker/users.yml
+++ b/config/docker/users.yml
@@ -24,7 +24,7 @@ operatorfabric.users.default:
       groups: [ "RTE","ADMIN","ReadOnly","Dispatcher"]
       entities: [ "ENTITY1_FR" ]
     - login: operator6_fr
-      groups: []
+      groups: ["ReadOnly"] 
       entities: ["ENTITY1_FR"]
     - login: itsupervisor1
       groups: ["ADMIN", "Supervisor"]

--- a/src/test/cypress/cypress/integration/LoginPage.spec.js
+++ b/src/test/cypress/cypress/integration/LoginPage.spec.js
@@ -84,7 +84,20 @@ describe('LoginPage', () => {
         cy.hash().should('eq', '#/monitoring');
         cy.contains('Cards with response from my entity');
     });
+    it ('login with user with no group shall popup a message and logout', () => {
+        //go to login page
+        cy.visit('/');
+        cy.get('#opfab-login').type('userwithnogroupnoentity');
+        cy.get('#opfab-password').type('test');
 
+        //press login button
+        cy.get('#opfab-login-btn-submit').click();
+
+        cy.get('#opfab-modal-body').contains('You are not allowed to access the application');
+        cy.get('#opfab-btn-ok').click();
+
+        cy.get('#opfab-login').should('be.visible');
+    });
     it('login is in french if settings.locale is set to fr in web-ui.json', () => {
         //go to login page
         script.setPropertyInConf('settings.locale', '\\"fr\\"');

--- a/ui/main/src/app/modules/core/application-loading/application-loading.component.html
+++ b/ui/main/src/app/modules/core/application-loading/application-loading.component.html
@@ -7,7 +7,7 @@
 <!-- SPDX-License-Identifier: MPL-2.0                                      -->
 <!-- This file is part of the OperatorFabric project.                      -->
 
-<of-loading-in-progress *ngIf="applicationLoader.loadingInProgress && !showLoginScreen"></of-loading-in-progress>
+<of-loading-in-progress *ngIf="applicationLoader.loadingInProgress && !showLoginScreen && applicationLoader.isAllowedToAccessOpfab"></of-loading-in-progress>
 
 <of-app-loaded-in-another-tab #appLoadedInAnotherTab> </of-app-loaded-in-another-tab>
 

--- a/ui/main/src/app/modules/core/application-loading/application-loading.component.ts
+++ b/ui/main/src/app/modules/core/application-loading/application-loading.component.ts
@@ -112,10 +112,12 @@ export class ApplicationLoadingComponent implements OnInit {
             this.applicationLoader.setAppLoadedInAnotherTabComponent(this.appLoadedInAnotherTabComponent);
             this.applicationLoader.setActivityAreaChoiceAfterLoginComponent(this.activityAreaChoiceAfterLoginComponent);
             this.applicationLoader.setMethodToAuthenticate(this.authenticate.bind(this));
-            await this.applicationLoader.startOpfab();
-            this.applicationLoadedDone.next(true);
-            this.applicationLoadedDone.complete();
-            this.applicationLoaded = true;
+            const success = await this.applicationLoader.startOpfab();
+            if (success) {
+                this.applicationLoadedDone.next(true);
+                this.applicationLoadedDone.complete();
+                this.applicationLoaded = true;
+            }
         } catch (err) {
             this.applicationLoader.loadingInProgress = false;
             logger.error('Impossible to load application', err);

--- a/ui/main/src/assets/i18n/en.json
+++ b/ui/main/src/assets/i18n/en.json
@@ -147,7 +147,8 @@
     "disconnected": "You are disconnected.",
     "disconnectedByNewUser": "You have been disconnected because another user logged in using this account.",
     "disconnectByAppLoadedInAnotherTab": "You have been disconnected because another tab of this browser was used to log in using this URL.",
-    "reloadPageButton": "Reload page"
+    "reloadPageButton": "Reload page",
+    "isNotAllowedToAccessOpfab": "You are not allowed to access the application"
   },
   "menu": {
     "feed": "Card Feed",

--- a/ui/main/src/assets/i18n/fr.json
+++ b/ui/main/src/assets/i18n/fr.json
@@ -147,7 +147,8 @@
     "disconnected": "Vous êtes déconnecté.",
     "disconnectedByNewUser": "Vous avez été déconnecté car un autre utilisateur s'est connecté avec ce compte.",
     "disconnectByAppLoadedInAnotherTab": "Vous avez été déconnecté car un autre onglet de ce navigateur a été utilisé pour se connecter à cette URL.",
-    "reloadPageButton": "Rafraîchir la page"
+    "reloadPageButton": "Rafraîchir la page",
+    "isNotAllowedToAccessOpfab": "Vous n'êtes pas autorisé à accéder à l'application"
   },
   "menu": {
     "feed": "Flux de cartes",

--- a/ui/main/src/assets/i18n/nl.json
+++ b/ui/main/src/assets/i18n/nl.json
@@ -147,7 +147,8 @@
     "disconnected": "Je bent losgekoppeld.",
     "disconnectedByNewUser": "De verbinding met u is verbroken omdat een andere gebruiker met dit account heeft ingelogd.",
     "disconnectByAppLoadedInAnotherTab": "De verbinding is verbroken omdat een ander tabblad van deze browser werd gebruikt om in te loggen met deze URL.",
-    "reloadPageButton": "Herlaad pagina"
+    "reloadPageButton": "Herlaad pagina",
+    "isNotAllowedToAccessOpfab": "U heeft geen toegang tot de applicatie"
   },
   "menu": {
     "feed": "Kaart Feed",


### PR DESCRIPTION
- Implement a feature that presents a popup and logs out users who are not attached to any group.
- Attach user `operator6_fr` to the `Readonly` group to ensure login capability, as this user is utilized in an archived Cypress test.
- Include a new Cypress test to verify the functionality of this feature.

- In release note :
  -  In chapter :  Features
  -  Text : #6240 Add an option to refuse login of a user without groups 