### PR TITLE
Remove Unnecessary BouncyCastle Dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,7 +76,6 @@ ext {
             rabbitMQ       : "com.rabbitmq:amqp-client:$rabbitMQ",
 
 //Transitive dependencies udpate needed for security reasons 
-            bouncyCastle    : "org.bouncycastle:bcprov-jdk18on:1.77",
             snakeyaml       : "org.yaml:snakeyaml:2.2",
             snappy          : "org.xerial.snappy:snappy-java:1.1.10.5"
 //End transitive dependencies

--- a/services/businessconfig/build.gradle
+++ b/services/businessconfig/build.gradle
@@ -8,7 +8,6 @@ dependencies {
 
 //Transitive dependencies udpate needed for security reasons 
     implementation misc.snakeyaml
-    implementation misc.bouncyCastle
 //End transitive dependencies
     
     compileOnly boot.annotationConfiguration

--- a/services/services.gradle
+++ b/services/services.gradle
@@ -13,7 +13,6 @@ subprojects {
 
     //Transitive dependencies udpate needed for security reasons 
         implementation misc.snakeyaml
-        implementation misc.bouncyCastle
     //End transitive dependencies
 
         testAnnotationProcessor misc.lombok


### PR DESCRIPTION
No longer required due to the removal of 'feign' in a previous version.

Nothing in release note 