### PR TITLE
Solve bug with week processing in process monitoring screen

### DIFF
--- a/ui/main/src/app/business/view/processmonitoring/processmonitoring.view.spec.ts
+++ b/ui/main/src/app/business/view/processmonitoring/processmonitoring.view.spec.ts
@@ -18,6 +18,7 @@ import {RightsEnum} from '@ofModel/perimeter.model';
 import {UserService} from 'app/business/services/users/user.service';
 import {UserServerMock} from '@tests/mocks/userServer.mock';
 import {PermissionEnum} from '@ofModel/permission.model';
+import moment from 'moment';
 
 describe('Process Monitoring view ', () => {
     let processServerMock: ProcessServerMock;
@@ -434,6 +435,7 @@ describe('Process Monitoring view ', () => {
 
     describe('get dates after period click if the current day/time is 2024-04-29 15:32 (summer time)', () => {
         beforeEach(() => {
+            moment.locale('en'); // set "en" local to have start of week on sunday
             jasmine.clock().install();
         });
 
@@ -464,6 +466,7 @@ describe('Process Monitoring view ', () => {
 
     describe('get dates after period click if the current day/time is 2023-12-31 9:18 (winter time)', () => {
         beforeEach(() => {
+            moment.locale('en'); // set "en" local to have start of week on sunday
             jasmine.clock().install();
         });
 

--- a/ui/main/src/app/business/view/processmonitoring/processmonitoring.view.ts
+++ b/ui/main/src/app/business/view/processmonitoring/processmonitoring.view.ts
@@ -278,7 +278,7 @@ export class ProcessMonitoringView {
         }
         if (periodClicked === 'week') {
             const startOfWeek = moment().startOf('week').toDate();
-            const endOfWeek = moment().endOf('week').toDate();
+            const endOfWeek = moment().endOf('week').add(1, 'days').toDate();
             return {
                 activeFrom:
                     startOfWeek.getFullYear() +
@@ -292,7 +292,7 @@ export class ProcessMonitoringView {
                     '-' +
                     String(endOfWeek.getMonth() + 1).padStart(2, '0') +
                     '-' +
-                    String(endOfWeek.getDate() + 1).padStart(2, '0') +
+                    String(endOfWeek.getDate()).padStart(2, '0') +
                     'T00:00'
             };
         }


### PR DESCRIPTION
Add one day via moment instead of adding one day to the date of month (lead to have date of month set to 32) 
Set local "en" for unit test to have the start of week set to Sunday (if not it may happens that the unit test is done with another local due to a previous unit test that have changed the local) 

Nothing in release note 