### PR TITLE
Migration guide for 4.3 is not referenced in documentation (#6357)

### DIFF
--- a/src/docs/asciidoc/resources/index.adoc
+++ b/src/docs/asciidoc/resources/index.adoc
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2023 RTE (http://www.rte-france.com)
+// Copyright (c) 2018-2024 RTE (http://www.rte-france.com)
 // See AUTHORS.txt
 // This document is subject to the terms of the Creative Commons Attribution 4.0 International license.
 // If a copy of the license was not distributed with this
@@ -65,3 +65,5 @@ include::migration_guide_to_4.0.adoc[leveloffset=+1]
 include::migration_guide_to_4.1.adoc[leveloffset=+1]
 
 include::migration_guide_to_4.2.adoc[leveloffset=+1]
+
+include::migration_guide_to_4.3.adoc[leveloffset=+1]


### PR DESCRIPTION
Nothing on release notes.