### PR TITLE
Update azul/zulu-openjdk-alpine Docker tag to v17.0.11-jre

### DIFF
--- a/bin/load_environment_light.sh
+++ b/bin/load_environment_light.sh
@@ -11,7 +11,7 @@
 
 source ${BASH_SOURCE%/*}/load_variables.sh
 
-sdk install java 17.0.10-zulu
-sdk use java 17.0.10-zulu
+sdk install java 17.0.11-zulu
+sdk use java 17.0.11-zulu
 nvm install v20.12.2
 nvm use v20.12.2

--- a/services/businessconfig/Dockerfile
+++ b/services/businessconfig/Dockerfile
@@ -1,4 +1,4 @@
-FROM azul/zulu-openjdk-alpine:17.0.10-jre@sha256:a87055ecb4be02f271e4fc13201129a01893bae5f1e541df6d30d9377851b644
+FROM azul/zulu-openjdk-alpine:17.0.11-jre@sha256:9bf1cff1512fe2bfaf21d518480d24d32e7b301d628e3a4268cd408e5b673e3f
 VOLUME /tmp
 ARG JAR_FILE
 RUN apk --no-cache add bash

--- a/services/cards-consultation/Dockerfile
+++ b/services/cards-consultation/Dockerfile
@@ -1,4 +1,4 @@
-FROM azul/zulu-openjdk-alpine:17.0.10-jre@sha256:a87055ecb4be02f271e4fc13201129a01893bae5f1e541df6d30d9377851b644
+FROM azul/zulu-openjdk-alpine:17.0.11-jre@sha256:9bf1cff1512fe2bfaf21d518480d24d32e7b301d628e3a4268cd408e5b673e3f
 VOLUME /tmp
 ARG JAR_FILE
 RUN apk --no-cache add bash

--- a/services/cards-publication/Dockerfile
+++ b/services/cards-publication/Dockerfile
@@ -1,4 +1,4 @@
-FROM azul/zulu-openjdk-alpine:17.0.10-jre@sha256:a87055ecb4be02f271e4fc13201129a01893bae5f1e541df6d30d9377851b644
+FROM azul/zulu-openjdk-alpine:17.0.11-jre@sha256:9bf1cff1512fe2bfaf21d518480d24d32e7b301d628e3a4268cd408e5b673e3f
 VOLUME /tmp
 ARG JAR_FILE
 RUN apk --no-cache add bash

--- a/services/external-devices/Dockerfile
+++ b/services/external-devices/Dockerfile
@@ -1,4 +1,4 @@
-FROM azul/zulu-openjdk-alpine:17.0.10-jre@sha256:a87055ecb4be02f271e4fc13201129a01893bae5f1e541df6d30d9377851b644
+FROM azul/zulu-openjdk-alpine:17.0.11-jre@sha256:9bf1cff1512fe2bfaf21d518480d24d32e7b301d628e3a4268cd408e5b673e3f
 VOLUME /tmp
 ARG JAR_FILE
 RUN apk --no-cache add bash

--- a/services/users/Dockerfile
+++ b/services/users/Dockerfile
@@ -1,4 +1,4 @@
-FROM azul/zulu-openjdk-alpine:17.0.10-jre@sha256:a87055ecb4be02f271e4fc13201129a01893bae5f1e541df6d30d9377851b644
+FROM azul/zulu-openjdk-alpine:17.0.11-jre@sha256:9bf1cff1512fe2bfaf21d518480d24d32e7b301d628e3a4268cd408e5b673e3f
 VOLUME /tmp
 ARG JAR_FILE
 RUN apk --no-cache add bash

--- a/src/test/dummyModbusDevice/Dockerfile
+++ b/src/test/dummyModbusDevice/Dockerfile
@@ -1,4 +1,4 @@
-FROM azul/zulu-openjdk-alpine:17.0.10-jre@sha256:a87055ecb4be02f271e4fc13201129a01893bae5f1e541df6d30d9377851b644
+FROM azul/zulu-openjdk-alpine:17.0.11-jre@sha256:9bf1cff1512fe2bfaf21d518480d24d32e7b301d628e3a4268cd408e5b673e3f
 VOLUME /tmp
 ARG JAR_FILE
 COPY build/libs/${JAR_FILE} app.jar

--- a/src/test/externalApp/Dockerfile
+++ b/src/test/externalApp/Dockerfile
@@ -1,4 +1,4 @@
-FROM azul/zulu-openjdk-alpine:17.0.10-jre@sha256:a87055ecb4be02f271e4fc13201129a01893bae5f1e541df6d30d9377851b644
+FROM azul/zulu-openjdk-alpine:17.0.11-jre@sha256:9bf1cff1512fe2bfaf21d518480d24d32e7b301d628e3a4268cd408e5b673e3f
 VOLUME /tmp
 RUN env
 ARG JAR_FILE


### PR DESCRIPTION
- In release note :
  -  In chapter :  Dependencies
  -  Text : openjdk  17.0.11