### PR TITLE
Restrict access to endPoint /rateLimiter in cards-publication to admin only (#6407)

### DIFF
--- a/services/cards-publication/src/main/java/org/opfab/cards/publication/configuration/oauth2/WebSecurityConfiguration.java
+++ b/services/cards-publication/src/main/java/org/opfab/cards/publication/configuration/oauth2/WebSecurityConfiguration.java
@@ -73,6 +73,7 @@ public class WebSecurityConfiguration {
                         .requestMatchers("/cards/translateCardField").access(authenticatedAndIpAllowed())
                         .requestMatchers("/cards/resetReadAndAcks/**").access(hasAnyUsernameAndIpAllowed("opfab"))
                         .requestMatchers(HttpMethod.DELETE, "/cards").access(hasAnyRoleAndIpAllowed(ADMIN_ROLE))
+                        .requestMatchers("/cards/rateLimiter").access(hasAnyRoleAndIpAllowed(ADMIN_ROLE))
                         .requestMatchers("/**").access(authenticatedAndIpAllowed())
                     );
         } else {
@@ -85,6 +86,7 @@ public class WebSecurityConfiguration {
                         .requestMatchers("/cards/userCard/**").access(authenticatedAndIpAllowed())
                         .requestMatchers("/cards/translateCardField").access(authenticatedAndIpAllowed())
                         .requestMatchers("/cards/resetReadAndAcks/**").access(hasAnyUsernameAndIpAllowed("opfab"))
+                        .requestMatchers("/cards/rateLimiter").access(hasAnyRoleAndIpAllowed(ADMIN_ROLE))
                         .requestMatchers("/**").permitAll()
                     );
         }

--- a/src/test/api/karate/cardTests.txt
+++ b/src/test/api/karate/cardTests.txt
@@ -28,4 +28,5 @@
       cards/externalRecipentErrors.feature        \
       cards/postCardWithRRuleRecurrence.feature   \
       cards/cardsReminder.feature                 \
-      cards/cardIdWithSpecialCharacters.feature
+      cards/cardIdWithSpecialCharacters.feature   \
+      cards/resetRateLimiter.feature

--- a/src/test/api/karate/cards/resetRateLimiter.feature
+++ b/src/test/api/karate/cards/resetRateLimiter.feature
@@ -1,0 +1,28 @@
+Feature: ResetRateLimiter
+
+
+  Background:
+
+    * def signIn = callonce read('../common/getToken.feature') { username: 'operator1_fr'}
+    * def authToken = signIn.authToken
+    * def signInAdmin = callonce read('../common/getToken.feature') { username: 'admin'}
+    * def authTokenAdmin = signInAdmin.authToken
+
+
+
+Scenario: ResetRateLimiter
+
+  # Send request without ADMIN rights
+    Given url opfabUrl + 'cardspub/cards/rateLimiter'
+    And header Authorization = 'Bearer ' + authToken
+    When method post
+    Then status 403
+
+  # Send request with ADMIN rights
+    Given url opfabUrl + 'cardspub/cards/rateLimiter'
+    And header Authorization = 'Bearer ' + authTokenAdmin
+    When method post
+    Then status 200
+
+
+    


### PR DESCRIPTION
Fix #6407

- In release note :
  -  In chapter :  Features
  -  Text : #6407 : Restrict access to endPoint /rateLimiter in cards-publication to admin only