### PR TITLE
Solve issue : Setting hidden value "sendCardsByEmail" in web-ui.json does not hide email field in settings (#6472)

### DIFF
--- a/ui/main/src/app/modules/settings/components/settings/settings.component.html
+++ b/ui/main/src/app/modules/settings/components/settings/settings.component.html
@@ -133,7 +133,7 @@
       </div>
     </div>
 
-    <div class="opfab-settings-item" *ngIf="settingsView.isSettingVisible('email')">
+    <div class="opfab-settings-item" *ngIf="settingsView.isSettingVisible('sendCardsByEmail')">
       <div class="opfab-input">
         <label for="opfab-setting-email" translate>settings.email</label>
         <input id="opfab-setting-input-email" type="email" formControlName="email" autocomplete="off">


### PR DESCRIPTION
- In release note :
  -  In chapter : Bugs 
  -  Text :  #6472 Setting hidden value "sendCardsByEmail" in web-ui.json does not hide email field in settings 