### PR TITLE
Add sound and notification when receiving child card with action PROPAGATE_READ ACK_TO_PARENT_CARD (#5879)

### DIFF
--- a/ui/main/src/app/business/services/notifications/notification-decision.ts
+++ b/ui/main/src/app/business/services/notifications/notification-decision.ts
@@ -7,7 +7,7 @@
  * This file is part of the OperatorFabric project.
  */
 
-import {LightCard, Severity} from '@ofModel/light-card.model';
+import {CardAction, LightCard, Severity} from '@ofModel/light-card.model';
 
 export class NotificationDecision {
     /* We allow a 30-minute window for a card to be considered 'recent'. This accounts for potential network issues that
@@ -79,6 +79,13 @@ export class NotificationDecision {
                 this.checkCardIsRecent(card)
             );
         }
+    }
+
+    public static isNotificationNeededForChildCard(card: LightCard) {
+        return (
+            card.actions?.includes(CardAction.PROPAGATE_READ_ACK_TO_PARENT_CARD) &&
+            (!this.lastSentCards.get(card.id) || this.checkSentCardIsRecentlyPublished(card))
+        );
     }
 
     public static isSystemNotificationToBeShownForCard(card: LightCard) {

--- a/ui/main/src/app/business/services/notifications/sound-notification.service.ts
+++ b/ui/main/src/app/business/services/notifications/sound-notification.service.ts
@@ -133,6 +133,9 @@ export class SoundNotificationService {
         OpfabStore.getLightCardStore()
             .getNewLightCards()
             .subscribe((card) => this.handleLoadedCard(card));
+        OpfabStore.getLightCardStore()
+            .getNewLightChildCards()
+            .subscribe((card) => this.handleLoadedChildCard(card));
     }
 
     public static clearOutstandingNotifications() {
@@ -144,6 +147,19 @@ export class SoundNotificationService {
         if (NotificationDecision.isSoundToBePlayedForCard(card)) {
             this.incomingCard.next(card);
             if (!OpfabStore.getFilteredLightCardStore().isCardVisibleInFeed(card))
+                AlertMessageService.sendAlertMessage({
+                    message: null,
+                    level: MessageLevel.BUSINESS,
+                    i18n: {key: 'feed.hiddenCardReceived'}
+                });
+        }
+    }
+
+    public static handleLoadedChildCard(lightCard: LightCard) {
+        if (NotificationDecision.isNotificationNeededForChildCard(lightCard)) {
+            const parentCard = OpfabStore.getLightCardStore().getLightCard(lightCard.parentCardId);
+            this.incomingCard.next(parentCard);
+            if (!OpfabStore.getFilteredLightCardStore().isCardVisibleInFeed(parentCard))
                 AlertMessageService.sendAlertMessage({
                     message: null,
                     level: MessageLevel.BUSINESS,

--- a/ui/main/src/app/business/services/notifications/system-notification.service.ts
+++ b/ui/main/src/app/business/services/notifications/system-notification.service.ts
@@ -66,10 +66,20 @@ export class SystemNotificationService {
         OpfabStore.getLightCardStore()
             .getNewLightCards()
             .subscribe((lightCard) => this.handleLoadedCard(lightCard));
+        OpfabStore.getLightCardStore()
+            .getNewLightChildCards()
+            .subscribe((card) => this.handleLoadedChildCard(card));
     }
 
     public static handleLoadedCard(lightCard: LightCard) {
         if (NotificationDecision.isSystemNotificationToBeShownForCard(lightCard)) this.incomingCard.next(lightCard);
+    }
+
+    public static handleLoadedChildCard(lightCard: LightCard) {
+        if (NotificationDecision.isNotificationNeededForChildCard(lightCard)) {
+            const parentCard = OpfabStore.getLightCardStore().getLightCard(lightCard.parentCardId);
+            this.incomingCard.next(parentCard);
+        }
     }
 
     private static initSystemNotificationForSeverity(severity: Severity) {

--- a/ui/main/src/app/modules/card/components/card-reponse/card-response.component.ts
+++ b/ui/main/src/app/modules/card/components/card-reponse/card-response.component.ts
@@ -27,6 +27,7 @@ import {CardService} from 'app/business/services/card/card.service';
 import {ServerResponseStatus} from 'app/business/server/serverResponse';
 import {OpfabAPIService} from 'app/business/services/opfabAPI.service';
 import {LoggerService as logger} from 'app/business/services/logs/logger.service';
+import {NotificationDecision} from 'app/business/services/notifications/notification-decision';
 
 class FormResult {
     valid: boolean;
@@ -189,6 +190,8 @@ export class CardResponseComponent implements OnChanges, OnInit {
                 actions: responseData.actions
             };
             this.sendingResponseInProgress = true;
+            // Exclude card from sound and system notifications before publishing to avoid synchronization problems
+            NotificationDecision.addSentCard(card.process + '.' + card.processInstanceId);
             CardService.postCard(card).subscribe((resp) => {
                 this.sendingResponseInProgress = false;
                 if (resp.status !== ServerResponseStatus.OK) {

--- a/ui/main/src/tests/helpers.ts
+++ b/ui/main/src/tests/helpers.ts
@@ -64,7 +64,23 @@ export function getOneLightCard(lightCardTemplate?: any): LightCard {
         lightCardTemplate.timeSpans ?? null,
         lightCardTemplate.rrule ?? null,
         lightCardTemplate.process ?? 'testProcess',
-        lightCardTemplate.state ?? 'testState'
+        lightCardTemplate.state ?? 'testState',
+        lightCardTemplate.parentCardId ?? null,
+        lightCardTemplate.initialParentCardUid ?? null,
+        lightCardTemplate.keepChildCards ?? false,
+        lightCardTemplate.representative ?? null,
+        lightCardTemplate.representativeType ?? null,
+        lightCardTemplate.wktGeometry ?? null,
+        lightCardTemplate.wktProjection ?? null,
+        lightCardTemplate.entitiesAcks ?? null,
+        lightCardTemplate.entityRecipients ?? null,
+        lightCardTemplate.entityRecipientsForInformation ?? null,
+        lightCardTemplate.entitiesAllowedToRespond ?? null,
+        lightCardTemplate.entitiesRequiredToRespond ?? null,
+        lightCardTemplate.entitiesAllowedToEdit ?? null,
+        lightCardTemplate.publisherType ?? null,
+        lightCardTemplate.secondsBeforeTimeSpanForReminder ?? null,
+        lightCardTemplate.actions ?? null
     );
 }
 


### PR DESCRIPTION
Fix #5879

- In release note :
  -  In chapter :  Features
  -  Text : #5879 : Add sound and notification when receiving child card with action PROPAGATE_READ ACK_TO_PARENT_CARD