### PR TITLE
Feed notification configuration screen : empty line displayed if all processes have a process group (#6549)

### DIFF
--- a/ui/main/src/app/modules/notificationconfiguration/notificationconfiguration.component.html
+++ b/ui/main/src/app/modules/notificationconfiguration/notificationconfiguration.component.html
@@ -29,7 +29,8 @@
         <br />
     </div>
     <br />
-    <div class="row opfab-notificationconfiguration-processlist opfab-notificationconfiguration-processgrid">
+    <div *ngIf="notificationConfigurationPage.processesWithNoProcessGroup.length"
+         class="row opfab-notificationconfiguration-processlist opfab-notificationconfiguration-processgrid">
         <ng-container *ngFor="let process of notificationConfigurationPage.processesWithNoProcessGroup">
             <ng-container *ngTemplateOutlet="processTemplate; context: { process: process }"></ng-container>
         </ng-container>


### PR DESCRIPTION
- In release note :
  -  In chapter : Bugs
  -  Text : #6549 : Feed notification configuration screen : empty line displayed if all processes have a process group