### PR TITLE
Add a title in built-in question card (#6668)

### DIFF
--- a/src/test/resources/bundles/messageOrQuestionExample/i18n.json
+++ b/src/test/resources/bundles/messageOrQuestionExample/i18n.json
@@ -4,7 +4,7 @@
 		"summary":"Message received"
 	},
 	"question":{
-		"title":"Question ",
+		"title":"Question - {{questionTitle}}",
 		"summary":"There is a question for you"
 	},
 	"message_or_question_list":{

--- a/ui/main/src/app/business/builtInTemplates/question/usercard/questionUserCardTemplate.ts
+++ b/ui/main/src/app/business/builtInTemplates/question/usercard/questionUserCardTemplate.ts
@@ -18,7 +18,13 @@ export class QuestionUserCardTemplate extends BaseUserCardTemplate {
     constructor() {
         super();
         this.view = new QuestionUserCardTemplateView();
+
         this.innerHTML = `
+        <br/>
+        <div class="opfab-input">
+            <label>${opfab.utils.getTranslation('builtInTemplate.questionUserCard.titleLabel')}</label>
+            <input id="usercard_question_title" value='${this.view.getTitle()}'>
+        </div>
         <br/>
         <div class="opfab-textarea">
             <label id="opfab-question-label">${opfab.utils.getTranslation('builtInTemplate.questionUserCard.textareaLabel')}</label>
@@ -30,7 +36,7 @@ export class QuestionUserCardTemplate extends BaseUserCardTemplate {
 
     getSpecificCardInformation() {
         const quillEditor = <HTMLInputElement>document.getElementById('usercard_question_input');
-
-        return this.view.getSpecificCardInformation(quillEditor);
+        const title = (<HTMLInputElement>document.getElementById('usercard_question_title')).value;
+        return this.view.getSpecificCardInformation(quillEditor, title);
     }
 }

--- a/ui/main/src/app/business/builtInTemplates/question/usercard/questionUserCardTemplateView.spec.ts
+++ b/ui/main/src/app/business/builtInTemplates/question/usercard/questionUserCardTemplateView.spec.ts
@@ -36,11 +36,12 @@ describe('Question UserCard template', () => {
         OpfabAPIService.initUserCardTemplateInterface();
     });
 
-    it('GIVEN an existing card WHEN user edit card THEN question is actual question', () => {
+    it('GIVEN an existing card WHEN user edit card THEN question and title are actual question and title', () => {
         const view = new QuestionUserCardTemplateView();
         OpfabAPIService.currentUserCard.editionMode = 'EDITION';
-        OpfabAPIService.currentCard.card = {data: {richQuestion: 'My question'}};
+        OpfabAPIService.currentCard.card = {data: {richQuestion: 'My question', questionTitle: 'My title'}};
         expect(view.getRichQuestion()).toEqual('My question');
+        expect(view.getTitle()).toEqual('My title');
     });
 
     it('GIVEN an existing card with an HTML tag in question WHEN user edit card THEN question is provide with HTML tag escaped', () => {
@@ -50,26 +51,30 @@ describe('Question UserCard template', () => {
         expect(view.getRichQuestion()).toEqual('My question &lt;script&gt;');
     });
 
-    it('GIVEN an existing card WHEN user copy card THEN question is actual question', () => {
+    it('GIVEN an existing card WHEN user copy card THEN question and title are actual question and title', () => {
         const view = new QuestionUserCardTemplateView();
         OpfabAPIService.currentUserCard.editionMode = 'COPY';
-        OpfabAPIService.currentCard.card = {data: {richQuestion: 'My question'}};
+        OpfabAPIService.currentCard.card = {data: {richQuestion: 'My question', questionTitle: 'My title'}};
         expect(view.getRichQuestion()).toEqual('My question');
+        expect(view.getTitle()).toEqual('My title');
     });
 
-    it('GIVEN a user WHEN create card THEN question is empty', () => {
+    it('GIVEN a user WHEN create card THEN title and question are empty', () => {
         const view = new QuestionUserCardTemplateView();
         OpfabAPIService.currentUserCard.editionMode = 'CREATE';
-        OpfabAPIService.currentCard.card = {data: {richQuestion: 'My question'}};
+        OpfabAPIService.currentCard.card = {data: {richQuestion: 'My question', questionTitle: 'My title'}};
         expect(view.getRichQuestion()).toEqual('');
+        expect(view.getTitle()).toEqual('');
     });
 
-    it('GIVEN a user WHEN create card with question THEN card is provided with question', () => {
+    it('GIVEN a user WHEN create card with title and question THEN card is provided with title and question', () => {
         const view = new QuestionUserCardTemplateView();
         const quillEditor = new QuillEditorMock();
         quillEditor.setContents('My question');
-        const specificCardInformation = view.getSpecificCardInformation(quillEditor);
+        const title = 'Question title';
+        const specificCardInformation = view.getSpecificCardInformation(quillEditor, title);
         expect(specificCardInformation.card.data.richQuestion).toEqual('My question');
+        expect(specificCardInformation.card.data.questionTitle).toEqual('Question title');
         expect(specificCardInformation.valid).toEqual(true);
     });
 
@@ -77,7 +82,8 @@ describe('Question UserCard template', () => {
         const view = new QuestionUserCardTemplateView();
         const quillEditor = new QuillEditorMock();
         quillEditor.setContents('');
-        const specificCardInformation = view.getSpecificCardInformation(quillEditor);
+        const title = 'Question title';
+        const specificCardInformation = view.getSpecificCardInformation(quillEditor, title);
         expect(specificCardInformation.valid).toEqual(false);
         expect(specificCardInformation.errorMsg).toEqual(
             'Translation (en) of builtInTemplate.questionUserCard.noQuestionError'

--- a/ui/main/src/app/business/builtInTemplates/question/usercard/questionUserCardTemplateView.ts
+++ b/ui/main/src/app/business/builtInTemplates/question/usercard/questionUserCardTemplateView.ts
@@ -10,11 +10,11 @@
 declare const opfab;
 
 export class QuestionUserCardTemplateView {
-    public getSpecificCardInformation(quillEditor: any) {
+    public getSpecificCardInformation(quillEditor: any, title: string) {
         const card = {
             summary: {key: 'question.summary'},
-            title: {key: 'question.title'},
-            data: {richQuestion: quillEditor.getContents()}
+            title: {key: 'question.title', parameters: {questionTitle: title}},
+            data: {richQuestion: quillEditor.getContents(), questionTitle: title}
         };
         if (quillEditor.isEmpty())
             return {
@@ -36,5 +36,16 @@ export class QuestionUserCardTemplateView {
             }
         }
         return question;
+    }
+
+    public getTitle() {
+        let title = '';
+        if (opfab.currentUserCard.getEditionMode() !== 'CREATE') {
+            const titleField = opfab.currentCard.getCard()?.data?.questionTitle;
+            if (titleField) {
+                title = titleField;
+            }
+        }
+        return title;
     }
 }

--- a/ui/main/src/app/business/services/notifications/system-notification.service.ts
+++ b/ui/main/src/app/business/services/notifications/system-notification.service.ts
@@ -34,7 +34,6 @@ export class SystemNotificationService {
         this.systemNotificationConfigBySeverity.forEach((systemNotificationConfig, severity) => {
             ConfigService.getConfigValueAsObservable(systemNotificationConfig, false).subscribe((x) => {
                 NotificationDecision.setSystemNotificationEnabledForSeverity(severity, x);
-                debugger;
                 if (NotificationDecision.isAtLeastOneSystemNotificationSeverityEnabled()) {
                     this.requestPermissionForSystemNotification();
                 }

--- a/ui/main/src/assets/i18n/en.json
+++ b/ui/main/src/assets/i18n/en.json
@@ -730,7 +730,8 @@
         },
         "questionUserCard": {
             "noQuestionError": "You must provide a question",
-            "textareaLabel": "QUESTION"
+            "textareaLabel": "QUESTION",
+            "titleLabel": "TITLE"
         },
         "taskCard": {
             "taskToDo": "You have the following task to do ",

--- a/ui/main/src/assets/i18n/fr.json
+++ b/ui/main/src/assets/i18n/fr.json
@@ -730,7 +730,8 @@
         },
         "questionUserCard": {
             "noQuestionError": "Vous devez fournir une question",
-            "textareaLabel": "QUESTION"
+            "textareaLabel": "QUESTION",
+            "titleLabel": "TITRE"
         },
         "taskCard": {
             "taskToDo": "Vous avez la tâche suivante à faire",

--- a/ui/main/src/assets/i18n/nl.json
+++ b/ui/main/src/assets/i18n/nl.json
@@ -730,7 +730,8 @@
         },
         "questionUserCard": {
             "noQuestionError": "U moet een vraag opgeven",
-            "textareaLabel": "VRAAG"
+            "textareaLabel": "VRAAG",
+            "titleLabel": "TITEL"
         },
         "taskCard": {
             "taskToDo": "U heeft de volgende taak te doen",


### PR DESCRIPTION
Fix #6668 

- In release note :
  -  In chapter :  Features
  -  Text : #6668 : Add a title in built-in question card