### PR TITLE
Remove unneeded client_id parameter in password flow (#6740)

### DIFF
--- a/cli/src/loginCommands.js
+++ b/cli/src/loginCommands.js
@@ -130,7 +130,7 @@ const loginCommands = {
         this.logout();
         console.log('Will try to login with user', this.login);
         const url = `${this.url}:${this.port}/auth/token`;
-        const body = `username=${this.login}&password=${this.password}&grant_type=password&client_id=opfab-client`;
+        const body = `username=${this.login}&password=${this.password}&grant_type=password`;
         const options = {
             method: 'POST',
             body: body,

--- a/node-services/common/src/common/server-side/opfabServicesInterface.ts
+++ b/node-services/common/src/common/server-side/opfabServicesInterface.ts
@@ -195,7 +195,7 @@ export default class OpfabServicesInterface {
             const response = await this.sendRequest({
                 method: 'post',
                 url: this.opfabGetTokenUrl,
-                data: `username=${this.login}&password=${this.password}&grant_type=password&client_id=opfab-client`
+                data: `username=${this.login}&password=${this.password}&grant_type=password`
             });
             this.token = response?.data?.access_token;
             if (this.token == null) throw new Error('No token provided , http response = ' + response);

--- a/src/docs/asciidoc/dev_env/token.adoc
+++ b/src/docs/asciidoc/dev_env/token.adoc
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2023 RTE (http://www.rte-france.com)
+// Copyright (c) 2020-2024 RTE (http://www.rte-france.com)
 // See AUTHORS.txt
 // This document is subject to the terms of the Creative Commons Attribution 4.0 International license.
 // If a copy of the license was not distributed with this
@@ -15,7 +15,6 @@ Method: `POST`
 
 Body arguments:
 
-* client_id: `string` constant=`clientIdPassword`;
 * grant_type: `string` constant=`password`;
 - username: `string` any value, must match an OperatorFabric registered user name;
 * password: `string` any value;
@@ -28,7 +27,7 @@ command:
 
 ----
 curl -s -X POST -d 
-"username=admin&password=test&grant_type=password&client_id=clientIdPassword" 
+"username=admin&password=test&grant_type=password" 
 http://localhost:2002/auth/token
 ----
 
@@ -60,7 +59,7 @@ user_info","jti":"02d82e85-13f0-4678-974d-18eb06215a65"}
 
 ----
 http --form POST http://localhost:2002/auth/token username=admin password=test 
-grant_type=password client_id=clientIdPassword
+grant_type=password
 ----
 
 example of expected result:
@@ -225,7 +224,7 @@ Here is a way to do so.
 
 [source,shell]
 ----
- curl -d "username=${user}&password=${password}&grant_type=password&client_id=opfab-client" "http://localhost:2002/auth/token" | jq -r .access_token
+ curl -d "username=${user}&password=${password}&grant_type=password" "http://localhost:2002/auth/token" | jq -r .access_token
 ----
 
 where:

--- a/src/docs/asciidoc/getting_started/index.adoc
+++ b/src/docs/asciidoc/getting_started/index.adoc
@@ -223,7 +223,7 @@ source ../getToken.sh
 This will run the following command:
 
 ----
-curl -s -X POST -d "username=admin&password=test&grant_type=password&client_id=opfab-client" http://localhost:2002/auth/token
+curl -s -X POST -d "username=admin&password=test&grant_type=password" http://localhost:2002/auth/token
 ----
 
 This should return a JSON a response like this:

--- a/src/docs/asciidoc/resources/migration_guide_to_4.4.adoc
+++ b/src/docs/asciidoc/resources/migration_guide_to_4.4.adoc
@@ -7,6 +7,11 @@
 
 = Migration Guide from release 4.3.X to release 4.4.0
 
+
+== Use of client_id to obtain token
+
+In the example script getToken.sh, a parameter client_id is set to `opfab-client`. This value was in fact not necessary and has been removed . The client_id is managed by the `web-ui` service and is not required in the authentication requests. You can remove the client_id from your scripts.
+
 == Endpoints configuration 
 
 To enhance consistency and avoid confusion, we made the following modifications to the endpoints:

--- a/src/test/api/karate/common/getToken.feature
+++ b/src/test/api/karate/common/getToken.feature
@@ -5,7 +5,6 @@ Feature: Get Token
     And form field username = username
     And form field password = 'test'
     And form field grant_type = 'password'
-    And form field client_id = 'opfab-client'
     When method post
     Then status 200
     And def authToken = response.access_token

--- a/src/test/externalApp/src/main/java/org/opfab/externalapp/security/AuthClient.java
+++ b/src/test/externalApp/src/main/java/org/opfab/externalapp/security/AuthClient.java
@@ -1,4 +1,4 @@
-/* Copyright (c) 2022, RTE (http://www.rte-france.com)
+/* Copyright (c) 2022-2024, RTE (http://www.rte-france.com)
  * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -44,7 +44,6 @@ public class AuthClient {
         map.add("username", "operator1_fr");
         map.add("password", "test");
         map.add("grant_type", "password");
-        map.add("client_id", "opfab-client");
  
         HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(map, headers);
 

--- a/src/test/gatling/src/gatling/java/org/opfab/sse/SseTest.java
+++ b/src/test/gatling/src/gatling/java/org/opfab/sse/SseTest.java
@@ -40,7 +40,6 @@ public class SseTest extends Simulation {
     .formParam("grant_type", "password")
     .formParam("username", "#{username}")
     .formParam("password", "test")
-    .formParam("client_id", "opfab-client")
     .check(jmesPath("access_token").ofString()
     .exists().saveAs("access_token")))
 

--- a/src/test/resources/getToken.sh
+++ b/src/test/resources/getToken.sh
@@ -31,7 +31,7 @@ fi
 getToken() {
 	echo "Get token for user $username on $url"
 	access_token_pattern='"access_token":"([^"]+)"'
-	response=$(curl -s -X POST -d "username="$username"&password="$password"&grant_type=password&client_id=opfab-client" $url:2002/auth/token)
+	response=$(curl -v -s -X POST -d "username="$username"&password="$password"&grant_type=password" $url:2002/auth/token)
 	if [[ $response =~ $access_token_pattern ]] ; then
 		export token=${BASH_REMATCH[1]}
 	fi

--- a/ui/main/src/app/authentication/password-authentication-handler.ts
+++ b/ui/main/src/app/authentication/password-authentication-handler.ts
@@ -1,4 +1,4 @@
-/* Copyright (c) 2023, RTE (http://www.rte-france.com)
+/* Copyright (c) 2023-2024, RTE (http://www.rte-france.com)
  * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -52,7 +52,6 @@ export class PasswordAuthenticationHandler extends AuthHandler {
         params.append('username', login);
         params.append('password', password);
         params.append('grant_type', 'password');
-        params.append('clientId', this.clientId);
         const headers = new HttpHeaders({'Content-type': 'application/x-www-form-urlencoded; charset=utf-8'});
         return this.httpClient.post<HttpAuthInfo>(this.askTokenUrl, params.toString(), {headers: headers});
     }


### PR DESCRIPTION
- In release note :
  -  In chapter :  Tasks
  -  Text : #6740  Remove unneeded client_id parameter in password flow