### PR TITLE
Add an option to set severity in built in templates (#6784)

### DIFF
--- a/src/docs/asciidoc/reference_doc/built-in_templates.adoc
+++ b/src/docs/asciidoc/reference_doc/built-in_templates.adoc
@@ -153,6 +153,7 @@ in the feed will be 'Message received : xxx'. If left empty the summary input fi
 
 For each user card templates, you can set : 
 
+- The initial severity
 - The entity recipient list 
 - The initial selected recipients 
 - The entity recipient for information list 
@@ -162,6 +163,7 @@ For each user card templates, you can set :
 For example :
 ```
 <opfab-message-usercard
+    initialSeverity="INFORMATION"
     entityRecipientList='[{"id": "ENTITY_FR", "levels": [0, 1]}, {"id": "ENTITY_IT"},{"id": "IT_SUPERVISOR_ENTITY"}]'
     initialSelectedRecipients='["ENTITY1_FR", "ENTITY2_FR", "ENTITY3_FR"]'
     entityRecipientForInformationList='[{"id": "ENTITY_FR", "levels": [0, 1]},{"id": "IT_SUPERVISOR_ENTITY"}]'

--- a/src/test/resources/bundles/messageOrQuestionExample/template/usercard_message.handlebars
+++ b/src/test/resources/bundles/messageOrQuestionExample/template/usercard_message.handlebars
@@ -1,4 +1,4 @@
-<!-- Copyright (c) 2020-2023, RTE (http://www.rte-france.com)              -->
+<!-- Copyright (c) 2020-2024, RTE (http://www.rte-france.com)              -->
 <!-- See AUTHORS.txt                                                       -->
 <!-- This Source Code Form is subject to the terms of the Mozilla Public   -->
 <!-- License, v. 2.0. If a copy of the MPL was not distributed with this   -->
@@ -7,6 +7,7 @@
 <!-- This file is part of the OperatorFabric project.                      -->
 
 <opfab-message-usercard
+    initialSeverity="INFORMATION"
     entityRecipientList='[{"id": "ENTITY_FR", "levels": [0, 1]}, {"id": "ENTITY_IT"},{"id": "IT_SUPERVISOR_ENTITY"}]'
     initialSelectedRecipients='["ENTITY1_FR", "ENTITY2_FR", "ENTITY3_FR"]'
     entityRecipientForInformationList='[{"id": "ENTITY_FR", "levels": [0, 1]},{"id": "IT_SUPERVISOR_ENTITY"}]'

--- a/ui/main/src/app/business/builtInTemplates/baseUserCardTemplate.ts
+++ b/ui/main/src/app/business/builtInTemplates/baseUserCardTemplate.ts
@@ -16,8 +16,14 @@ export abstract class BaseUserCardTemplate extends HTMLElement {
 
     constructor() {
         super();
+        this.setInitialSeverity();
         this.initRecipients();
         this.registerFunctionToGetSpecificCardInformation();
+    }
+
+    private setInitialSeverity() {
+        const initialSeverity = this.getAttribute('initialSeverity');
+        if (initialSeverity) opfab.currentUserCard.setInitialSeverity(initialSeverity);
     }
 
     private initRecipients() {


### PR DESCRIPTION
Fix #6784

- In release note :
  -  In chapter :  Features 
  -  Text : #6784 : Add an option to set severity in built in templates 