### PR TITLE
Signal mapping screen : margin on the right not correct in the table (#6371)

### DIFF
--- a/ui/main/src/app/modules/externaldevicesconfiguration/table/externaldevicesconfiguration-directive.ts
+++ b/ui/main/src/app/modules/externaldevicesconfiguration/table/externaldevicesconfiguration-directive.ts
@@ -148,7 +148,8 @@ export abstract class ExternalDevicesConfigurationDirective {
                 type: field.type,
                 headerName: field.name,
                 field: field.name,
-                colId: field.name
+                colId: field.name,
+                cellClass: field.name === 'supportedSignals' ? 'opfab-ag-cell-with-no-padding-right' : null
             };
 
             columnDefs[index] = columnDef;

--- a/ui/main/src/scss/styles.scss
+++ b/ui/main/src/scss/styles.scss
@@ -508,6 +508,10 @@ body {
         font-size: 13px;
     }
 
+    .opfab-ag-cell-with-no-padding-right {
+        padding-right: 0px;
+    }
+
     .opfab-ag-cell-with-left-padding {
         padding-left: 5px;
         padding-right: 0px;


### PR DESCRIPTION

- In release note :
  -  In chapter : Bugs
  -  Text : #6371 : Signal mapping screen : margin on the right not correct in the table 