### PR TITLE
Question usercard built-in template set title from question if empty (#6884)

### DIFF
--- a/ui/main/src/app/business/builtInTemplates/question/usercard/questionUserCardTemplateView.spec.ts
+++ b/ui/main/src/app/business/builtInTemplates/question/usercard/questionUserCardTemplateView.spec.ts
@@ -90,4 +90,32 @@ describe('Question UserCard template', () => {
             'Translation (en) of builtInTemplate.questionUserCard.noQuestionError'
         );
     });
+
+    it('GIVEN a user WHEN create card with empty title AND question text has multiple lines THEN title is the first line of question text', () => {
+        const view = new QuestionUserCardTemplateView();
+        const quillEditor = new QuillEditorMock();
+        quillEditor.setContents(
+            '{"ops":[{"insert":"Question\\n"},{"attributes":{"bold":true},"insert":"first line in bold"},{"insert":"\\n"},{"attributes":{"color":"#e60000"},"insert":"second line red"},{"insert":"\\n"}]}'
+        );
+        const title = '';
+
+        const specificCardInformation = view.getSpecificCardInformation(quillEditor, title);
+        expect(specificCardInformation.valid).toEqual(true);
+        expect(specificCardInformation.card.title.parameters.questionTitle).toEqual('Question');
+    });
+
+    it('GIVEN a user WHEN create card with empty title AND question text is longer than 30 characters THEN title is the first 30 characters of question text', () => {
+        const view = new QuestionUserCardTemplateView();
+        const quillEditor = new QuillEditorMock();
+        quillEditor.setContents(
+            '{"ops":[{"insert":"France-England\'s interconnection is 100% operational / Result of the maintenance is <OK>"}]}'
+        );
+        const title = '';
+
+        const specificCardInformation = view.getSpecificCardInformation(quillEditor, title);
+        expect(specificCardInformation.valid).toEqual(true);
+        expect(specificCardInformation.card.title.parameters.questionTitle).toEqual(
+            "France-England's interconnecti..."
+        );
+    });
 });

--- a/ui/main/src/app/business/builtInTemplates/question/usercard/questionUserCardTemplateView.ts
+++ b/ui/main/src/app/business/builtInTemplates/question/usercard/questionUserCardTemplateView.ts
@@ -12,10 +12,15 @@ declare const opfab;
 export class QuestionUserCardTemplateView {
     public getSpecificCardInformation(quillEditor: any, title: string) {
         const severity = opfab.currentUserCard.severity ?? 'ACTION';
-
+        let question_title = title;
+        if (title?.length === 0) {
+            question_title = opfab.richTextEditor.getPlainText(quillEditor.getContents());
+            question_title = question_title.split(/\r\n|\r|\n/g)[0];
+            if (question_title.length > 33) question_title = question_title.substring(0, 30) + '...';
+        }
         const card = {
             summary: {key: 'question.summary'},
-            title: {key: 'question.title', parameters: {questionTitle: title}},
+            title: {key: 'question.title', parameters: {questionTitle: question_title}},
             data: {richQuestion: quillEditor.getContents(), questionTitle: title},
             severity: severity
         };

--- a/ui/main/src/assets/js/opfab.js
+++ b/ui/main/src/assets/js/opfab.js
@@ -160,6 +160,27 @@ opfab.richTextEditor = {
         return html;
     },
 
+    getPlainText: function(delta) {
+        let delta_obj = null;
+        if (typeof delta === 'string') delta_obj = JSON.parse(delta);
+        else if (typeof delta === 'object') delta_obj = delta;
+
+        if (delta_obj === null || !('ops' in delta_obj)) throw "Can't convert invalid Quill Delta to plaintext!";
+
+        let plaintext = '';
+        for (let i = 0; i < delta_obj.ops.length; i++) {
+            const op = delta_obj.ops[i];
+            if (op.insert) {
+                if (typeof op.insert === 'string') {
+                    plaintext += op.insert;
+                } else {
+                    plaintext += ' ';
+                }
+            }
+        }
+        return plaintext;
+    },
+
     getJson: function (input) {
         if (input) {
             const element = document.createElement('textarea');


### PR DESCRIPTION
Fix #6884

- In release note :
  -  In chapter :  Features 
  -  Text : #6884 : Question usercard built-in template set title from question if empty 