### PR TITLE
Opfab cli: wrong autocompletion for perimeters command (#6905)

### DIFF
--- a/cli/src/index.js
+++ b/cli/src/index.js
@@ -69,7 +69,7 @@ omelette('opfab').tree({
         'login',
         'logout',
         'monitoringconfig',
-        'perimeter',
+        'perimeters',
         'processgroups',
         'realtimescreen',
         'service',
@@ -82,7 +82,7 @@ omelette('opfab').tree({
         load: listFiles,
         delete: []
     },
-    perimeter: {
+    perimeters: {
         create: listFiles,
         addtogroup: [],
         delete: []


### PR DESCRIPTION
- In release note :
  -  In chapter : Bugs
  -  Text : #6905 : Opfab cli : wrong autocompletion for perimeters command