### PR TITLE
Set as impossible to load a perimeter with no right field (#6753)

### DIFF
--- a/services/users/src/main/java/org/opfab/users/services/PerimetersService.java
+++ b/services/users/src/main/java/org/opfab/users/services/PerimetersService.java
@@ -28,6 +28,7 @@ public class PerimetersService {
 
     private static final String PERIMETER_NOT_FOUND_MSG = "Perimeter %s not found";
     private static final String DUPLICATE_STATE_IN_PERIMETER = "Bad stateRights list : there is one or more duplicate state(s) in the perimeter";
+    private static final String STATE_OR_RIGHT_MISSING = "Bad stateRights list : state or right field is missing for perimeter %s";
     private static final String PERIMETER_ALREADY_EXIST = "Creation failed because perimeter %s already exist";
     private static final String BAD_GROUP_LIST_MSG = "Bad group list : group %s not found";
     private static final String GROUP_NOT_FOUND_MSG = "Group %s not found";
@@ -78,6 +79,17 @@ public class PerimetersService {
 
     }
 
+    private boolean areStateAndRightFilled(Perimeter perimeter) {
+        if ((perimeter != null) && (perimeter.getStateRights() != null)) {
+            for (StateRight stateRight : perimeter.getStateRights()) {
+                if ((stateRight == null) || (stateRight.getState() == null) || (stateRight.getRight() == null)) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
     private boolean isEachStateUniqueInPerimeter(Perimeter perimeter) {
 
         if ((perimeter != null) && (perimeter.getStateRights().size() > 1)) {
@@ -97,6 +109,12 @@ public class PerimetersService {
 
     public OperationResult<EntityCreationReport<Perimeter>> updatePerimeter(Perimeter perimeter) {
         IdFormatChecker.IdCheckResult formatCheckResult = IdFormatChecker.check(perimeter.getId());
+
+        if (!areStateAndRightFilled(perimeter)) {
+            return new OperationResult<>(null, false, OperationResult.ErrorType.BAD_REQUEST,
+                    String.format(STATE_OR_RIGHT_MISSING, perimeter.getId()));
+        }
+
         if (formatCheckResult.isValid()) {
             boolean isAlreadyExisting = perimeterRepository.findById(perimeter.getId()).isPresent();
             if (!isEachStateUniqueInPerimeter(perimeter))

--- a/services/users/src/main/modeling/swagger.yaml
+++ b/services/users/src/main/modeling/swagger.yaml
@@ -177,6 +177,9 @@ definitions:
       filteringNotificationAllowed:
         type: boolean
         description: When set to false, the user can not unselect the state in the notification configuration screen.
+    required:
+      - state
+      - right
     example:
       state: State1
       right: Receive

--- a/services/users/src/test/java/org/opfab/users/services/PerimetersServiceShould.java
+++ b/services/users/src/test/java/org/opfab/users/services/PerimetersServiceShould.java
@@ -314,6 +314,64 @@ public class PerimetersServiceShould {
             assertThat(perimeterRepositoryStub.findById("perimeter1").get().getProcess()).isEqualTo("processTest");
         }
 
+        @Test
+        void GIVEN_A_Perimeter_With_A_State_And_No_Corresponding_Right_WHEN_Create_Perimeter_THEN_Return_BAD_REQUEST() {
+
+            Perimeter perimeter = new Perimeter();
+            perimeter.setId("INVALID");
+            perimeter.setProcess("process2");
+            StateRight stateRight1 = new StateRight("state1", RightsEnum.ReceiveAndWrite, true);
+            StateRight stateRight2 = new StateRight("state2", null, true);
+
+            List<StateRight> stateRights = new ArrayList<>();
+            stateRights.add(stateRight1);
+            stateRights.add(stateRight2);
+            perimeter.setStateRights(stateRights);
+
+            OperationResult<EntityCreationReport<Perimeter>> result = perimetersService.updatePerimeter(perimeter);
+            assertThat(result.isSuccess()).isFalse();
+            assertThat(result.getErrorType()).isEqualTo(OperationResult.ErrorType.BAD_REQUEST);
+            assertThat(result.getErrorMessage()).isEqualTo("Bad stateRights list : state or right field is missing for perimeter INVALID");
+        }
+
+        @Test
+        void GIVEN_A_Perimeter_With_A_Right_And_No_Corresponding_State_WHEN_Create_Perimeter_THEN_Return_BAD_REQUEST() {
+
+            Perimeter perimeter = new Perimeter();
+            perimeter.setId("INVALID");
+            perimeter.setProcess("process2");
+            StateRight stateRight1 = new StateRight("state1", RightsEnum.ReceiveAndWrite, true);
+            StateRight stateRight2 = new StateRight(null, RightsEnum.ReceiveAndWrite, true);
+
+            List<StateRight> stateRights = new ArrayList<>();
+            stateRights.add(stateRight1);
+            stateRights.add(stateRight2);
+            perimeter.setStateRights(stateRights);
+
+            OperationResult<EntityCreationReport<Perimeter>> result = perimetersService.updatePerimeter(perimeter);
+            assertThat(result.isSuccess()).isFalse();
+            assertThat(result.getErrorType()).isEqualTo(OperationResult.ErrorType.BAD_REQUEST);
+            assertThat(result.getErrorMessage()).isEqualTo("Bad stateRights list : state or right field is missing for perimeter INVALID");
+        }
+
+        @Test
+        void GIVEN_A_Perimeter_With_A_Null_StateRight_WHEN_Create_Perimeter_THEN_Return_BAD_REQUEST() {
+
+            Perimeter perimeter = new Perimeter();
+            perimeter.setId("INVALID");
+            perimeter.setProcess("process2");
+            StateRight stateRight1 = new StateRight("state1", RightsEnum.ReceiveAndWrite, true);
+            StateRight stateRight2 = null;
+            List<StateRight> stateRights = new ArrayList<>();
+            stateRights.add(stateRight1);
+            stateRights.add(stateRight2);
+            perimeter.setStateRights(stateRights);
+
+            OperationResult<EntityCreationReport<Perimeter>> result = perimetersService.updatePerimeter(perimeter);
+            assertThat(result.isSuccess()).isFalse();
+            assertThat(result.getErrorType()).isEqualTo(OperationResult.ErrorType.BAD_REQUEST);
+            assertThat(result.getErrorMessage()).isEqualTo("Bad stateRights list : state or right field is missing for perimeter INVALID");
+        }
     }
 
     @Nested


### PR DESCRIPTION
- In release note :
  -  In chapter :  Features
  -  Text : #6753 : Set as impossible to load a perimeter with no right field