### PR TITLE
Don't display confirmation pop up if no changes have been made (#6863)

### DIFF
--- a/src/test/cypress/cypress/integration/ActivityArea.spec.js
+++ b/src/test/cypress/cypress/integration/ActivityArea.spec.js
@@ -203,11 +203,20 @@ describe('ActivityAreaPage', () => {
         opfab.loginWithUser('operator1_fr');
         opfab.navigateToActivityArea();
         cy.delayRequestResponse('/users/users/**');
+
+        // We disconnect operator1_fr from 'Control Center FR North'
+        cy.get('.opfab-checkbox').contains('Control Center FR North').click();
         cy.get('#opfab-activityarea-btn-confirm').should('exist').click(); // click confirm settings
         cy.get('#opfab-activityarea-btn-yes').should('exist').click(); // click yes on the confirmation popup
         cy.waitDefaultTime();
         opfab.checkLoadingSpinnerIsDisplayed();
         opfab.checkLoadingSpinnerIsNotDisplayed();
+
+        // We reconnect operator1_fr to 'Control Center FR North'
+        opfab.navigateToActivityArea();
+        cy.get('.opfab-checkbox').contains('Control Center FR North').click();
+        cy.get('#opfab-activityarea-btn-confirm').should('exist').click(); // click confirm settings
+        cy.get('#opfab-activityarea-btn-yes').should('exist').click(); // click yes on the confirmation popup
     });
 
     it('Check message is displayed when user has no activity area', function () {

--- a/ui/main/src/app/modules/activityarea/activityarea.component.ts
+++ b/ui/main/src/app/modules/activityarea/activityarea.component.ts
@@ -81,7 +81,9 @@ export class ActivityareaComponent implements OnInit, OnDestroy {
         if (this.saveSettingsInProgress) return; // avoid multiple clicks
         this.saveSettingsInProgress = true;
 
-        if (this.confirmationPopup) this.confirmationPopup.close();
+        if (this.confirmationPopup) {
+            this.confirmationPopup.close();
+        }
 
         const resp = await firstValueFrom(this.activityAreaView.saveActivityArea());
         this.saveSettingsInProgress = false;
@@ -90,7 +92,9 @@ export class ActivityareaComponent implements OnInit, OnDestroy {
             this.messageAfterSavingSettings = 'shared.error.impossibleToSaveSettings';
             this.displaySendResultError = true;
         }
-        if (this.confirmationPopup) this.confirmationPopup.close();
+        if (this.confirmationPopup) {
+            this.confirmationPopup.close();
+        }
         this.confirm.emit();
     }
 
@@ -100,13 +104,17 @@ export class ActivityareaComponent implements OnInit, OnDestroy {
         // it results with nothing in the feed
         // This happens because the method this.LightCardsStoreService.removeAllLightCards();
         // is called too late (in activityAreaView)
-        if (!this.saveSettingsInProgress) this.confirmationPopup.close();
+        if (!this.saveSettingsInProgress) {
+            this.confirmationPopup.close();
+        }
     }
 
     openConfirmSaveSettingsModal(content) {
-        if (this.askConfirmation)
+        if (this.askConfirmation && this.activityAreaView.doesActivityAreasNeedToBeSaved()) {
             this.confirmationPopup = this.modalService.open(content, {centered: true, backdrop: 'static'});
-        else this.confirmSaveSettings();
+        } else {
+            this.confirmSaveSettings();
+        }
     }
 
     isEllipsisActive(id: string): boolean {


### PR DESCRIPTION
- In release note :
  -  In chapter :  Features
  -  Text : #6863 : Don't display confirmation pop up if no changes have been made