### PR TITLE
Message card used for stress test has empty message (#6859)

### DIFF
--- a/src/test/resources/cardsForStressTests/defaultProcess/message.json
+++ b/src/test/resources/cardsForStressTests/defaultProcess/message.json
@@ -18,7 +18,7 @@
 	"endDate" : 28800000 ,
 	"summary" : {"key" : "message.summary"},
 	"title" : {"key" : "message.title"},
-	"data" : {"message":" Information card number 1"},
+	"data" : {"richMessage":" Information card number 1"},
 	"timeSpans" : [
 		{"start" :7200000},
 		{"start" : 28800000}


### PR DESCRIPTION
Nothing in release notes.