### PR TITLE
Do not show "create copy" if user is not allowed to send card (#6878)

### DIFF
--- a/ui/main/src/app/modules/card/components/card-actions/card-actions.component.ts
+++ b/ui/main/src/app/modules/card/components/card-actions/card-actions.component.ts
@@ -72,6 +72,7 @@ export class CardActionsComponent implements OnChanges, OnDestroy {
             this.doesTheUserHavePermissionToDeleteCard();
 
         this.showCreateCopyButton =
+            !this.isReadOnlyUser &&
             this.cardState.copyCardEnabledOnUserInterface &&
             this.cardState.userCard &&
             UserService.isWriteRightsForProcessAndState(this.card.process, this.card.state);


### PR DESCRIPTION
- In release note :
  -  In chapter : Bugs
  -  Text : #6878 : Do not show "create copy" if user is not allowed to send card