### PR TITLE
Interval between sound should be better controlled in settings screen (#6881)

### DIFF
--- a/ui/main/src/app/modules/settings/components/settings/settings.component.html
+++ b/ui/main/src/app/modules/settings/components/settings/settings.component.html
@@ -66,7 +66,8 @@
       </div>
       <div class="opfab-input">
         <label for="opfab-setting-replayInterval" translate>settings.replayInterval</label>
-        <input id="opfab-setting-input-replayInterval" type="number" formControlName="replayInterval">
+        <input id="opfab-setting-input-replayInterval" type="number" min="0" formControlName="replayInterval"
+               oninput="if (this.value < 0) this.value = '';">
       </div>
     </div>
 


### PR DESCRIPTION
- In release note :
  -  In chapter : Features
  -  Text : #6881 : Interval between sound should be better controlled in settings screen