### PR TITLE
Settings screen: "Interval between sound replays" is set to 5 when entering a string on firefox (#6998)

### DIFF
--- a/ui/main/src/app/business/view/settings/settings.view.spec.ts
+++ b/ui/main/src/app/business/view/settings/settings.view.spec.ts
@@ -119,6 +119,40 @@ describe('Settings view ', () => {
             expect(ConfigService.getConfigValue('settings.locale')).toBe('en');
         });
 
+        it(
+            'should return the default value of 5 if replayInterval is set to a string value in the local configuration ' +
+                'when saveSettings is called',
+            async () => {
+                settingsView.setSetting('replayInterval', 'aStringValue');
+                await settingsView.saveSettings();
+                expect(ConfigService.getConfigValue('settings.replayInterval')).toBe(5);
+            }
+        );
+
+        it(
+            'should return the default value of 5 if replayInterval is set to null in the local configuration ' +
+                'when saveSettings is called',
+            async () => {
+                settingsView.setSetting('replayInterval', null);
+                await settingsView.saveSettings();
+                expect(ConfigService.getConfigValue('settings.replayInterval')).toBe(5);
+            }
+        );
+
+        it(
+            'should return the previous value set by the user (here, 28) if replayInterval is set to null in the local configuration ' +
+                'when saveSettings is called',
+            async () => {
+                settingsView.setSetting('replayInterval', 28);
+                await settingsView.saveSettings();
+                expect(ConfigService.getConfigValue('settings.replayInterval')).toBe(28);
+
+                settingsView.setSetting('replayInterval', null);
+                await settingsView.saveSettings();
+                expect(ConfigService.getConfigValue('settings.replayInterval')).toBe(28);
+            }
+        );
+
         it('should save settings in the back end when saveSettings is called', async () => {
             const serverResponse = await settingsView.saveSettings();
             expect(serverResponse.status).toBe(ServerResponseStatus.OK);

--- a/ui/main/src/app/business/view/settings/settings.view.ts
+++ b/ui/main/src/app/business/view/settings/settings.view.ts
@@ -25,11 +25,10 @@ export class SettingsView {
     }
 
     public getSetting(setting: string): string | boolean | number {
-        const settingValue = ConfigService.getConfigValue('settings.' + setting);
-        if (settingValue == null && setting === 'replayInterval') {
-            return 5;
+        if (setting === 'replayInterval') {
+            return ConfigService.getConfigValue('settings.replayInterval', 5);
         }
-        return settingValue;
+        return ConfigService.getConfigValue('settings.' + setting);
     }
 
     public async isExternalDeviceSettingVisible(): Promise<boolean> {
@@ -75,8 +74,16 @@ export class SettingsView {
         return true;
     }
 
+    private isReplayIntervalInvalid(): boolean {
+        return this.newSettings?.replayInterval == null || isNaN(this.newSettings?.replayInterval);
+    }
+
     public async saveSettings(): Promise<ServerResponse<any>> {
         if (this.doesSettingsNeedToBeSaved()) {
+            if (this.isReplayIntervalInvalid()) {
+                this.newSettings.replayInterval = ConfigService.getConfigValue('settings.replayInterval', 5);
+            }
+
             const serverResponse = await firstValueFrom(SettingsService.patchUserSettings(this.newSettings));
             if (serverResponse.status === ServerResponseStatus.OK) {
                 for (const setting in this.newSettings) {


### PR DESCRIPTION
- In release note :
  -  In chapter : Bugs
  -  Text : #6998 : Settings screen: "Interval between sound replays" is set to 5 when entering a string on firefox