### PR TITLE
Monitoring processus screen : fields not in default config are not displayed (#7039)

### DIFF
--- a/ui/main/src/app/modules/processmonitoring/processmonitoring.component.ts
+++ b/ui/main/src/app/modules/processmonitoring/processmonitoring.component.ts
@@ -431,7 +431,7 @@ export class ProcessMonitoringComponent implements OnDestroy, OnInit, AfterViewI
         this.columnFilters.forEach((filter) => localFilters.push(filter));
 
         const selectedFields: string[] = [];
-        this.processMonitoringFieldsDefaultConfig.forEach((column) => {
+        this.processMonitoringFields.forEach((column) => {
             selectedFields.push(column.field);
         });
         if (this.isMapEnabled && this.isMapViewActivated) {


### PR DESCRIPTION
- In release note :
  -  In chapter : Bugs
  -  Text : #7039 : Monitoring processus screen : fields not in default config are not displayed