### PR TITLE
Move monitoring process configuration in a specific configuration file loaded via businessconfig API (#6734)

### DIFF
--- a/cli/src/commands.js
+++ b/cli/src/commands.js
@@ -21,6 +21,7 @@ const businessData = require('./businessDataCommands.js');
 const service = require('./serviceCommands.js');
 const bundleCommand = require('./bundleCommands.js');
 const monitoringConfig = require('./monitoringConfigCommands.js');
+const processMonitoring = require('./processMonitoringCommands.js');
 const connectedUsers = require('./connectedUsersCommands.js');
 const users = require('./usersCommands.js');
 const entities = require('./entitiesCommands');
@@ -69,6 +70,10 @@ const commands = {
             case 'monitoringconfig':
                 this.exitIfNotLoggedIn();
                 await monitoringConfig.processMonitoringConfigCommand(args.slice(1));
+                break;
+            case 'processmonitoring':
+                this.exitIfNotLoggedIn();
+                await processMonitoring.processProcessMonitoringCommand(args.slice(1));
                 break;
             case 'processgroups':
                 this.exitIfNotLoggedIn();
@@ -167,24 +172,25 @@ const commands = {
     
     Command list :
     
-        bundle           Load or delete a bundle
-        businessdata     Load or delete business data
-        card             Send a card, delete a card or reset the card limiter for sending cards 
-        commands         Executes commands list read from input file
-        config           Set, get or list opfab cli configuration values
-        connectedusers   Send a message to subscriptions
-        entities         Load a list of entities
-        groups           Load a list of groups
-        help             Show help on a command using help <command> or all commands using help  
-        login            Log in to opfab
-        logout           Log out to opfab
-        monitoringconfig Load or delete a configuration for monitoring screen
-        perimeters       Create or delete perimeters
-        processgroups    Load or clear processgroups
-        realtimescreen   Load real time screen definition file
-        service          Get or set log level for services
-        status           Show login status
-        users            Set or unset process/state notifications
+        bundle                  Load or delete a bundle
+        businessdata            Load or delete business data
+        card                    Send a card, delete a card or reset the card limiter for sending cards 
+        commands                Executes commands list read from input file
+        config                  Set, get or list opfab cli configuration values
+        connectedusers          Send a message to subscriptions
+        entities                Load a list of entities
+        groups                  Load a list of groups
+        help                    Show help on a command using help <command> or all commands using help  
+        login                   Log in to opfab
+        logout                  Log out to opfab
+        monitoringconfig        Load or delete a configuration for monitoring screen
+        perimeters              Create or delete perimeters
+        processgroups           Load or clear processgroups
+        processmonitoring       Load configuration for monitoring processus screen
+        realtimescreen          Load real time screen definition file
+        service                 Get or set log level for services
+        status                  Show login status
+        users                   Set or unset process/state notifications
     
     `);
         } else {
@@ -227,6 +233,9 @@ const commands = {
                     break;
                 case 'monitoringconfig':
                     monitoringConfig.printHelp();
+                    break;
+                case 'processmonitoring':
+                    processmonitoring.printHelp();
                     break;
                 case 'users':
                     users.printHelp();

--- a/cli/src/index.js
+++ b/cli/src/index.js
@@ -61,6 +61,7 @@ omelette('opfab').tree({
         'monitoringconfig',
         'perimeters',
         'processgroups',
+        'processmonitoring',
         'realtimescreen',
         'service',
         'status',
@@ -80,6 +81,9 @@ omelette('opfab').tree({
     processgroups: {
         load: listFiles,
         clear: []
+    },
+    processmonitoring: {
+        load: listFiles
     },
     realtimescreen: {
         load: listFiles

--- a/cli/src/processMonitoringCommands.js
+++ b/cli/src/processMonitoringCommands.js
@@ -1,0 +1,69 @@
+/* Copyright (c) 2024, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
+ */
+
+const prompts = require('prompts');
+const config = require('./configCommands');
+const utils = require('./utils');
+const fs = require('fs').promises;
+
+const processMonitoringCommands = {
+    async processProcessMonitoringCommand(args) {
+        let command = args[0];
+        if (!command) {
+            command = (
+                await prompts({
+                    type: 'select',
+                    name: 'value',
+                    message: 'Process Monitoring Config command',
+                    choices: [
+                        {title: 'load', value: 'load'}
+                    ]
+                })
+            ).value;
+            if (!command) {
+                console.log('Proceess Monitoring Config command is required');
+                return;
+            }
+        }
+        if (command === 'load') {
+            await this.loadProcessMonitoringConfigFile(args[1]);
+        } else {
+            console.log(`Unknown Process Monitoring Config command : ${command}
+                `);
+            await this.printHelp();
+        }
+    },
+
+    async loadProcessMonitoringConfigFile(monitoringConfigFile) {
+        if (!monitoringConfigFile) {
+            monitoringConfigFile = (
+                await prompts({
+                    type: 'text',
+                    name: 'value',
+                    message: 'Process Monitoring Config file name '
+                })
+            ).value;
+            if (!monitoringConfigFile) {
+                console.log('Process Monitoring Config file name is required');
+                return;
+            }
+        }
+        utils.sendFile('businessconfig/processmonitoring', monitoringConfigFile);
+    },
+
+    async printHelp() {
+        console.log(`Usage: opfab processmonitoring <command> [args]
+
+Command list :
+
+    load      load configuration for monitoring processus screen : opfab processmonitoring load <fileName>        
+        `);
+    }
+};
+module.exports = processMonitoringCommands;

--- a/client/businessconfig/src/main/modeling/config.json
+++ b/client/businessconfig/src/main/modeling/config.json
@@ -19,6 +19,7 @@
     "TypeOfStateEnum": "org.opfab.businessconfig.model.TypeOfStateEnum",
     "EpochDate": "java.time.Instant",
     "LongInteger": "java.lang.Long",
-    "MonitoringExportFieldTypeEnum":"org.opfab.cards.model.MonitoringExportFieldTypeEnum"
+    "MonitoringExportFieldTypeEnum": "org.opfab.cards.model.MonitoringExportFieldTypeEnum",
+    "ProcessMonitoringFieldTypeEnum": "org.opfab.cards.model.ProcessMonitoringFieldTypeEnum"
   }
 }

--- a/config/docker/ui-config/web-ui.json
+++ b/config/docker/ui-config/web-ui.json
@@ -152,43 +152,5 @@
   "usercard": {
     "useDescriptionFieldForEntityList": false
   },
-  "processMonitoring": {
-    "fields": [
-      { "field": "startDate", "type": "date", "colName": "Start Date", "size": "200"},
-      { "field": "titleTranslated", "colName": "Title", "size": "250"},
-      { "field": "entityRecipients", "type": "array", "colName": "Entity Recipients", "size": "400"},
-      { "field": "data.stateName", "colName": "My field", "size": "300"},
-      { "field": "summaryTranslated", "colName": "Summary", "size": "250"},
-      { "field": "data.error", "colName": "My second field", "size": "100"}
-    ],
-    "fieldsForProcesses": {
-      "conferenceAndITIncidentExample" : [
-        { "field": "startDate", "type": "date", "colName": "Start Date", "size": "200"},
-        { "field": "titleTranslated", "colName": "Title", "size": "250"},
-        { "field": "entityRecipients", "type": "array", "colName": "Entity Recipients", "size": "400"}
-      ],
-      "messageOrQuestionExample" : [
-        { "field": "startDate", "type": "date", "colName": "Start Date", "size": "200"},
-        { "field": "endDate", "type": "date", "colName": "End Date", "size": "200"},
-        { "field": "titleTranslated", "colName": "Title", "size": "250"},
-        { "field": "entityRecipients", "type": "array", "colName": "Entity Recipients", "size": "400"}
-      ]
-    },
-
-    "filters": {
-      "tags": {
-        "list": [
-          {
-            "label": "Label for tag 1",
-            "value": "tag1"
-          },
-          {
-            "label": "Label for tag 2",
-            "value": "tag2"
-          }
-        ]
-      }
-    }
-  },
   "customJsToLoad": ["http://localhost:2002/externalJs/handlebarsExample.js","http://localhost:2002/externalJs/loadTags.js"]
 }

--- a/services/businessconfig/src/main/java/org/opfab/businessconfig/controllers/BusinessconfigController.java
+++ b/services/businessconfig/src/main/java/org/opfab/businessconfig/controllers/BusinessconfigController.java
@@ -302,7 +302,9 @@ public class BusinessconfigController {
                 processService.updateRealTimeScreensFile(new String(file.getBytes()));
             if (endPointName.equals("businessdata"))
                 processService.updateBusinessDataFile(new String(file.getBytes()), resourceName);
-
+            if (endPointName.equals("processmonitoring"))
+                processService.updateProcessMonitoringFile(new String(file.getBytes()));
+                
             response.addHeader(LOCATION, request.getContextPath() + "/businessconfig/" + endPointName);
             response.setStatus(201);
             return null;
@@ -418,6 +420,18 @@ public class BusinessconfigController {
                     .message("unable to delete submitted resource").error(e.getMessage()).build(),
                     message, e);
         }
+    }
+
+    @PostMapping(value = "/processmonitoring", produces = { "application/json" }, consumes = {
+        "multipart/form-data" })
+    public Void uploadProcessMonitoring(HttpServletRequest request, HttpServletResponse response,
+            @Valid @RequestPart("file") MultipartFile file) {
+        return uploadFile(request, response, file, "processmonitoring", null);
+    }
+
+    @GetMapping(value = "/processmonitoring", produces = { "application/json" })
+    public ProcessMonitoring getProcessMonitoring(HttpServletRequest request, HttpServletResponse response) {
+        return processService.getProcessMonitoring();
     }
 
 }

--- a/services/businessconfig/src/main/java/org/opfab/businessconfig/model/ProcessMonitoring.java
+++ b/services/businessconfig/src/main/java/org/opfab/businessconfig/model/ProcessMonitoring.java
@@ -1,0 +1,29 @@
+/* Copyright (c) 2024, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
+ */
+
+package org.opfab.businessconfig.model;
+
+import java.util.List;
+import org.springframework.validation.annotation.Validated;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+/**
+ * Configuration for the process monitoring screen
+ */
+
+@Validated
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record ProcessMonitoring (
+    List<ProcessMonitoringField> fields,
+    List<ProcessMonitoringFieldsForProcess> fieldsForProcesses,
+    ProcessMonitoringFilters filters
+) {
+}
+
+

--- a/services/businessconfig/src/main/java/org/opfab/businessconfig/model/ProcessMonitoringField.java
+++ b/services/businessconfig/src/main/java/org/opfab/businessconfig/model/ProcessMonitoringField.java
@@ -1,0 +1,20 @@
+/* Copyright (c) 2024, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
+ */
+
+package org.opfab.businessconfig.model;
+
+import org.springframework.validation.annotation.Validated;
+
+@Validated
+public record ProcessMonitoringField (
+    String field,
+    String colName,
+    ProcessMonitoringFieldTypeEnum type,
+    Integer size
+) {}

--- a/services/businessconfig/src/main/java/org/opfab/businessconfig/model/ProcessMonitoringFieldTypeEnum.java
+++ b/services/businessconfig/src/main/java/org/opfab/businessconfig/model/ProcessMonitoringFieldTypeEnum.java
@@ -1,0 +1,44 @@
+/* Copyright (c) 2024, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
+ */
+
+package org.opfab.businessconfig.model;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+public enum ProcessMonitoringFieldTypeEnum {
+
+  STRING("string"),
+
+  DATE("date"),
+
+  ARRAY("array");
+
+  private String value;
+
+  ProcessMonitoringFieldTypeEnum(String value) {
+    this.value = value;
+  }
+
+  @Override
+  @JsonValue
+  public String toString() {
+    return String.valueOf(value);
+  }
+
+  @JsonCreator
+  public static ProcessMonitoringFieldTypeEnum fromValue(String text) {
+    for (ProcessMonitoringFieldTypeEnum b : ProcessMonitoringFieldTypeEnum.values()) {
+      if (String.valueOf(b.value).equals(text)) {
+        return b;
+      }
+    }
+    return null;
+  }
+}

--- a/services/businessconfig/src/main/java/org/opfab/businessconfig/model/ProcessMonitoringFieldsForProcess.java
+++ b/services/businessconfig/src/main/java/org/opfab/businessconfig/model/ProcessMonitoringFieldsForProcess.java
@@ -1,0 +1,20 @@
+/* Copyright (c) 2024, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
+ */
+
+package org.opfab.businessconfig.model;
+
+import java.util.List;
+
+import org.springframework.validation.annotation.Validated;
+
+@Validated
+public record ProcessMonitoringFieldsForProcess (
+    String process,
+    List<ProcessMonitoringField> fields
+) {}

--- a/services/businessconfig/src/main/java/org/opfab/businessconfig/model/ProcessMonitoringFilterTag.java
+++ b/services/businessconfig/src/main/java/org/opfab/businessconfig/model/ProcessMonitoringFilterTag.java
@@ -1,0 +1,18 @@
+/* Copyright (c) 2024, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
+ */
+
+package org.opfab.businessconfig.model;
+
+import org.springframework.validation.annotation.Validated;
+
+@Validated
+public record ProcessMonitoringFilterTag (
+    String label,
+    String value
+) {}

--- a/services/businessconfig/src/main/java/org/opfab/businessconfig/model/ProcessMonitoringFilters.java
+++ b/services/businessconfig/src/main/java/org/opfab/businessconfig/model/ProcessMonitoringFilters.java
@@ -1,0 +1,19 @@
+/* Copyright (c) 2024, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
+ */
+
+package org.opfab.businessconfig.model;
+
+import java.util.List;
+
+import org.springframework.validation.annotation.Validated;
+
+@Validated
+public record ProcessMonitoringFilters (
+    List<ProcessMonitoringFilterTag> tags, Integer pageSize
+) {}

--- a/services/businessconfig/src/main/modeling/swagger.yaml
+++ b/services/businessconfig/src/main/modeling/swagger.yaml
@@ -514,7 +514,45 @@ paths:
           description: Authentication required
         '403':
           description: Forbidden - ADMIN role necessary
-
+  '/businessconfig/processmonitoring':
+    get:
+      summary: Get the process monitoring configuration
+      description: >-
+         Get the process monitoring configuration
+      operationId: getProcessMonitoring
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/ProcessMonitoring'
+        '401':
+          description: Authentication required
+    post:
+      summary: Post the json defining the process monitoring config
+      description: >-
+        Post the json defining the process monitoring config
+        This json is saved to disk, under the name 'processmonitoring.json'.
+        The uploaded file should be a valid JSON file containing the ProcessMonitoring object structure as defined in the schema
+      operationId: uploadProcessMonitoring
+      consumes:
+        - multipart/form-data
+      produces:
+        - application/json
+      parameters:
+        - name: file
+          in: formData
+          description: file to upload
+          required: true
+          type: file
+      responses:
+        '201':
+          description: Successful creation
+        '401':
+          description: Authentication required
+        '403':
+          description: Forbidden - ADMIN role necessary
 definitions:
   Process:
     type: object
@@ -575,7 +613,7 @@ definitions:
               type: string
               description: color for the state in the logging screen (optional) 
             userCard:
-              description : User card template and visibility options
+              description: User card template and visibility options
               $ref: '#/definitions/UserCard'
             templateName:
               description: >-
@@ -777,19 +815,19 @@ definitions:
     properties:
       template:
         type: string
-      severityVisible: 
+      severityVisible:
         type: boolean
-      keepChildCardsVisible: 
+      keepChildCardsVisible:
         type: boolean
         description: Sets the visibility of the keepChildCards checkbox on the usercard. Default value set to false.
       startDateVisible: 
         type: boolean      
-      endDateVisible: 
+      endDateVisible:
         type: boolean
       expirationDateVisible:
         type: boolean
         description: Default value set to false.
-      lttdVisible: 
+      lttdVisible:
         type: boolean
         description: Default value set to false.
       recipientVisible: # tells whether to display recipient dropdown when creating a user card
@@ -802,7 +840,7 @@ definitions:
           $ref: '#/definitions/EntitiesTree'
   EntitiesTree:
     description: >- 
-      Object containing the id of the entity and an optional list of connection levels 
+      Object containing the id of the entity and an optional list of connection levels
       with 0 meaning the entity itself, 1 for first level children, 2 for 2nd level connections, etc.
     properties:
       id:
@@ -815,9 +853,9 @@ definitions:
   
   Monitoring:
     description: Configuration for the monitoring screen
-    properties: 
-      export : 
-        description : export configuration
+    properties:
+      export:
+        description: export configuration
         $ref: '#/definitions/MonitoringExport'
   
   MonitoringExport:
@@ -827,23 +865,23 @@ definitions:
         type: array
         items: 
           $ref: '#/definitions/MonitoringExportField'
-  
-  MonitoringExportField: 
-    description: Configuration for Field to export 
+
+  MonitoringExportField:
+    description: Configuration for Field to export
     properties:
       columnName:
-        description: Name of the colum in export 
+        description: Name of the colum in export
         type: string
       jsonField:
-        description: Name of the field corresponding to the column name 
+        description: Name of the field corresponding to the column name
         type: string
       type:
-        description: Type of the field (for now only type EPOCHDATE is used) 
+        description: Type of the field (for now only type EPOCHDATE is used)
         type: MonitoringExportFieldTypeEnum
       fields:
         description: Nested fields description
         type: array
-        items: 
+        items:
           $ref: '#/definitions/MonitoringExportField'
 
   MonitoringExportFieldTypeEnum:
@@ -852,3 +890,64 @@ definitions:
     enum:
       - STRING
       - EPOCHDATE
+  ProcessMonitoring:
+    description: Configuration for the process monitoring screen
+    properties:
+      fields:
+        description: monitoring fields configuration
+        type: array
+        items:
+          $ref: '#/definitions/ProcessMonitoringField'
+      fieldsForProcesses:
+        description: monitoring fields configuration for processes
+        type: array
+        items:
+          $ref: '#/definitions/ProcessMonitoringFields'
+      filters:
+        description: process monitoring filters
+        properties:
+          tags:
+            description: Array of filter tags for process monitoring
+            type: array
+            items:
+              $ref: '#/definitions/ProcessMonitoringFilterTag'
+          pageSize:
+            description: Number of items to display per page in the process monitoring view
+            type: integer
+          
+  ProcessMonitoringFields:
+    properties:
+      process:
+        description: process name
+        type: string
+      fields:
+        description: monitoring fields configuration for process
+        type: array
+        items:
+          $ref: '#/definitions/ProcessMonitoringField'
+  ProcessMonitoringField:
+    description: process monitoring field
+    properties:
+      field:
+        type: string
+      type:
+        type: ProcessMonitoringFieldTypeEnum
+      colName:
+        type: string
+      size:
+        description: The size of the field
+        type: integer
+  ProcessMonitoringFilterTag:
+    description: process monitoring filter tag
+    properties:
+      label:
+        type: string
+      value:
+        type: string
+  ProcessMonitoringFieldTypeEnum:
+    type: string
+    description: Type of field
+    enum:
+      - string
+      - date
+      - array

--- a/src/docs/asciidoc/reference_doc/monitoring.adoc
+++ b/src/docs/asciidoc/reference_doc/monitoring.adoc
@@ -42,45 +42,41 @@ The process monitoring screen has the following similarities with the monitoring
 this screen, the parameter `uiVisibility.processmonitoring` must be set to `true` in the `config.json` file of its
 process.
 
-This screen provides the following features :
 
-- the columns displayed on this screen can be configured. To do that, you have to define the `processMonitoring.fields` field
-in the `web-ui.json` configuration file. This object is a list of the fields you want to see in the array.
-You also have the possibility to define the columns displayed per process. To do that, you have to configure the field
-`processMonitoring.fieldsForProcesses`.
-If more than one process is selected by the user or if a process has no configuration, the columns displayed will
-be those of the default config (`processMonitoring.fields`).
-- depending on the permissions of the groups to which the user is attached, he can also see the cards he is not the
-recipient of.
-- if geographical map view is enabled ('feed.geomap.enableMap' set to 'true' in web-ui.json) it is possible to view the cards on the map by checking the "View Results on a Geographical Map" checkbox.
+The columns displayed on this screen can be configured. To do that, you have to define a JSON file and load the file by sending an HTTP POST request to the `/processmonitoring` API of businessconfig service or using CLI command `opfab processmonitoring load <file>`.
 
-Here is an example of processMonitoring configuration :
+Here is an example of processMonitoring configuration file:
 ```
-"processMonitoring": {
+{
   "fields": [
-    { "field": "startDate", "type": "date", "colName": "Start Date", "size": "200"},
-    { "field": "titleTranslated", "colName": "Title", "size": "250"},
-    { "field": "entityRecipients", "type": "array", "colName": "Entity Recipients", "size": "400"},
-    { "field": "data.stateName", "colName": "My field", "size": "300"},
-    { "field": "summaryTranslated", "colName": "Summary", "size": "250"},
-    { "field": "data.error", "colName": "My second field", "size": "100"}
+    { "field": "startDate", "type": "date", "colName": "Start Date", "size": 200},
+    { "field": "titleTranslated", "colName": "Title", "size": 250},
+    { "field": "entityRecipients", "type": "array", "colName": "Entity Recipients", "size": 400},
+    { "field": "data.stateName", "colName": "My field", "size": 300},
+    { "field": "summaryTranslated", "colName": "Summary", "size": 250},
+    { "field": "data.error", "colName": "My second field", "size": 100}
   ],
-  "fieldsForProcesses": {
-    "process1" : [
-      { "field": "startDate", "type": "date", "colName": "Start Date", "size": "200"},
-      { "field": "titleTranslated", "colName": "Title", "size": "250"},
-      { "field": "entityRecipients", "type": "array", "colName": "Entity Recipients", "size": "400"}
-    ],
-    "process2" : [
-      { "field": "startDate", "type": "date", "colName": "Start Date", "size": "200"},
-      { "field": "endDate", "type": "date", "colName": "End Date", "size": "200"},
-      { "field": "titleTranslated", "colName": "Title", "size": "250"},
-      { "field": "entityRecipients", "type": "array", "colName": "Entity Recipients", "size": "400"}
-    ]
-  },
+  "fieldsForProcesses": [
+    {
+      "process": "process1",
+      "fields" : [
+        { "field": "startDate", "type": "date", "colName": "Start Date", "size": 200},
+        { "field": "titleTranslated", "colName": "Title", "size": 250},
+        { "field": "entityRecipients", "type": "array", "colName": "Entity Recipients", "size": 400}
+      ]
+    },
+    {
+      "process": "process2",
+      "fields" : [
+        { "field": "startDate", "type": "date", "colName": "Start Date", "size": 200},
+        { "field": "endDate", "type": "date", "colName": "End Date", "size": 200},
+        { "field": "titleTranslated", "colName": "Title", "size": 250},
+        { "field": "entityRecipients", "type": "array", "colName": "Entity Recipients", "size": 400}
+      ]
+    }
+  ],
   "filters": {
-    "tags": {
-      "list": [
+    "tags": [
         {
           "label": "Label for tag 1",
           "value": "tag1"
@@ -90,10 +86,22 @@ Here is an example of processMonitoring configuration :
           "value": "tag2"
         }
       ]
-    }
+    "pageSize": 10
   }
 }
 ```
+
+The `fields` field in the process monitoring configuration file defines the list of the fields you want to see in the array.
+
+You also have the possibility to define the columns displayed per process. To do that, you have to configure the field `fieldsForProcesses`.
+
+If more than one process is selected by the user or if a process has no configuration, the columns displayed will be those of the default config (`fields`).
+Depending on the permissions of the groups to which the user is attached, he can also see the cards he is not the recipient of.
+
+In the process monitoring config file it is possible to configure the page size `filters.pageSize` and the list of available tags used in the UI to filter the results `filters.tags`.
+
+If geographical map view is enabled ('feed.geomap.enableMap' set to 'true' in web-ui.json) it is possible to view the cards on the map by checking the "View Results on a Geographical Map" checkbox.
+
 
 Here is the description of the fields :
 

--- a/src/docs/asciidoc/resources/migration_guide_to_4.5.adoc
+++ b/src/docs/asciidoc/resources/migration_guide_to_4.5.adoc
@@ -30,3 +30,83 @@ Some fields of the `web-ui.json` file have changed and renamed:
 
 * `alerts.messageBusinessAutoClose` has been renamed as `alerts.alarmLevelAutoClose`
 * `alerts.hideBusinessMessages` has been renamed as `alerts.doNotAlertForHiddenCardReceived`
+
+== Process monitoring configuration
+The configuration for process monitoring screen has been removed from `web-ui.json` and externalized in a dedicated JSON file. The process monitoring configuration file has to be loaded by sending an HTTP POST request to the `/processmonitoring` API of businessconfig service or using the CLI command `opfab processmonitoring load <file>`.
+The structure of the process monitoring configuration fields has to be modified as follows:
+
+- "fieldsForProcesses" is now an array of objects with "process" and "fields" fields.
+
+- The "size" attribute in now a number, not a string as before
+
+- "filters" is now an object with "pageSize" and "tags" fields
+
+So for example the configuration should be changed from:
+[source,json] 
+----
+"fieldsForProcesses": {
+      "conferenceAndITIncidentExample" : [
+        { "field": "startDate", "type": "date", "colName": "Start Date", "size": "200"},
+        { "field": "titleTranslated", "colName": "Title", "size": "250"},
+        { "field": "entityRecipients", "type": "array", "colName": "Entity Recipients", "size": "400"}
+      ],
+      "messageOrQuestionExample" : [
+        { "field": "startDate", "type": "date", "colName": "Start Date", "size": "200"},
+        { "field": "endDate", "type": "date", "colName": "End Date", "size": "200"},
+        { "field": "titleTranslated", "colName": "Title", "size": "250"},
+        { "field": "entityRecipients", "type": "array", "colName": "Entity Recipients", "size": "400"}
+      ]
+    },
+    "filters": {
+      "tags": {
+        "list": [
+          {
+            "label": "Label for tag 1",
+            "value": "tag1"
+          },
+          {
+            "label": "Label for tag 2",
+            "value": "tag2"
+          }
+        ]
+      },
+      "page": {
+        "size": 10
+      }
+    }
+----
+
+to 
+
+[source,json] 
+----
+   "fieldsForProcesses": [
+      {
+        "process": "conferenceAndITIncidentExample",
+        "fields" : [
+        { "field": "startDate", "type": "date", "colName": "Start Date", "size": 200},
+        { "field": "titleTranslated", "colName": "Title", "size": 250},
+        { "field": "entityRecipients", "type": "array", "colName": "Entity Recipients", "size": 400}
+      ]}, {
+        "process" : "messageOrQuestionExample",
+        "fields" : [
+        { "field": "startDate", "type": "date", "colName": "Start Date", "size": 200},
+        { "field": "endDate", "type": "date", "colName": "End Date", "size": 200},
+        { "field": "titleTranslated", "colName": "Title", "size": 250},
+        { "field": "entityRecipients", "type": "array", "colName": "Entity Recipients", "size": 400}
+      ]}
+    ],
+    "filters": {
+      "tags": [
+          {
+            "label": "Label for tag 1",
+            "value": "tag1"
+          },
+          {
+            "label": "Label for tag 2",
+            "value": "tag2"
+          }
+        ],
+        "pageSize": 10
+      }
+----

--- a/src/test/api/karate/businessConfigTests.txt
+++ b/src/test/api/karate/businessConfigTests.txt
@@ -13,3 +13,4 @@
       businessconfig/getResponseBusinessconfig.feature    \
       businessconfig/getBusinessconfigHistory.feature     \
       businessconfig/security.feature                     \
+      businessconfig/uploadAndGetProcessMonitoringFile.feature \

--- a/src/test/api/karate/businessconfig/resources/processMonitoring1.json
+++ b/src/test/api/karate/businessconfig/resources/processMonitoring1.json
@@ -1,0 +1,6 @@
+{
+    "fields": [
+      { "field": "startDate", "type": "date", "colName": "Start Date", "size": 200},
+      { "field": "data.stateName", "colName": "My field", "size": 300}
+    ]
+  }

--- a/src/test/api/karate/businessconfig/resources/processMonitoring2.json
+++ b/src/test/api/karate/businessconfig/resources/processMonitoring2.json
@@ -1,0 +1,5 @@
+{
+    "fields": [
+      { "field": "titleTranslated", "colName": "Title", "size": 250}
+    ]
+  }

--- a/src/test/api/karate/businessconfig/uploadAndGetProcessMonitoringFile.feature
+++ b/src/test/api/karate/businessconfig/uploadAndGetProcessMonitoringFile.feature
@@ -1,0 +1,72 @@
+Feature: uploadProcessMonitoringConfiguration
+
+  Background:
+    # Get admin token
+    * def signIn = callonce read('../common/getToken.feature') { username: 'admin'}
+    * def authToken = signIn.authToken
+
+    # Get TSO-operator
+    * def signInAsTSO = callonce read('../common/getToken.feature') { username: 'operator1_fr'}
+    * def authTokenAsTSO = signInAsTSO.authToken
+
+  Scenario: Post process monitoring configuration file without authentication
+    Given url opfabUrl + '/businessconfig/processmonitoring'
+    And multipart file file = { read: 'resources/processMonitoring1.json' }
+    When method post
+    And status 401
+
+
+  Scenario: Post process monitoring configuration file without admin role
+    Given url opfabUrl + '/businessconfig/processmonitoring'
+    And header Authorization = 'Bearer ' + authTokenAsTSO
+    And multipart file file = { read: 'resources/processMonitoring1.json' }
+    When method post
+    And status 403
+
+
+  Scenario: Post process monitoring configuration file
+    Given url opfabUrl + '/businessconfig/processmonitoring'
+    And header Authorization = 'Bearer ' + authToken
+    And multipart file file = { read: 'resources/processMonitoring1.json' }
+    When method post
+    And status 201
+
+
+  Scenario: Check that process monitoring configuration has been created
+    Given url opfabUrl + '/businessconfig/processmonitoring'
+    And header Authorization = 'Bearer ' + authTokenAsTSO
+    When method GET
+    Then status 200
+    And assert response.fields.length == 2
+    Then match response.fields[0].field == 'startDate'
+    Then match response.fields[0].type == 'date'
+    Then match response.fields[0].colName == 'Start Date'
+    Then match response.fields[0].size == 200
+    Then match response.fields[1].field == 'data.stateName'
+    Then match response.fields[1].colName == 'My field'
+    Then match response.fields[1].size == 300
+
+
+  Scenario: Post a new process monitoring configuration file
+    Given url opfabUrl + '/businessconfig/processmonitoring'
+    And header Authorization = 'Bearer ' + authToken
+    And multipart file file = { read: 'resources/processMonitoring2.json' }
+    When method post
+    And status 201
+
+
+  Scenario: Check that the new process monitoring configuration has overwritten the previous one
+    Given url opfabUrl + '/businessconfig/processmonitoring'
+    And header Authorization = 'Bearer ' + authTokenAsTSO
+    When method GET
+    Then status 200
+    And assert response.fields.length == 1
+    Then match response.fields[0].field == 'titleTranslated'
+    Then match response.fields[0].colName == 'Title'
+    Then match response.fields[0].size == 250
+
+
+  Scenario: Get process monitoring configuration without authentication
+    Given url opfabUrl + '/businessconfig/processmonitoring'
+    When method GET
+    Then status 401

--- a/src/test/resources/loadTestConf.sh
+++ b/src/test/resources/loadTestConf.sh
@@ -26,6 +26,8 @@ fi
 	opfab processgroups load processGroups.json
 	cd ../perimeters
 	./createAllPerimeter.sh
+	cd ../processMonitoring
+	opfab processmonitoring load processMonitoring.json
 	cd ../realTimeScreens
 	opfab realtimescreen load realTimeScreens.json
 	cd ../businessData

--- a/src/test/resources/processMonitoring/loadProcessMonitoringConfig.sh
+++ b/src/test/resources/processMonitoring/loadProcessMonitoringConfig.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Copyright (c) 2024, RTE (http://www.rte-france.com)
+# See AUTHORS.txt
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# SPDX-License-Identifier: MPL-2.0
+# This file is part of the OperatorFabric project.
+
+opfab login http://localhost 2002 admin test
+opfab processmonitoring load $1

--- a/src/test/resources/processMonitoring/processMonitoring.json
+++ b/src/test/resources/processMonitoring/processMonitoring.json
@@ -1,0 +1,39 @@
+{
+    "fields": [
+      { "field": "startDate", "type": "date", "colName": "Start Date", "size": 200},
+      { "field": "titleTranslated", "colName": "Title", "size": 250},
+      { "field": "entityRecipients", "type": "array", "colName": "Entity Recipients", "size": 400},
+      { "field": "data.stateName", "colName": "My field", "size": 300},
+      { "field": "summaryTranslated", "colName": "Summary", "size": 250},
+      { "field": "data.error", "colName": "My second field", "size": 100}
+    ],
+    "fieldsForProcesses": [
+      {
+        "process": "conferenceAndITIncidentExample",
+        "fields" : [
+        { "field": "startDate", "type": "date", "colName": "Start Date", "size": 200},
+        { "field": "titleTranslated", "colName": "Title", "size": 250},
+        { "field": "entityRecipients", "type": "array", "colName": "Entity Recipients", "size": 400}
+      ]}, {
+        "process" : "messageOrQuestionExample",
+        "fields" : [
+        { "field": "startDate", "type": "date", "colName": "Start Date", "size": 200},
+        { "field": "endDate", "type": "date", "colName": "End Date", "size": 200},
+        { "field": "titleTranslated", "colName": "Title", "size": 250},
+        { "field": "entityRecipients", "type": "array", "colName": "Entity Recipients", "size": 400}
+      ]}
+    ],
+    "filters": {
+      "tags": [
+          {
+            "label": "Label for tag 1",
+            "value": "tag1"
+          },
+          {
+            "label": "Label for tag 2",
+            "value": "tag2"
+          }
+        ],
+        "pageSize": 10
+      }
+  }

--- a/ui/main/src/app/business/application-loader.ts
+++ b/ui/main/src/app/business/application-loader.ts
@@ -259,7 +259,8 @@ export class ApplicationLoader {
             ProcessesService.loadAllProcessesWithLatestVersion(),
             ProcessesService.loadAllProcessesWithAllVersions(),
             ProcessesService.loadProcessGroups(),
-            ConfigService.loadMonitoringConfig()
+            ConfigService.loadMonitoringConfig(),
+            ConfigService.loadProcessMonitoringConfig()
         ];
         return firstValueFrom(Utilities.subscribeAndWaitForAllObservablesToEmitAnEvent(requestsToLaunch$));
     }

--- a/ui/main/src/app/business/model/process-monitoring-config.model.ts
+++ b/ui/main/src/app/business/model/process-monitoring-config.model.ts
@@ -1,0 +1,52 @@
+/* Copyright (c) 2024, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
+ */
+
+export class ProcessMonitoringConfig {
+    public constructor(
+        readonly fields: ProcessMonitoringField[],
+        readonly fieldsForProcesses: ProcessMonitoringFieldsForProcess[],
+        readonly filters: ProcessMonitoringFilters
+    ) {}
+}
+
+export class ProcessMonitoringField {
+    constructor(
+        readonly field: string,
+        readonly colName: string,
+        readonly type: string,
+        readonly size: number
+    ) {}
+}
+
+export class ProcessMonitoringFieldsForProcess {
+    constructor(
+        readonly process: string,
+        readonly fields: ProcessMonitoringField[]
+    ) {}
+}
+
+export class ProcessMonitoringFilters {
+    constructor(
+        readonly tags: ProcessMonitoringFilterTag[],
+        readonly pageSize: number
+    ) {}
+}
+
+export class ProcessMonitoringFilterTag {
+    constructor(
+        readonly label: string,
+        readonly value: string
+    ) {}
+}
+
+export enum ProcessMonitoringFieldEnum {
+    STRING = 'string',
+    DATE = 'date',
+    ARRAY = 'array'
+}

--- a/ui/main/src/app/business/server/config.server.ts
+++ b/ui/main/src/app/business/server/config.server.ts
@@ -11,11 +11,13 @@ import {MonitoringConfig} from '@ofModel/monitoringConfig.model';
 import {RealTimeScreens} from '@ofModel/real-time-screens.model';
 import {Observable} from 'rxjs';
 import {ServerResponse} from './serverResponse';
+import {ProcessMonitoringConfig} from '@ofModel/process-monitoring-config.model';
 
 export abstract class ConfigServer {
     abstract getWebUiConfiguration(): Observable<ServerResponse<any>>;
     abstract getMenuConfiguration(): Observable<ServerResponse<any>>;
     abstract getMonitoringConfiguration(): Observable<ServerResponse<MonitoringConfig>>;
+    abstract getProcessMonitoringConfiguration(): Observable<ServerResponse<ProcessMonitoringConfig>>;
     abstract getLocale(locale: string): Observable<ServerResponse<any>>;
     abstract getRealTimeScreenConfiguration(): Observable<ServerResponse<RealTimeScreens>>;
 }

--- a/ui/main/src/app/business/services/config.service.ts
+++ b/ui/main/src/app/business/services/config.service.ts
@@ -15,11 +15,13 @@ import {ConfigServer} from '../server/config.server';
 import {MonitoringConfig} from '@ofModel/monitoringConfig.model';
 import {ServerResponseStatus} from '../server/serverResponse';
 import {LoggerService} from './logs/logger.service';
+import {ProcessMonitoringConfig} from '@ofModel/process-monitoring-config.model';
 
 export class ConfigService {
     private static configServer: ConfigServer;
     private static config;
     private static monitoringConfig: MonitoringConfig;
+    private static processMonitoringConfig: ProcessMonitoringConfig;
 
     private static menuConfig: UIMenuFile;
 
@@ -106,7 +108,26 @@ export class ConfigService {
         );
     }
 
-    public static getMonitoringConfig(): any {
+    public static loadProcessMonitoringConfig(): Observable<ProcessMonitoringConfig> {
+        return ConfigService.configServer.getProcessMonitoringConfiguration().pipe(
+            map((serverResponse) => {
+                const processMonitoringConfig = serverResponse.data;
+                if (processMonitoringConfig) {
+                    ConfigService.processMonitoringConfig = processMonitoringConfig;
+                    LoggerService.info('Process Monitoring config loaded');
+                } else LoggerService.info('No process monitoring config to load');
+                if (serverResponse.status !== ServerResponseStatus.OK)
+                    LoggerService.error('An error occurred when loading processMonitoringConfig');
+                return processMonitoringConfig;
+            })
+        );
+    }
+
+    public static getMonitoringConfig(): MonitoringConfig {
         return ConfigService.monitoringConfig;
+    }
+
+    public static getProcessMonitoringConfig(): ProcessMonitoringConfig {
+        return ConfigService.processMonitoringConfig;
     }
 }

--- a/ui/main/src/app/modules/processmonitoring/components/processmonitoring-table/processmonitoring-table.component.html
+++ b/ui/main/src/app/modules/processmonitoring/components/processmonitoring-table/processmonitoring-table.component.html
@@ -23,7 +23,7 @@
         <span translate> shared.resultsNumber </span> : {{totalElements}}
         </div>
         <div style="width:40%;margin-top:5px">
-        <ngb-pagination *ngIf="totalPages > 1" [collectionSize]="totalElements"
+        <ngb-pagination *ngIf="totalPages > 1" [collectionSize]="totalElements" [pageSize]="pageSize"
             [page]="page" (pageChange)="updateResultPage($event)" [maxSize]="3" [rotate]="true">
         </ngb-pagination>
         </div>

--- a/ui/main/src/app/modules/processmonitoring/components/processmonitoring-table/processmonitoring-table.component.ts
+++ b/ui/main/src/app/modules/processmonitoring/components/processmonitoring-table/processmonitoring-table.component.ts
@@ -18,6 +18,7 @@ import {SelectedCardService} from '../../../../business/services/card/selectedCa
 import {AgGridAngular} from 'ag-grid-angular';
 import {NgIf} from '@angular/common';
 import {CardComponent} from '../../../card/card.component';
+import {ProcessMonitoringField, ProcessMonitoringFieldEnum} from '@ofModel/process-monitoring-config.model';
 
 @Component({
     selector: 'of-processmonitoring-table',
@@ -33,9 +34,10 @@ export class ProcessmonitoringTableComponent {
     @Input() totalElements: number;
     @Input() totalPages: number;
     @Input() page: number;
+    @Input() pageSize: number;
     @Input() processStateNameMap: Map<string, string>;
     @Input() processStateDescriptionMap: Map<string, string>;
-    @Input() processMonitoringFields: any[];
+    @Input() processMonitoringFields: ProcessMonitoringField[];
 
     @Output() pageChange = new EventEmitter<number>();
     @Output() filterChange = new EventEmitter<number>();
@@ -132,7 +134,7 @@ export class ProcessmonitoringTableComponent {
             const columnSizeAverage = this.computeColumnSizeAverage();
 
             this.processMonitoringFields.forEach((column) => {
-                if (column.type === 'date') {
+                if (column.type === ProcessMonitoringFieldEnum.DATE) {
                     this.columnDefs.push({
                         type: 'summaryColumn',
                         headerName: column.colName,

--- a/ui/main/src/app/modules/processmonitoring/processmonitoring.component.html
+++ b/ui/main/src/app/modules/processmonitoring/processmonitoring.component.html
@@ -143,7 +143,7 @@
   </div>
   <div *ngIf="!isMapViewActivated" style="margin-left:5%;margin-right:5%">
     <of-processmonitoring-table  [result]="results" [processGroupVisible]="isProcessGroupFilterVisible" [page]="page"
-      [totalElements]="totalElements" [totalPages]="totalPages" [processStateNameMap]="processStateName"
+      [totalElements]="totalElements" [pageSize]="size" [totalPages]="totalPages" [processStateNameMap]="processStateName"
       [processStateDescriptionMap]="processStateDescription" [processMonitoringFields]="processMonitoringFields"
       (filterChange)="onTableFilterChange($event)" (pageChange)="onPageChange($event)" (export)="exportToExcel()">
     </of-processmonitoring-table>

--- a/ui/main/src/app/server/angularConfig.server.ts
+++ b/ui/main/src/app/server/angularConfig.server.ts
@@ -18,6 +18,7 @@ import {map, Observable} from 'rxjs';
 import {ConfigServer} from '../business/server/config.server';
 import {AngularServer} from './angular.server';
 import {LoggerService as logger} from 'app/business/services/logs/logger.service';
+import {ProcessMonitoringConfig} from '@ofModel/process-monitoring-config.model';
 
 @Injectable({
     providedIn: 'root'
@@ -26,6 +27,7 @@ export class AngularConfigServer extends AngularServer implements ConfigServer {
     private configUrl: string;
     private menuUrl: string;
     private monitoringConfigUrl: string;
+    private processMonitoringConfigUrl: string;
     private localUrl: string;
     readonly realTimeScreensUrl: string;
 
@@ -34,6 +36,7 @@ export class AngularConfigServer extends AngularServer implements ConfigServer {
         this.configUrl = `${environment.url}config/web-ui.json`;
         this.menuUrl = `${environment.url}config/ui-menu.json`;
         this.monitoringConfigUrl = `${environment.url}businessconfig/monitoring`;
+        this.processMonitoringConfigUrl = `${environment.url}businessconfig/processmonitoring`;
         this.localUrl = `${environment.url}assets/i18n`;
         this.realTimeScreensUrl = `${environment.url}businessconfig/realtimescreens`;
     }
@@ -61,6 +64,9 @@ export class AngularConfigServer extends AngularServer implements ConfigServer {
         return this.processHttpResponse(this.httpClient.get<MonitoringConfig>(this.monitoringConfigUrl));
     }
 
+    getProcessMonitoringConfiguration(): Observable<ServerResponse<ProcessMonitoringConfig>> {
+        return this.processHttpResponse(this.httpClient.get<ProcessMonitoringConfig>(this.processMonitoringConfigUrl));
+    }
     getLocale(locale: string): Observable<ServerResponse<any>> {
         return this.processHttpResponse(this.httpClient.get(`${this.localUrl}/${locale}.json`));
     }

--- a/ui/main/src/tests/mocks/configServer.mock.ts
+++ b/ui/main/src/tests/mocks/configServer.mock.ts
@@ -1,4 +1,4 @@
-/* Copyright (c) 2023, RTE (http://www.rte-france.com)
+/* Copyright (c) 2023-2024, RTE (http://www.rte-france.com)
  * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -12,6 +12,7 @@ import {ConfigServer} from 'app/business/server/config.server';
 import {MonitoringConfig} from '@ofModel/monitoringConfig.model';
 import {ServerResponse} from 'app/business/server/serverResponse';
 import {RealTimeScreens} from '@ofModel/real-time-screens.model';
+import {ProcessMonitoringConfig} from '@ofModel/process-monitoring-config.model';
 
 export class ConfigServerMock implements ConfigServer {
     private webUiConf = new ReplaySubject<ServerResponse<any>>();
@@ -19,6 +20,7 @@ export class ConfigServerMock implements ConfigServer {
     private monitoringConf = new ReplaySubject<ServerResponse<MonitoringConfig>>();
     private locale = new ReplaySubject<ServerResponse<any>>();
     private realtimescreenconfiguration = new ReplaySubject<ServerResponse<RealTimeScreens>>();
+    private processmonitoringconfiguration = new ReplaySubject<ServerResponse<ProcessMonitoringConfig>>();
 
     getWebUiConfiguration(): Observable<ServerResponse<any>> {
         return this.webUiConf.asObservable();
@@ -40,6 +42,10 @@ export class ConfigServerMock implements ConfigServer {
         return this.realtimescreenconfiguration.asObservable();
     }
 
+    getProcessMonitoringConfiguration(): Observable<ServerResponse<ProcessMonitoringConfig>> {
+        return this.processmonitoringconfiguration.asObservable();
+    }
+
     setResponseForWebUIConfiguration(webuiConf: ServerResponse<any>) {
         this.webUiConf.next(webuiConf);
     }
@@ -54,5 +60,9 @@ export class ConfigServerMock implements ConfigServer {
 
     setResponseForRealTimeScreenConfiguration(realtimeScreenConf: ServerResponse<any>) {
         this.realtimescreenconfiguration.next(realtimeScreenConf);
+    }
+
+    setResponseForProcessMonitoringConfiguration(processMonitoringConf: ServerResponse<ProcessMonitoringConfig>) {
+        this.processmonitoringconfiguration.next(processMonitoringConf);
     }
 }


### PR DESCRIPTION
Fix #6734 

- In release notes :
  -  In chapter : Features
  -  Text : #6734 : Move monitoring process configuration in a specific configuration file loaded via businessconfig API (#6734)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced a `processmonitoring` command in the CLI for managing process monitoring configurations.
  - Added endpoints for uploading and retrieving process monitoring files in the API.
  - Enhanced the application to load process monitoring configurations during startup.
  - Implemented a new configuration structure for process monitoring, improving data organization.
  - Updated Swagger API documentation to include new process monitoring endpoints.

- **Bug Fixes**
  - Improved error handling for configuration loading and validation.

- **Documentation**
  - Revised user documentation for configuring the process monitoring screen.

- **Tests**
  - Added feature tests for uploading and retrieving process monitoring configuration files.
  - Expanded test coverage for process monitoring functionalities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->