### PR TITLE
Add entities answers popover in card header (#7230)

### DIFF
--- a/src/test/cypress/cypress/integration/ResponseCard.spec.js
+++ b/src/test/cypress/cypress/integration/ResponseCard.spec.js
@@ -583,16 +583,14 @@ describe('Response card tests', function () {
         usercard.previewThenSendCard();
         feed.openFirstCard();
 
+        card.openEntityDropdownInCardHeader();
+        cy.get('ngb-popover-window').should('exist');
+        cy.get('#opfab-answered-list').find('span').should("have.length", 0);
+        cy.get('#opfab-not-answered-list').find('span').should("have.length", 6);
+
         card.checkEntityIsOrangeInCardHeader('ENTITY1_FR');
         card.checkEntityIsOrangeInCardHeader('ENTITY2_FR');
         card.checkEntityIsOrangeInCardHeader('ENTITY3_FR');
-        card.checkEntityIsNotVisibleInCardHeader('ENTITY4_FR');
-        card.checkEntityIsNotVisibleInCardHeader('ENTITY1_IT');
-        card.checkEntityIsNotVisibleInCardHeader('ENTITY2_IT');
-
-        card.openEntityDropdownInCardHeader();
-
-        // The other entities are now visible
         card.checkEntityIsOrangeInCardHeader('ENTITY4_FR');
         card.checkEntityIsOrangeInCardHeader('ENTITY1_IT');
         card.checkEntityIsOrangeInCardHeader('ENTITY2_IT');
@@ -604,7 +602,8 @@ describe('Response card tests', function () {
         card.sendResponse();
 
         card.openEntityDropdownInCardHeader();
-
+        cy.get('#opfab-answered-list').find('span').should("have.length", 1);
+        cy.get('#opfab-not-answered-list').find('span').should("have.length", 5);
         card.checkEntityIsOrangeInCardHeader('ENTITY4_FR');
         card.checkEntityIsGreenInCardHeader('ENTITY1_IT');
         card.checkEntityIsOrangeInCardHeader('ENTITY2_IT');

--- a/src/test/cypress/cypress/support/cardCommands.js
+++ b/src/test/cypress/cypress/support/cardCommands.js
@@ -67,7 +67,7 @@ export class CardCommands extends OpfabCommands {
     }
 
     openEntityDropdownInCardHeader() {
-        cy.get('#opfab-entities-dropdown').click();
+        cy.get('#opfab-card-response-header-right').trigger('mouseenter');
     }
 
     clickOnSendResponse = function() {

--- a/ui/main/src/app/modules/card/components/card-header/card-header.component.html
+++ b/ui/main/src/app/modules/card/components/card-header/card-header.component.html
@@ -21,34 +21,35 @@
             </span>
       </div>
 
-      <div id="opfab-card-response-header-right" style="width:70%;text-align: right">
-            <div id="opfab-answer-help" class="opfab-icon-help" placement="left" [ngbPopover]="helpContent"
-                  container="body" triggers="mouseenter:mouseleave" popoverClass="opfab-popover-unclickable">
-            </div>
+      <div id="opfab-card-response-header-right" class="opfab-entities-dropdown" style="width:70%;text-align: right"
+            placement="bottom-right" [ngbPopover]="entitiesDropdown" container="body" triggers="mouseenter:mouseleave"
+            closeDelay="1000" [autoClose]="'true'" popoverClass="opfab-popover-arrow-shift-right">
             <span translate>response.answers</span> :
-            <span *ngFor="let entity of listVisibleEntitiesToRespond; let isLast = last"
-                  [ngStyle]="{'color': entity.color,'text-align': 'center'}"
-                  [id]="'opfab-card-header-entity-'+entity.id">
+            <span *ngFor="let entity of entitiesForCardHeader; let isLast = last"
+                  [ngStyle]="{'color': entity.color,'text-align': 'center'}" [id]="'opfab-card-header-entity-'+entity.id">
                   &nbsp; {{entity.name}} &nbsp;
-            </span>
-            <span *ngIf="listDropdownEntitiesToRespond && listDropdownEntitiesToRespond.length > 0"
-                  id="opfab-entities-dropdown" class="opfab-entities-dropdown" placement="bottom-right"
-                  [ngbPopover]="entitiesDropdown" container="body" [autoClose]="'true'"
-                  popoverClass="opfab-popover-no-arrow">
-                  &nbsp;..&nbsp;
             </span>
       </div>
 </div>
 
-<ng-template #helpContent>
-      <label class="label-help"><span class="label-answered" translate>response.answered</span></label>
-      <label class="label-help"><span class="label-unanswered" translate>response.unanswered</span></label>
-</ng-template>
-
 <ng-template #entitiesDropdown>
-      <div *ngFor="let entity of listDropdownEntitiesToRespond;"
-            [ngStyle]="{'color': entity.color,'text-align': 'left'}"
-            [id]="'opfab-card-header-entity-'+entity.id">
-            &nbsp; {{entity.name}} &nbsp;
-      </div>
-</ng-template>
+      <table>
+          <tr>
+              <th style="padding:10px"><span translate>response.answered</span></th>
+              <th style="padding:10px"><span translate>response.unanswered</span></th>
+          </tr>
+          <tr>
+              <td id="opfab-answered-list" style="vertical-align:top; padding:10px">
+                  <div *ngFor="let entity of answeredList">
+                      <span style="white-space: nowrap;" [ngStyle]="{'color': entity.color}" [id]="'opfab-list-answered-entity-'+entity.id">&nbsp; {{entity.name}} &nbsp;</span>
+                  </div> 
+              </td>
+              <td id="opfab-not-answered-list" style="vertical-align:top; padding:10px">
+                  <div *ngFor="let entity of notAnsweredList">
+                      <span style="white-space: nowrap;" [ngStyle]="{'color': entity.color}" [id]="'opfab-list-not-answered-entity-'+entity.id">&nbsp; {{entity.name}} &nbsp;</span>
+                  </div> 
+              </td>
+          </tr>
+      </table>
+  
+  </ng-template>

--- a/ui/main/src/app/modules/card/components/card-header/card-header.component.scss
+++ b/ui/main/src/app/modules/card/components/card-header/card-header.component.scss
@@ -1,4 +1,4 @@
-/* Copyright (c) 2022, RTE (http://www.rte-france.com)
+/* Copyright (c) 2022-2024, RTE (http://www.rte-france.com)
  * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -10,19 +10,10 @@
 .opfab-entities-dropdown {
     text-align: center;
     padding-left: 5px;
+    white-space: nowrap;
+    text-overflow: ellipsis; 
+    overflow: hidden; 
+    
 }
 
-.opfab-entities-dropdown::after {
-    content: 'V';
-    transform: matrix(1, 0, 0, 0.5, 0, 3);
-    position: relative;
-    display: inline-block;
-    width: 30px;
-    height: 100%;
-    text-align: center;
-    font-size: 20px;
-    margin-top: -5px;
-    color: var(--opfab-form-border-color);
-    pointer-events: none;
-}
 

--- a/ui/main/src/app/modules/card/components/card-header/card-header.component.ts
+++ b/ui/main/src/app/modules/card/components/card-header/card-header.component.ts
@@ -17,8 +17,6 @@ import {TranslateModule} from '@ngx-translate/core';
 import {CountDownComponent} from '../../../share/countdown/countdown.component';
 import {NgbPopover} from '@ng-bootstrap/ng-bootstrap';
 
-const maxVisibleEntitiesForCardHeader = 3;
-
 class EntityForCardHeader {
     id: string;
     name: string;
@@ -41,9 +39,12 @@ export class CardHeaderComponent implements OnChanges {
     public showExpiredIcon = true;
     public showExpiredLabel = true;
     public expiredLabel = 'feed.lttdFinished';
+    public entitiesForCardHeader: EntityForCardHeader[];
+    public answeredList: EntityForCardHeader[];
+    public notAnsweredList: EntityForCardHeader[];
 
-    public listVisibleEntitiesToRespond = [];
-    public listDropdownEntitiesToRespond = [];
+    private static readonly ANSWERED_COLOR = 'var(--opfab-color-green)';
+    private static readonly NOT_ANSWERED_COLOR = 'var(--opfab-color-darker-orange)';
 
     ngOnChanges(): void {
         this.computeExpireLabelAndIcon();
@@ -85,9 +86,9 @@ export class CardHeaderComponent implements OnChanges {
     }
 
     private setEntitiesForCardHeader(entities) {
-        const entitiesForCardHeader = this.getEntitiesForCardHeaderFromEntityIds(entities);
-        entitiesForCardHeader.sort((a, b) => a.name?.localeCompare(b.name));
-        this.separateEntitiesBetweenVisibleAndDropdown(entitiesForCardHeader);
+        this.entitiesForCardHeader = this.getEntitiesForCardHeaderFromEntityIds(entities);
+        this.entitiesForCardHeader.sort((a, b) => a.name?.localeCompare(b.name));
+        this.computeAnswersLists();
     }
 
     private getEntitiesForCardHeaderFromEntityIds(entities: string[]) {
@@ -99,8 +100,8 @@ export class CardHeaderComponent implements OnChanges {
                     id: entity,
                     name: entityName,
                     color: this.hasEntityAnswered(entity)
-                        ? 'var(--opfab-color-green)'
-                        : 'var(--opfab-color-darker-orange)'
+                        ? CardHeaderComponent.ANSWERED_COLOR
+                        : CardHeaderComponent.NOT_ANSWERED_COLOR
                 });
             }
         });
@@ -111,13 +112,12 @@ export class CardHeaderComponent implements OnChanges {
         return this.childCards.some((childCard) => childCard.publisher === entity);
     }
 
-    private separateEntitiesBetweenVisibleAndDropdown(entities) {
-        this.listVisibleEntitiesToRespond =
-            entities.length > maxVisibleEntitiesForCardHeader
-                ? entities.slice(0, maxVisibleEntitiesForCardHeader)
-                : entities;
-
-        this.listDropdownEntitiesToRespond =
-            entities.length > maxVisibleEntitiesForCardHeader ? entities.slice(maxVisibleEntitiesForCardHeader) : [];
+    private computeAnswersLists() {
+        this.answeredList = this.entitiesForCardHeader.filter(
+            (entity) => entity.color === CardHeaderComponent.ANSWERED_COLOR
+        );
+        this.notAnsweredList = this.entitiesForCardHeader.filter(
+            (entity) => entity.color === CardHeaderComponent.NOT_ANSWERED_COLOR
+        );
     }
 }

--- a/ui/main/src/scss/styles.scss
+++ b/ui/main/src/scss/styles.scss
@@ -394,6 +394,14 @@ body {
     max-width: 100%;
 }
 
+.opfab-popover-arrow-shift-right {
+    @extend %opfab-popover;
+    max-width: 100%;
+    .popover-arrow::after, .popover-arrow::before {
+        left: 150px;
+    }
+}
+
 .opfab-popover-with-scrolling {
     max-width: 800px;
 


### PR DESCRIPTION
Fix #7230 

- In release notes :
  -  In chapter : Features 
  -  Text : #7230 : Add entities answers popover in card header 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced display of entities in the card header with a new table format for answered and not answered lists.
	- Improved interaction model for opening the entity dropdown in the card header.

- **Bug Fixes**
	- Streamlined visibility assertions for entities, ensuring accurate representation of their status.

- **Style**
	- Updated styling for the dropdown to manage text overflow and enhance visual presentation.
	- Introduced a new CSS class for adjusting popover arrow positioning.

- **Refactor**
	- Simplified logic for handling entity lists, consolidating properties and methods for better clarity and efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->