### PR TITLE
Set supported mongo version to 5 and above

### DIFF
--- a/CICD/github/setOldMongoVersion.sh
+++ b/CICD/github/setOldMongoVersion.sh
@@ -8,5 +8,5 @@
 # SPDX-License-Identifier: MPL-2.0
 # This file is part of the OperatorFabric project.
  
-echo "Set mongo version to 4.4-bionic"
-sed -i "s/mongo:.*$/mongo:4.4-bionic/g" config/docker/docker-compose.yml
+echo "Set mongo version to mongo:5.0.28-focal"
+sed -i "s/mongo:.*$/mongo:5.0.28-focal/g" config/docker/docker-compose.yml

--- a/src/docs/asciidoc/deployment/configuration/configuration.adoc
+++ b/src/docs/asciidoc/deployment/configuration/configuration.adoc
@@ -39,6 +39,7 @@ See link:{mongo_doc}connection-string/[mongo connection string] for the complete
 
 This configuration is mandatory (no default configuration is provided).
 
+Operator Fabric is supporting mongo version 5.0.0 and above.
 
 === RabbitMQ
 

--- a/src/docs/asciidoc/deployment/index.adoc
+++ b/src/docs/asciidoc/deployment/index.adoc
@@ -14,12 +14,8 @@ The aim of this document is to explain how to configure and deploy OperatorFabri
 For now OperatorFabric consist of Docker images available either by compiling
 the project or by using images releases from link:https://hub.docker.com/[Dockerhub]
 
-Service images are all based on link:https://hub.docker.com/_/openjdk[openjdk:8-jre-alpine].
-
-For simple one instance per service deployment, you can find a sample
-deployment as a docker compose file
-link:https://github.com/opfab/operatorfabric-core/tree/master/config/docker[here]
-
+For simple one instance per service deployment, you can find in our "Getting Started" a 
+link:https://github.com/opfab/operatorfabric-getting-started/blob/master/server/docker-compose.yml[sample deployment as a docker compose file]
 
 To run OperatorFabric in development mode, see
 ifdef::single-page-doc[<<dev_env, the development environment documentation>>]


### PR DESCRIPTION
Nothing in release note

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated MongoDB version to 5.0.28 for improved compatibility.
  - Added documentation indicating support for MongoDB version 5.0.0 and above.

- **Documentation**
  - Streamlined deployment documentation for OperatorFabric, enhancing clarity and resource accessibility by linking to the "Getting Started" section.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->