### PR TITLE
Add opfab.alertMessage API (#7017)

### DIFF
--- a/src/docs/asciidoc/reference_doc/ui_api.adoc
+++ b/src/docs/asciidoc/reference_doc/ui_api.adoc
@@ -634,3 +634,21 @@ To avoid script injection, OperatorFabric provides a utility function 'opfab.uti
 
 </script>
 ```
+
+== AlertMessage API 
+
+=== Function show
+
+It’s possible to show an alert message as a popover by calling  by calling the following function from the template :
+
+```
+opfab.alertMessage.show('message', opfab.alertMessage.messageLevel.INFO);
+```
+
+The popover will have a different backgroung color based on the message level specified.
+The available message levels are:
+
+- DEBUG (blue)
+- INFO (green)
+- ERROR (orange)
+- ALARM (red)

--- a/src/test/cypress/cypress/integration/CardDetail.spec.js
+++ b/src/test/cypress/cypress/integration/CardDetail.spec.js
@@ -245,13 +245,42 @@ describe('Card detail', function () {
             feed.openFirstCard();
             cy.hash().should('eq', '#/feed/cards/cypress.kitchenSink');
 
-            
             // We click on show card link
             cy.get('#showCardLink').click();
   
             cy.hash().should('eq', '#/feed/cards/defaultProcess.process1');
             cy.get('#opfab-div-card-template-processed').contains('Hello operator1_fr, you received the following message');
             
+        });
+  
+
+        it(`Check show alert message links`, function () {
+            script.sendCard('cypress/cardDetail/cardDetail.json');
+
+            opfab.loginWithUser('operator1_fr');
+
+            feed.openFirstCard();
+            cy.hash().should('eq', '#/feed/cards/cypress.kitchenSink');
+
+            cy.get('#showDebugMessage').click();
+            cy.get('#opfab-alert-detail-msg').contains('Debug message');
+            cy.get('#opfab-alert-detail-msg').should('have.css', 'background-color', 'rgb(0, 112, 218)');
+            cy.get('.opfab-alert-close').click();
+
+            cy.get('#showInfoMessage').click();
+            cy.get('#opfab-alert-detail-msg').contains('Info message');
+            cy.get('#opfab-alert-detail-msg').should('have.css', 'background-color', 'rgb(103, 168, 84)');
+            cy.get('.opfab-alert-close').click();
+
+            cy.get('#showErrorMessage').click();
+            cy.get('#opfab-alert-detail-msg').contains('Error message');
+            cy.get('#opfab-alert-detail-msg').should('have.css', 'background-color', 'rgb(232, 122, 8)');
+            cy.get('.opfab-alert-close').click();
+
+            cy.get('#showAlarmMessage').click();
+            cy.get('#opfab-alert-detail-msg').contains('Alarm message');
+            cy.get('#opfab-alert-detail-msg').should('have.css', 'background-color', 'rgb(167, 26, 26)');
+            cy.get('.opfab-alert-close').click();
 
         });
     });

--- a/src/test/cypress/cypress/integration/SoundNotification.spec.js
+++ b/src/test/cypress/cypress/integration/SoundNotification.spec.js
@@ -217,17 +217,17 @@ describe('Sound notification test', function () {
         cy.tick(1000);
         feed.checkNumberOfDisplayedCardsIs(0);
         sendCardWithSeverityAlarm();
-        cy.get('#div-detail-msg').find('span').eq(0).contains('You have received a card hidden by the filters you have activated (Timeline or card feed)');
+        cy.get('#opfab-alert-detail-msg').find('span').eq(0).contains('You have received a card hidden by the filters you have activated (Timeline or card feed)');
         cy.tick(100);
         sound.checkNumberOfEmittedSoundIs(1);
         feed.checkNumberOfDisplayedCardsIs(0);
 
         cy.tick(6000);
         // Check that alert message is not closed automatically after 6 seconds
-        cy.get('#div-detail-msg').should('exist');
+        cy.get('#opfab-alert-detail-msg').should('exist');
         // close it
         cy.get('#opfab-close-alert').click();
-        cy.get('div-detail-msg').should('not.exist');
+        cy.get('#opfab-alert-detail-msg').should('not.exist');
     }
 
     function setTimeLineDomain(domain) {

--- a/src/test/cypress/cypress/integration/UserCard.spec.js
+++ b/src/test/cypress/cypress/integration/UserCard.spec.js
@@ -311,7 +311,7 @@ describe('User Card ', function () {
       // a report name and a report link : no error
       cy.get('#report_title').type("report name");
       cy.get('#opfab-usercard-btn-prepareCard').click();
-      cy.get('#div-detail-msg').should('not.exist'); // no error message
+      cy.get('#opfab-alert-detail-msg').should('not.exist'); // no error message
       usercard.cancelCardSending();
     });
   })

--- a/src/test/resources/bundles/cypress/template/kitchenSink.handlebars
+++ b/src/test/resources/bundles/cypress/template/kitchenSink.handlebars
@@ -33,6 +33,10 @@
 
 <H3> OPFAB CALLS</H3>
 <div><span id="showCardLink" style="cursor:pointer;color:rgb(19, 85, 170);text-decoration:underline;" onclick="opfab.navigate.showCardInFeed('defaultProcess.process1')">LINK TO ANOTHER CARD</span></div>
+<div><span id="showDebugMessage" style="cursor:pointer;color:rgb(19, 85, 170);text-decoration:underline;" onclick="opfab.alertMessage.show('Debug message', opfab.alertMessage.messageLevel.DEBUG)">SHOW DEBUG MESSAGE</span></div>
+<div><span id="showInfoMessage" style="cursor:pointer;color:rgb(19, 85, 170);text-decoration:underline;" onclick="opfab.alertMessage.show('Info message', opfab.alertMessage.messageLevel.INFO)">SHOW INFO MESSAGE</span></div>
+<div><span id="showErrorMessage" style="cursor:pointer;color:rgb(19, 85, 170);text-decoration:underline;" onclick="opfab.alertMessage.show('Error message', opfab.alertMessage.messageLevel.ERROR)">SHOW ERROR MESSAGE</span></div>
+<div><span id="showAlarmMessage" style="cursor:pointer;color:rgb(19, 85, 170);text-decoration:underline;" onclick="opfab.alertMessage.show('Alarm message', opfab.alertMessage.messageLevel.ALARM)">SHOW ALARM MESSAGE</span></div>
 
 <H3> HANDLEBARS TEMPLATING </H3>
 

--- a/ui/main/src/app/business/services/opfabAPI.service.ts
+++ b/ui/main/src/app/business/services/opfabAPI.service.ts
@@ -11,6 +11,8 @@ import {BusinessDataService} from './businessconfig/businessdata.service';
 import {TranslationService} from './translation/translation.service';
 import {EntitiesService} from './users/entities.service';
 import {LogOption, LoggerService as logger} from './logs/logger.service';
+import {AlertMessageService} from './alert-message.service';
+import {Message, MessageLevel} from '@ofModel/message.model';
 
 declare const opfab: any;
 
@@ -19,6 +21,7 @@ export class OpfabAPIService {
     public static currentUserCard;
     public static businessconfig;
     public static handlebars;
+    public static readonly alertMessage;
 
     public static templateInterface: any;
     public static userCardTemplateInterface: any;
@@ -143,6 +146,14 @@ export class OpfabAPIService {
 
         opfab.utils.getTranslation = function (key, params) {
             return OpfabAPIService.translationService.getTranslation(key, params);
+        };
+
+        opfab.alertMessage = {
+            messageLevel: Object.freeze(MessageLevel),
+            show(message, messageLevel) {
+                const msg = new Message(message, messageLevel);
+                return AlertMessageService.sendAlertMessage(msg);
+            }
         };
 
         OpfabAPIService.initUserApi();

--- a/ui/main/src/app/modules/core/alert/alert.component.html
+++ b/ui/main/src/app/modules/core/alert/alert.component.html
@@ -1,4 +1,4 @@
-<!-- Copyright (c) 2018-2023, RTE (http://www.rte-france.com)              -->
+<!-- Copyright (c) 2018-2024, RTE (http://www.rte-france.com)              -->
 <!-- Copyright (c) 2023, Alliander (http://www.alliander.com)              -->
 <!-- See AUTHORS.txt                                                       -->
 <!-- This Source Code Form is subject to the terms of the Mozilla Public   -->
@@ -7,7 +7,7 @@
 <!-- SPDX-License-Identifier: MPL-2.0                                      -->
 <!-- This file is part of the OperatorFabric project.                      -->
 
-<div id='div-detail-msg' class="opfab-info-message"  *ngIf='alertPage.display' [style]="alertPage.style + ';background-color:' + alertPage.backgroundColor">
+<div id='opfab-alert-detail-msg' class="opfab-info-message"  *ngIf='alertPage.display' [style]="alertPage.style + ';background-color:' + alertPage.backgroundColor">
     <span> &nbsp; {{alertPage.message}}</span>
     <div id="opfab-close-alert" class="opfab-alert-close" aria-label="Close" (click)=" this.alertView.closeAlert();">
       <span aria-hidden="true">&times;</span>


### PR DESCRIPTION
Fix  #7017

- In release notes :
  -  In chapter : Features
  -  Text : #7017 : Add opfab.alertMessage API

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new `AlertMessage API` documentation section detailing how to display alert messages with varying background colors based on severity levels (DEBUG, INFO, ERROR, ALARM).
	- Added interactive elements to trigger different alert messages in the UI.

- **Bug Fixes**
	- Updated selectors in tests to ensure accurate interaction with alert messages.

- **Documentation**
	- Enhanced documentation for the `opfab.alertMessage.show` function.

- **Chores**
	- Updated copyright year in the alert component's HTML.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->