### PR TITLE
Solve issue with dependency androidthings not available (#7274)

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -3,15 +3,9 @@ dependencyResolutionManagement {
     repositories {
         mavenCentral()
         maven { url "https://repo1.maven.org/maven2" }
-        maven { url "https://repo.spring.io/release" }
-        maven { url "https://repo.spring.io/snapshot" }
-        maven { url "https://repo.spring.io/milestone" }
-        maven { url "https://repo.spring.io/libs-snapshot" }
-        maven { url "https://repo.spring.io/libs-milestone" }
-        maven { url "https://maven.eveoh.nl/content/repositories/releases" }
-        maven { url "https://packages.confluent.io/maven/" }
-        maven { url "https://artifacts.elastic.co/maven/"}
+        maven { url "https://packages.confluent.io/maven/" } // needed for kafka 
         maven { url "https://plugins.gradle.org/m2/" }
+        maven { url "https://maven.google.com/" } // needed for tranisitive dependencies jlibmodbus : com.google.android.things:androidthings:1.0
     }
 }
 


### PR DESCRIPTION
Clean maven repositories and add google maven repository

Nothing in release note

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated repository configurations to streamline dependency management.
	- Removed several Maven repositories while retaining the Confluent repository for Kafka.
	- Added a new Maven repository for Google to support `jlibmodbus` library dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->