### PR TITLE
Add opfab cli completion in docker cli

### DIFF
--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -1,15 +1,17 @@
 FROM node:20.17.0-alpine@sha256:1a526b97cace6b4006256570efa1a29cd1fe4b96a5301f8d48e87c5139438a45
+RUN apk add --no-cache bash bash-completion
 WORKDIR /usr/app
-RUN chown node:node /usr/app
-RUN mkdir ./opfab-cli
-COPY src ./opfab-cli/
+RUN chown node:node /usr/app && mkdir /usr/app/opfab-cli
+COPY src /usr/app/opfab-cli/
 COPY entryPoint.sh /
+COPY loadCompletion.sh /
+RUN mkdir /opfab && chmod 777 /opfab
+COPY bashrcForDocker /opfab/.bashrc
 RUN chmod +x /entryPoint.sh
-WORKDIR ./opfab-cli
+WORKDIR /usr/app/opfab-cli
 # Use --ignore-scripts to improve security
 RUN npm install -g --ignore-scripts
-RUN mkdir /opfab
-RUN chmod 777 /opfab
+
  #switch to non-root user
 USER node 
 CMD ["/entryPoint.sh"]

--- a/cli/bashrcForDocker
+++ b/cli/bashrcForDocker
@@ -1,0 +1,1 @@
+source /loadCompletion.sh

--- a/cli/cli.gradle
+++ b/cli/cli.gradle
@@ -4,7 +4,7 @@ plugins {
 
 task buildDocker(type: Exec) {
     workingDir project.projectDir
-    commandLine 'docker', 'build', '-t', "lfeoperatorfabric/of-opfab-cli:${project.version}", '.'
+    commandLine 'docker', 'build', '--build-arg', "https_proxy=${proxy.https}",'-t', "lfeoperatorfabric/of-opfab-cli:${project.version}", '.'
 }
 
 tasks.named("buildDocker") {

--- a/cli/entryPoint.sh
+++ b/cli/entryPoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Copyright (c) 2024, RTE (http://www.rte-france.com)
 # See AUTHORS.txt
@@ -33,4 +33,4 @@ else
 fi
 
 cd /opfab/host
-/bin/sh
+/bin/bash


### PR DESCRIPTION
In release notes :
  -  In chapter : Features
  -  Text : #6848  Add opfab cli completion in docker cli

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced shell capabilities with the addition of a completion script.
	- New directory `/opfab` created for improved organization.

- **Bug Fixes**
	- Removed redundant commands for directory creation and permission settings.

- **Documentation**
	- Updated entry point script to utilize Bash for improved functionality.

- **Chores**
	- Added HTTPS proxy support in Docker build process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->