### PR TITLE
Opfab cli: add a command to load a list of users (#7237)

### DIFF
--- a/cli/src/commands.js
+++ b/cli/src/commands.js
@@ -28,7 +28,6 @@ const entities = require('./entitiesCommands');
 const groups = require('./groupsCommands');
 
 const commands = {
-
     async processCommand(args) {
         switch (args[0]) {
             case 'bundle':
@@ -139,11 +138,11 @@ const commands = {
             input: fileStream,
             crlfDelay: Infinity
         });
-        
-        rl.on('line', line => {
+
+        rl.on('line', (line) => {
             commandList.push(line);
         });
-        
+
         rl.on('close', async () => {
             for (let commandLine of commandList) {
                 await this.processCommand(commandLine.split(' '));
@@ -190,7 +189,7 @@ const commands = {
         realtimescreen          Load real time screen definition file
         service                 Get or set log level for services
         status                  Show login status
-        users                   Set or unset process/state notifications
+        users                   Manage users
     
     `);
         } else {

--- a/cli/src/index.js
+++ b/cli/src/index.js
@@ -28,8 +28,8 @@ omelette('opfab')
         connectedusers: {
             sendmessage: ['RELOAD', 'BUSINESS_CONFIG_CHANGE', 'USER_CONFIG_CHANGE']
         },
-        entities: ['load'],
-        groups: ['load'],
+        entities: ['load', 'delete'],
+        groups: ['load', 'delete'],
         help: [
             'bundle',
             'businessdata',
@@ -82,14 +82,15 @@ omelette('opfab')
         status: [],
         users: [
             'addtoentity',
-            'removefromentity',
             'addtogroup',
+            'delete',
+            'load',
+            'removefromentity',
             'removefromgroup',
-            'set-notified',
             'set-not-notified',
-            'set-notified-mail',
             'set-not-notified-mail',
-            'delete'
+            'set-notified',
+            'set-notified-mail'
         ]
     })
     .init();


### PR DESCRIPTION
- In release notes :
  -  In chapter : Features
  -  Text : #7237 Opfab cli: add a command to load a list of users 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced several new commands for user management: `removefromentity`, `delete`, `load`, `set-notified`, and `set-notified-mail`.
	- Added functionality to load multiple user entries from a specified file.

- **Improvements**
	- Updated autocompletion for the CLI to include new commands.
	- Enhanced help messages to reflect the new command structure, changing the description of the `users` command to "Manage users."
	- Improved command processing logic for clarity and functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->