### PR TITLE
Opfab cli : add a command to set or unset an activity area (#7293)

### DIFF
--- a/cli/src/connectedUsersCommands.js
+++ b/cli/src/connectedUsersCommands.js
@@ -7,7 +7,6 @@
  * This file is part of the OperatorFabric project.
  */
 
-const config = require('./configCommands.js');
 const prompts = require('prompts');
 const utils = require('./utils.js');
 

--- a/cli/src/index.js
+++ b/cli/src/index.js
@@ -89,8 +89,10 @@ omelette('opfab')
             'removefromgroup',
             'set-not-notified',
             'set-not-notified-mail',
+            'setactivityarea',
             'set-notified',
-            'set-notified-mail'
+            'set-notified-mail',
+            'unsetactivityarea'
         ]
     })
     .init();

--- a/cli/src/monitoringConfigCommands.js
+++ b/cli/src/monitoringConfigCommands.js
@@ -8,7 +8,6 @@
  */
 
 const prompts = require('prompts');
-const config = require('./configCommands');
 const utils = require('./utils');
 const fs = require('fs').promises;
 

--- a/cli/src/processMonitoringCommands.js
+++ b/cli/src/processMonitoringCommands.js
@@ -8,9 +8,7 @@
  */
 
 const prompts = require('prompts');
-const config = require('./configCommands');
 const utils = require('./utils');
-const fs = require('fs').promises;
 
 const processMonitoringCommands = {
     async processProcessMonitoringCommand(args) {
@@ -21,9 +19,7 @@ const processMonitoringCommands = {
                     type: 'select',
                     name: 'value',
                     message: 'Process Monitoring Config command',
-                    choices: [
-                        {title: 'load', value: 'load'}
-                    ]
+                    choices: [{title: 'load', value: 'load'}]
                 })
             ).value;
             if (!command) {

--- a/cli/src/serviceCommands.js
+++ b/cli/src/serviceCommands.js
@@ -9,9 +9,8 @@
 
 const prompts = require('prompts');
 const utils = require('./utils.js');
-const { validKeys } = require('./configCommands.js');
 
-const NODE_SERVICES = ['supervisor', 'cards-external-diffusion', 'cards-reminder']
+const NODE_SERVICES = ['supervisor', 'cards-external-diffusion', 'cards-reminder'];
 
 const serviceCommands = {
     async processServiceCommand(args) {
@@ -63,10 +62,8 @@ const serviceCommands = {
         );
 
         if (result.ok) {
-            if (this.isNodeService(serviceName))
-                console.log(this.fromNodeToStandardLevel(await result.json()))
-            else
-                console.info(await result.json());
+            if (this.isNodeService(serviceName)) console.log(this.fromNodeToStandardLevel(await result.json()));
+            else console.info(await result.json());
         }
     },
 
@@ -97,8 +94,7 @@ const serviceCommands = {
                 return;
             }
         }
-        if (this.isNodeService(serviceName))
-            logLevel = this.fromStandardToNodeLevel(logLevel);
+        if (this.isNodeService(serviceName)) logLevel = this.fromStandardToNodeLevel(logLevel);
 
         await utils.sendRequest(
             this.getServicePath(serviceName),
@@ -108,7 +104,6 @@ const serviceCommands = {
             'Failed to set log level',
             'Failed to set log level not found error'
         );
-
     },
 
     getServicePath(serviceName) {
@@ -158,8 +153,8 @@ const serviceCommands = {
             default:
                 break;
         }
-        logLevel.effectiveLevel = standardLevel
-        logLevel.configuredLevel = standardLevel
+        logLevel.effectiveLevel = standardLevel;
+        logLevel.configuredLevel = standardLevel;
         return logLevel;
     },
 
@@ -180,7 +175,7 @@ const serviceCommands = {
                         {title: 'External-devices', value: 'external-devices'},
                         {title: 'Supervisor', value: 'supervisor'},
                         {title: 'Cards-external-diffusion', value: 'cards-external-diffusion'},
-                        {title: 'Cards-reminder', value: 'cards-reminder'},
+                        {title: 'Cards-reminder', value: 'cards-reminder'}
                     ]
                 })
             ).value;


### PR DESCRIPTION
- In release notes :
  -  In chapter : Features
  -  Text : #7293 Opfab cli : add a command to set or unset an activity area

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Added command options for users to set and unset activity areas.
	- Introduced a new logging configuration for Gatling applications.

- **Bug Fixes**
	- Removed unused import statements across various modules to streamline functionality.

- **Documentation**
	- Updated help documentation to reflect new user command options for managing activity areas.

- **Style**
	- Improved code formatting for consistency, including semicolon additions and consolidation of multi-line statements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->