### PR TITLE
Exclude gatling bin directory from git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,6 +77,7 @@ services/*/bin
 tools/spring/spring-oauth2-utilities/bin
 src/test/externalApp/bin
 src/test/dummyModbusDevice/bin
+src/test/gatling/bin
 */**/*.class
 
 ### Gradle ###


### PR DESCRIPTION
Nothing in release note

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the `.gitignore` file to exclude files and directories related to IntelliJ, Visual Studio Code, Gradle, Cypress, and Node Modules.
	- Added entries to ignore logs, Sonar reports, Docker configurations, and MacOS metadata files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->