### PR TITLE
Remove deprecated API method opfab.currentCard.getEntityUsedForUserRe…

### DIFF
--- a/src/docs/asciidoc/reference_doc/ui_api.adoc
+++ b/src/docs/asciidoc/reference_doc/ui_api.adoc
@@ -176,15 +176,6 @@ If inside your template, you want to get the ids of the entities allowed to send
     const entities = opfab.currentCard.getEntitiesAllowedToRespond(); 
 ```
 
-=== Function  getEntityUsedForUserResponse
-
-If inside your template, you want to get the id of the entity used by the user to send a response, you can call the method getEntityUsedForUserResponse. This method is deprecated and you should favor the use of the method getEntitiesUsableForUserResponse.
-
-```
-    const entity = opfab.currentCard.getEntityUsedForUserResponse()
-        
-```
-
 === Function  getEntitiesUsableForUserResponse
 
 If inside your template, you want to get the ids of the entities the user can answer on behalf of, you can call the method getEntitiesUsableForUserResponse. This method will return an array containing the entities' ids.

--- a/src/docs/asciidoc/resources/migration_guide_to_4.5.adoc
+++ b/src/docs/asciidoc/resources/migration_guide_to_4.5.adoc
@@ -117,3 +117,9 @@ In order to simplify the code and the administration of opfab, we have deleted t
 `VIEW_ALL_ARCHIVED_CARDS` and `VIEW_ALL_ARCHIVED_CARDS_FOR_USER_PERIMETERS`. So, administrators of opfab have to
 update manually the permissions of the users via the UI, replacing VIEW_ALL_ARCHIVED_CARDS by
 VIEW_ALL_CARDS and VIEW_ALL_ARCHIVED_CARDS_FOR_USER_PERIMETERS by VIEW_ALL_CARDS_FOR_USER_PERIMETERS.
+
+== Deletion of the deprecated API method `opfab.currentCard.getEntityUsedForUserResponse()`
+
+As mentioned in the migration guide to opfab 4.1, the API method `opfab.currentCard.getEntityUsedForUserResponse()`
+has been replaced by `opfab.currentCard.getEntitiesUsableForUserResponse()`. Now, this deprecated API method has been
+deleted, so you need to upgrade your code and use the method `opfab.currentCard.getEntitiesUsableForUserResponse()`.

--- a/ui/main/src/app/business/services/opfabAPI.service.ts
+++ b/ui/main/src/app/business/services/opfabAPI.service.ts
@@ -46,7 +46,6 @@ export class OpfabAPIService {
             isUserAllowedToRespond: false,
             isUserMemberOfAnEntityRequiredToRespond: false,
             entitiesAllowedToRespond: [],
-            entityUsedForUserResponse: null,
             entitiesUsableForUserResponse: [],
             displayContext: '',
             isResponseLocked: false,
@@ -245,12 +244,6 @@ export class OpfabAPIService {
 
         opfab.currentCard.getEntitiesAllowedToRespond = function () {
             return self.currentCard.entitiesAllowedToRespond;
-        };
-        opfab.currentCard.getEntityUsedForUserResponse = function () {
-            logger.warn(
-                ' WARNING : Use of opfab.currentCard.getEntityUsedForUserResponse is deprecated, you should use opfab.currentCard.getEntitiesUsableForUserResponse instead'
-            );
-            return self.currentCard.entityUsedForUserResponse;
         };
         opfab.currentCard.getEntitiesUsableForUserResponse = function () {
             return self.currentCard.entitiesUsableForUserResponse;

--- a/ui/main/src/app/modules/card/components/card-body/card-body.component.ts
+++ b/ui/main/src/app/modules/card/components/card-body/card-body.component.ts
@@ -96,7 +96,6 @@ export class CardBodyComponent implements OnChanges, OnInit, OnDestroy {
     private lastCardSetToReadButNotYetOnFeed;
     private entityIdsAllowedOrRequiredToRespondAndAllowedToSendCards = [];
     public userEntityIdsPossibleForResponse = [];
-    private userEntityIdToUseForResponse = '';
     private userMemberOfAnEntityRequiredToRespondAndAllowedToSendCards = false;
     private unsubscribe$: Subject<void> = new Subject<void>();
 
@@ -246,8 +245,6 @@ export class CardBodyComponent implements OnChanges, OnInit, OnDestroy {
             (entityId) => this.user.entities.includes(entityId)
         );
         logger.debug(`Detail card - user entities allowed to respond = ${this.userEntityIdsPossibleForResponse}`);
-        if (this.userEntityIdsPossibleForResponse.length === 1)
-            this.userEntityIdToUseForResponse = this.userEntityIdsPossibleForResponse[0];
     }
     private computeUserMemberOfAnEntityRequiredToRespondAndAllowedToSendCards() {
         if (!this.card.entitiesRequiredToRespond) {
@@ -337,7 +334,6 @@ export class CardBodyComponent implements OnChanges, OnInit, OnDestroy {
             this.entityIdsAllowedOrRequiredToRespondAndAllowedToSendCards;
         OpfabAPIService.currentCard.isUserMemberOfAnEntityRequiredToRespond =
             this.userMemberOfAnEntityRequiredToRespondAndAllowedToSendCards;
-        OpfabAPIService.currentCard.entityUsedForUserResponse = this.userEntityIdToUseForResponse;
         OpfabAPIService.currentCard.entitiesUsableForUserResponse = this.userEntityIdsPossibleForResponse;
     }
 

--- a/ui/main/src/assets/js/opfab.js
+++ b/ui/main/src/assets/js/opfab.js
@@ -102,7 +102,6 @@ opfab.currentCard = {
     isUserAllowedToRespond: function () {},
     isUserMemberOfAnEntityRequiredToRespond: function () {},
     getEntitiesAllowedToRespond: function () {},
-    getEntityUsedForUserResponse: function () {},
     getDisplayContext: function () {},
     isResponseLocked: function () {},
     getChildCards: function () {},


### PR DESCRIPTION
- In release notes :
  -  In chapter : Features
  -  Text : #6837 : Remove deprecated API method opfab.currentCard.getEntityUsedForUserResponse

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced documentation for the frontend API, improving clarity on various methods and functionalities.
	- Introduction of new methods for handling user interactions and responses in the CurrentCard and CurrentUserCard APIs.
	- Added input sanitization method to enhance security.

- **Bug Fixes**
	- Deprecated and removed outdated API methods, streamlining user response handling.

- **Documentation**
	- Updated migration guide for version 4.5.0, detailing significant changes including library updates and configuration modifications.
	- Clarified API usage and configurations to ensure a smoother transition for users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->