### PR TITLE
Add version option in opfab CLI (#7349)

### DIFF
--- a/CICD/prepare_release_version.sh
+++ b/CICD/prepare_release_version.sh
@@ -70,6 +70,8 @@ sed -i "s/\( *image *: *\"lfeoperatorfabric\/.*:\)\(.*\)\"/\1$newVersion\"/g" ./
 
 echo "Using $newVersion for lfeoperatorfabric/of-opfab-cli"
 sed -i "s/lfeoperatorfabric\/of-opfab-cli:.*/lfeoperatorfabric\/of-opfab-cli:$newVersion/" ./cli/opfabDockerCli.sh;
+sed -i "s/\"version\": \"[^\"]*\"/\"version\": \"$newVersion\"/" ./cli/src/package.json
+
 
 echo "Using $newVersion for About menu in web-ui.json files"
 jq --arg a "${newVersion}" '.opfabVersion = $a' ./ui/main/package.json > "tmp" && mv "tmp" ./ui/main/package.json

--- a/cli/entryPoint.sh
+++ b/cli/entryPoint.sh
@@ -19,6 +19,7 @@ echo -e "                                                                       
 echo -e ""
 
 export HOME=/opfab
+opfab version
 if [ -z "$ENV_NAME" ]; then
     # Add opfab-cli to the prompt in red
     export PS1="\033[32mOPFAB-CLI\033[0m \w \$ "

--- a/cli/src/commands.js
+++ b/cli/src/commands.js
@@ -99,6 +99,9 @@ const commands = {
             case 'help':
                 this.printHelp(args.slice(1));
                 break;
+            case 'version':
+                console.log('OperatorFabric CLI version', require('./package.json').version);
+                break;
             default:
                 console.log(`\n Unknown command : ${args[0]}
                 `);
@@ -190,6 +193,7 @@ const commands = {
         service                 Get or set log level for services
         status                  Show login status
         users                   Manage users
+        version                 Show CLI version
     
     `);
         } else {

--- a/cli/src/index.js
+++ b/cli/src/index.js
@@ -93,7 +93,8 @@ omelette('opfab')
             'set-notified',
             'set-notified-mail',
             'unsetactivityarea'
-        ]
+        ],
+        version: []
     })
     .init();
 

--- a/cli/src/package.json
+++ b/cli/src/package.json
@@ -1,6 +1,6 @@
 {
     "name": "opfab-cli",
-    "version": "1.0.0",
+    "version": "SNAPSHOT",
     "main": "index.js",
     "scripts": {
         "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
- In release notes :
  -  In chapter : Features
  -  Text : #7349 Opfab Cli : add version option  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new command `opfab version` to display the current version of the OperatorFabric CLI.
	- Added version command to the CLI autocompletion options for easier access.
- **Improvements**
	- Updated scripts to automatically modify the version in the `package.json` file during releases. 
- **Documentation**
	- Help output now includes the new `version` command for user guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->