### PR TITLE
UserCard: do not show "Create copy" button if user not allowed to publish the card (#7427)

### DIFF
--- a/src/test/cypress/cypress/integration/UserCard.spec.js
+++ b/src/test/cypress/cypress/integration/UserCard.spec.js
@@ -1334,7 +1334,6 @@ describe('User Card ', function () {
     })
   })
 
-
   describe('Check "create a copy" feature', function () {
     
     it('Check "create a copy" button is present only when it should', () => {
@@ -1361,6 +1360,18 @@ describe('User Card ', function () {
 
       feed.openNthCard(5);
       card.checkCopyButtonDoesExist();
+
+      // chack "create a copy" button is not visible if user not in publisherList entities
+      opfab.navigateToUserCard();
+      usercard.selectService('Base Examples');
+      usercard.selectProcess('Process example');
+      usercard.selectState('Process example');
+      usercard.selectRecipient('Control Center FR South');
+      usercard.previewThenSendCard();
+      opfab.logout();
+      opfab.loginWithUser('operator2_fr');
+      feed.openFirstCard();
+      card.checkCopyButtonDoesNotExist();
     })
 
     

--- a/ui/main/src/app/modules/card/components/card-actions/card-actions.component.ts
+++ b/ui/main/src/app/modules/card/components/card-actions/card-actions.component.ts
@@ -28,6 +28,7 @@ import {NgIf} from '@angular/common';
 import {TranslateModule} from '@ngx-translate/core';
 import {UserCardComponent} from '../../../usercard/usercard.component';
 import {SpinnerComponent} from '../../../share/spinner/spinner.component';
+import {EntitiesService} from 'app/business/services/users/entities.service';
 
 @Component({
     selector: 'of-card-actions',
@@ -81,7 +82,16 @@ export class CardActionsComponent implements OnChanges, OnDestroy {
             !this.isReadOnlyUser &&
             this.cardState.copyCardEnabledOnUserInterface &&
             this.cardState.userCard &&
+            this.isUserMemberOfAnEntityAllowedToPublishForThisState() &&
             UserService.isWriteRightsForProcessAndState(this.card.process, this.card.state);
+    }
+
+    private isUserMemberOfAnEntityAllowedToPublishForThisState(): boolean {
+        if (!this.cardState.userCard.publisherList) return true;
+        const userEntities = UserService.getCurrentUserWithPerimeters().userData.entities;
+        const allowedPublishers = EntitiesService.resolveEntities(this.cardState.userCard.publisherList);
+        const userAllowedEntities = allowedPublishers.filter((publisher) => userEntities.includes(publisher.id));
+        return userAllowedEntities.length > 0;
     }
 
     private doesTheUserHavePermissionToEditCard(): boolean {


### PR DESCRIPTION
Fix #7427

- In release notes :
  -  In chapter : Bugs
  -  Text : #7427 : UserCard: do not show "Create copy" button if user not allowed to publish the card