### PR TITLE
Missing space in templates if startDate, endDate and severity are not visible (#7403)

### DIFF
--- a/src/docs/asciidoc/resources/migration_guide_to_4.6.adoc
+++ b/src/docs/asciidoc/resources/migration_guide_to_4.6.adoc
@@ -10,3 +10,9 @@
 == Deprecated `toNotify` field
 
 The card field `toNotify` is deprecated. You should use the `actions` field including "STORE_ONLY_IN_ARCHIVES" action instead.
+
+== New line added between opfab fields and template in usercard form
+
+A new line (<br/>) has been added in the usercard form, between the opfab fields (service/process/state or severity or
+dates fields (depending on which fields are visible or not)) and the display of the template. So you have to check that
+the display of your usercard form still suits you.

--- a/ui/main/src/app/modules/usercard/usercard.component.html
+++ b/ui/main/src/app/modules/usercard/usercard.component.html
@@ -42,6 +42,7 @@
                     </of-multi-select>
                 </div>
             </div>
+            <br/>
 
             <div [hidden]="templateLoadingInProgress" style="display:flex;align-items: center;justify-content: center;"
                 id="opfab-usercard-input-severity">


### PR DESCRIPTION
- In release notes :
  -  In chapter : Bugs
  -  Text : #7403 : Missing space in templates if startDate, endDate and severity are not visible