### PR TITLE
Archives/Logging screens : display error if there is no process group and no tag (#7425)

### DIFF
--- a/ui/main/src/app/modules/share/archives-logging-filters/archives-logging-filters.component.html
+++ b/ui/main/src/app/modules/share/archives-logging-filters/archives-logging-filters.component.html
@@ -133,7 +133,7 @@
                         [selectedOptions]="processSelected">
                     </of-multi-select>
                 </div>
-                <div style="width: 400px; max-height: 48px">
+                <div style="width: 300px; max-height: 48px">
                     <of-multi-select
                         id="opfab-state"
                         multiSelectId="state"


### PR DESCRIPTION
- In release notes :
  -  In chapter : Bugs
  -  Text : #7425 : Archives/Logging screens : display error if there is no process group and no tag 