### PR TITLE
Uniformize tooltips

### DIFF
--- a/src/test/cypress/cypress/integration/Admin.spec.js
+++ b/src/test/cypress/cypress/integration/Admin.spec.js
@@ -471,7 +471,7 @@ describe('AdmininstrationPages', () => {
 
         agGrid.cellShould('ag-grid-angular', 1, 0, 'have.text', 'testperimeter');
         agGrid.cellShould('ag-grid-angular', 1, 1, 'have.text', 'cypress');
-        agGrid.cellShould('ag-grid-angular', 1, 2, 'have.text', 'Message');
+        agGrid.cellShould('ag-grid-angular', 1, 2, 'contains.text', 'Message');
         // We check the right for Message is ReceiveAndWrite (the badge must be from class opfab-bg-right-receiveandwrite)
         cy.get('ag-grid-angular')
             .find('.ag-center-cols-container')
@@ -522,7 +522,7 @@ describe('AdmininstrationPages', () => {
         // We check the perimeter is updated
         agGrid.cellShould('ag-grid-angular', 1, 0, 'have.text', 'testperimeter');
         agGrid.cellShould('ag-grid-angular', 1, 1, 'have.text', 'cypress');
-        agGrid.cellShould('ag-grid-angular', 1, 2, 'have.text', 'Message with no ack');
+        agGrid.cellShould('ag-grid-angular', 1, 2, 'contains.text', 'Message with no ack');
         // We check the right for Message is Receive (the badge must be from class opfab-bg-right-receive)
         cy.get('ag-grid-angular')
             .find('.ag-center-cols-container')

--- a/ui/main/src/app/modules/activityarea/activityarea.component.html
+++ b/ui/main/src/app/modules/activityarea/activityarea.component.html
@@ -30,14 +30,19 @@
                         </th>
                         <td>
                             <ng-template #connected >
+                               <div class="opfab-tooltip">
                                 <span class="opfab-rounded-badge opfab-blue-background opfab-activityarea-badge">{{line.connectedUsers.length}}
                                 </span>&nbsp;&nbsp;<span [id]="'table-line-' + line.entityId"
                                                          class="opfab-activityarea-table-line"
-                                                         placement="top-left"
-                                                         [disablePopover]="!isEllipsisActive('table-line-' + line.entityId)"
-                                                         [ngbPopover]="usersDropdown" container="body"
-                                                         triggers="mouseenter:mouseleave"
-                                                         popoverClass="opfab-popover-no-arrow">{{line.connectedUsersText}}</span>
+                                                         >{{line.connectedUsersText}}
+
+                                </span>
+                                    <span *ngIf="isEllipsisActive('table-line-' + line.entityId)" class="opfab-tooltip-content bottom" style="margin-top:0px;z-index:1;text-align: left;">  
+                                      <div *ngFor="let user of line.connectedUsers">
+                                        &nbsp; {{user}} &nbsp;
+                                      </div> 
+                                    </span>
+                            </div>
                             </ng-template>
                             <ng-template #disconnected> <span class="opfab-rounded-badge opfab-grey-background opfab-activityarea-badge">0</span></ng-template>
                             <ng-template #usersDropdown>

--- a/ui/main/src/app/modules/activityarea/activityarea.component.ts
+++ b/ui/main/src/app/modules/activityarea/activityarea.component.ts
@@ -8,7 +8,7 @@
  */
 
 import {Component, EventEmitter, Input, OnDestroy, OnInit, Output} from '@angular/core';
-import {NgbModal, NgbPopover} from '@ng-bootstrap/ng-bootstrap';
+import {NgbModal} from '@ng-bootstrap/ng-bootstrap';
 import {NgbModalRef} from '@ng-bootstrap/ng-bootstrap/modal/modal-ref';
 import {FormControl, FormGroup, FormsModule, ReactiveFormsModule} from '@angular/forms';
 import {ActivityAreaView} from 'app/business/view/activityarea/activityarea.view';
@@ -24,7 +24,7 @@ import {SpinnerComponent} from '../share/spinner/spinner.component';
     templateUrl: './activityarea.component.html',
     styleUrls: ['./activityarea.component.scss'],
     standalone: true,
-    imports: [TranslateModule, NgIf, SpinnerComponent, FormsModule, ReactiveFormsModule, NgFor, NgbPopover]
+    imports: [TranslateModule, NgIf, SpinnerComponent, FormsModule, ReactiveFormsModule, NgFor]
 })
 export class ActivityareaComponent implements OnInit, OnDestroy {
     @Input() titleI18nKey = 'activityArea.title';

--- a/ui/main/src/app/modules/admin/components/cell-renderers/state-rights-cell-renderer.component.html
+++ b/ui/main/src/app/modules/admin/components/cell-renderers/state-rights-cell-renderer.component.html
@@ -7,10 +7,13 @@
 <!-- This file is part of the OperatorFabric project.                      -->
 
 <span *ngFor="let element of _stateRightsValues">
+  <span class="opfab-tooltip">
     <span class="opfab-badge opfab-bg-right-{{element.stateRight.right.toString()|lowercase}}"
-          style="font-size: 14px; margin: 3px; color: black"
-          [ngbPopover]="element.stateRight.right.toString()" [openDelay]="300" placement="top" triggers="mouseenter:mouseleave"
-          popoverClass="opfab-popover-unclickable" container="body">{{element.stateName}}</span>
+          style="font-size: 14px; margin: 3px; color: black">{{element.stateName}}</span>
+    <span class="opfab-tooltip-content left" style="text-align:center;min-width: unset;padding-top:0;padding-bottom:0;translate: 10px;">
+      {{element.stateRight.right.toString()}}
+    </span>
+  </span>
 </span>
 
 

--- a/ui/main/src/app/modules/admin/components/cell-renderers/state-rights-cell-renderer.component.ts
+++ b/ui/main/src/app/modules/admin/components/cell-renderers/state-rights-cell-renderer.component.ts
@@ -16,7 +16,6 @@ import {ProcessesService} from 'app/business/services/businessconfig/processes.s
 import {Utilities} from '../../../../business/common/utilities';
 import {LoggerService} from 'app/business/services/logs/logger.service';
 import {NgFor, LowerCasePipe} from '@angular/common';
-import {NgbPopover} from '@ng-bootstrap/ng-bootstrap';
 
 @Component({
     selector: 'of-state-rights-cell-renderer',
@@ -24,7 +23,7 @@ import {NgbPopover} from '@ng-bootstrap/ng-bootstrap';
     styleUrls: ['./state-rights-cell-renderer.component.scss'],
     changeDetection: ChangeDetectionStrategy.OnPush,
     standalone: true,
-    imports: [NgFor, NgbPopover, LowerCasePipe]
+    imports: [NgFor, LowerCasePipe]
 })
 export class StateRightsCellRendererComponent implements ICellRendererAngularComp {
     // For explanations regarding ag-grid CellRenderers see

--- a/ui/main/src/app/modules/admin/components/table/admin-table.directive.html
+++ b/ui/main/src/app/modules/admin/components/table/admin-table.directive.html
@@ -30,7 +30,7 @@
                 (gridReady)="onGridReady($event)"
                 [gridOptions]="gridOptions"
                 [rowData]="rowData"
-                class="ag-theme-opfab"
+                class="ag-theme-opfab opfab-cell-overflow-visible"
                 (filterChanged)="onFilterChanged($event)"
         >
         </ag-grid-angular>

--- a/ui/main/src/app/modules/card/components/card-header/card-header.component.ts
+++ b/ui/main/src/app/modules/card/components/card-header/card-header.component.ts
@@ -36,7 +36,6 @@ export class CardHeaderComponent implements OnChanges {
     @Input() cardState: State;
     @Input() lttdExpiredIsTrue: boolean;
 
-    public showExpiredIcon = true;
     public showExpiredLabel = true;
     public expiredLabel = 'feed.lttdFinished';
     public entitiesForCardHeader: EntityForCardHeader[];
@@ -55,10 +54,8 @@ export class CardHeaderComponent implements OnChanges {
         ProcessesService.queryProcess(this.card.process, this.card.processVersion).subscribe((process) => {
             const state = process.states.get(this.card.state);
             if (state.type === TypeOfStateEnum.FINISHED) {
-                this.showExpiredIcon = false;
                 this.showExpiredLabel = false;
             } else {
-                this.showExpiredIcon = false;
                 this.showExpiredLabel = true;
                 this.expiredLabel = 'feed.responsesClosed';
             }

--- a/ui/main/src/app/modules/feed/components/card-list/filters/filters.component.html
+++ b/ui/main/src/app/modules/feed/components/card-list/filters/filters.component.html
@@ -1,4 +1,4 @@
-<!-- Copyright (c) 2018-2023, RTE (http://www.rte-france.com)              -->
+<!-- Copyright (c) 2018-2024, RTE (http://www.rte-france.com)              -->
 <!-- See AUTHORS.txt                                                       -->
 <!-- This Source Code Form is subject to the terms of the Mozilla Public   -->
 <!-- License, v. 2.0. If a copy of the MPL was not distributed with this   -->
@@ -15,13 +15,10 @@
 
         <div style="width:100%">
         </div>
-        <div  *ngIf="loadingInProgress" class="opfab-loading-spinner">
-            <ng-template #tipLoadingInProgress>
-                <span translate>feed.tips.loadingInProgress</span>
-            </ng-template>
-            <div [ngbPopover]="tipLoadingInProgress" popoverClass="opfab-popover-unclickable" container="body"
-            triggers="mouseenter:mouseleave">
-            <em  class="fas fa-spinner fa-spin opfab-slow-spinner"  ></em>
+        <div *ngIf="loadingInProgress" class="opfab-loading-spinner opfab-tooltip">
+            <div>
+            <em  class="fas fa-spinner fa-spin opfab-slow-spinner"></em>
+            <span class="opfab-tooltip-content left" style="z-index:1;text-align: left;"> <span translate>feed.tips.loadingInProgress</span></span>
             </div>
 
          </div>

--- a/ui/main/src/app/modules/feed/components/card-list/filters/filters.component.ts
+++ b/ui/main/src/app/modules/feed/components/card-list/filters/filters.component.ts
@@ -15,14 +15,13 @@ import {FeedFilterAndSortIconsComponent} from './feed-filter-and-sort-icons/feed
 import {FeedSearchComponent} from './feed-search/feed-search.component';
 import {NgIf} from '@angular/common';
 import {TranslateModule} from '@ngx-translate/core';
-import {NgbPopover} from '@ng-bootstrap/ng-bootstrap';
 
 @Component({
     selector: 'of-filters',
     templateUrl: './filters.component.html',
     styleUrls: ['./filters.component.scss'],
     standalone: true,
-    imports: [FeedFilterAndSortIconsComponent, FeedSearchComponent, NgIf, TranslateModule, NgbPopover]
+    imports: [FeedFilterAndSortIconsComponent, FeedSearchComponent, NgIf, TranslateModule]
 })
 export class FiltersComponent implements OnInit {
     @Input() filterActive: boolean;

--- a/ui/main/src/app/modules/navbar/info/info.component.html
+++ b/ui/main/src/app/modules/navbar/info/info.component.html
@@ -1,4 +1,4 @@
-<!-- Copyright (c) 2018-2023, RTE (http://www.rte-france.com)              -->
+<!-- Copyright (c) 2018-2024, RTE (http://www.rte-france.com)              -->
 <!-- See AUTHORS.txt                                                       -->
 <!-- This Source Code Form is subject to the terms of the Mozilla Public   -->
 <!-- License, v. 2.0. If a copy of the MPL was not distributed with this   -->
@@ -6,8 +6,7 @@
 <!-- SPDX-License-Identifier: MPL-2.0                                      -->
 <!-- This file is part of the OperatorFabric project.                      -->
 
-<div [ngbPopover]="userEntitiesTooltip" #p="ngbPopover" popoverClass="opfab-popover-unclickable" container="body"
-triggers="manual" (mouseenter)="userEntitiesToDisplayTrimmed && p.open()" (mouseleave)="p.close()">
+<div class="opfab-tooltip" >
     <div class="navbar-info-block">
         <div class="opfab-menu-icon-profile"></div>
         <div class="time" >{{timeToDisplay}}</div>
@@ -18,8 +17,7 @@ triggers="manual" (mouseenter)="userEntitiesToDisplayTrimmed && p.open()" (mouse
         <div *ngIf="userEntitiesToDisplay"  class="user-entities" style="padding-top:10px;margin-left:5px;text-align:center; padding-right: 8px;">{{userEntitiesToDisplay}}</div>
         <div *ngIf="!userEntitiesToDisplay" class="user-entities" style="padding-top:5px; padding-right: 8px;"> &nbsp;</div>
     </div>
+    <div *ngIf="userEntitiesToDisplayTrimmed" class="opfab-tooltip-content bottom" style="max-width: 280px;text-align: left;white-space:normal;width:max-content">  
+        <div *ngFor="let entity of userEntities" style="margin: 5px 10px 5px 10px">{{entity}}</div>
+    </div>
 </div>
-
-<ng-template #userEntitiesTooltip>
-    <div *ngFor="let entity of userEntities" style="margin-bottom: 5px;">{{entity}}</div>
-</ng-template>

--- a/ui/main/src/app/modules/navbar/info/info.component.ts
+++ b/ui/main/src/app/modules/navbar/info/info.component.ts
@@ -15,7 +15,6 @@ import {DateTimeFormatterService} from 'app/business/services/date-time-formatte
 import {ApplicationEventsService} from 'app/business/services/events/application-events.service';
 import * as _ from 'lodash-es';
 import {RolesEnum} from '@ofModel/roles.model';
-import {NgbPopover} from '@ng-bootstrap/ng-bootstrap';
 import {NgIf, NgFor} from '@angular/common';
 
 @Component({
@@ -24,7 +23,7 @@ import {NgIf, NgFor} from '@angular/common';
     styleUrls: ['./info.component.scss'],
     changeDetection: ChangeDetectionStrategy.OnPush,
     standalone: true,
-    imports: [NgbPopover, NgIf, NgFor]
+    imports: [NgIf, NgFor]
 })
 export class InfoComponent implements OnInit {
     userName: string;

--- a/ui/main/src/app/modules/navbar/navbar.component.html
+++ b/ui/main/src/app/modules/navbar/navbar.component.html
@@ -99,20 +99,22 @@
     <nav class="opfab-full-navbar" aria-label="Full Navigation Icons">
         <ul class="opfab-icons-menu">
             <ng-template #createNewCard>
-                <span translate>menu.newcardTooltip</span>
+              
             </ng-template>
-            <li id="opfab-newcard-menu" *ngIf="navbarMenuView.getNavbarMenu().isCreateUserCardIconVisible">
+            <li class="opfab-tooltip" id="opfab-newcard-menu" *ngIf="navbarMenuView.getNavbarMenu().isCreateUserCardIconVisible">
                 <a tabindex="0" (click)="openCardCreation()" (keydown.enter)="openCardCreation()">
                     <div class="opfab-menu-icon-newcard"></div>
                 </a>
+                <div class="opfab-tooltip-content bottom" style="margin-top: 0px;min-width: unset;">  <span translate>menu.newcardTooltip</span></div>
             </li>
             <ng-template #calendartooltip>
                 <span translate>menu.calendarTooltip</span>
             </ng-template>
-            <li id="opfab-calendar-menu" *ngIf="navbarMenuView.getNavbarMenu().isCalendarIconVisible">
+            <li class="opfab-tooltip" id="opfab-calendar-menu" *ngIf="navbarMenuView.getNavbarMenu().isCalendarIconVisible">
                 <a tabindex="0" (click)="goToCoreMenu('calendar')" (keydown.enter)="goToCoreMenu('calendar')">
                     <div class="opfab-menu-icon-calendar"></div>
                 </a>
+                <div class="opfab-tooltip-content bottom" style="margin-top: 0px;min-width:unset;">  <span translate>menu.calendarTooltip</span></div>
             </li>
             <li class="opfab-navbar-info">
                 <a

--- a/ui/main/src/app/modules/realtimeusers/realtimeusers.component.html
+++ b/ui/main/src/app/modules/realtimeusers/realtimeusers.component.html
@@ -33,27 +33,24 @@
                     <table class="opfab-realtimeusers-entitiesgroups-table" aria-describedby="real time users table">
                         <tr *ngFor="let line of entitiesGroupsElement.lines;">
                             <th scope="row">{{line.entityName}}</th>
-
                             <td>
                                 <ng-template #connected>
+                                  <div class="opfab-tooltip">
                                     <span class="opfab-rounded-badge opfab-blue-background">{{line.connectedUsersCount}}
                                     </span>
-                                    <span [id]="'grouped-label-' + line.entityId" class="opfab-group-label"
-                                        [disablePopover]="!isEllipsisActive('grouped-label-' + line.entityId)"
-                                        placement="top-left"
-                                        [ngbPopover]="usersDropdown" container="body"
-                                        triggers="mouseenter:mouseleave"
-                                        popoverClass="opfab-popover-no-arrow">
+                                    <span [id]="'grouped-label-' + line.entityId" class="opfab-group-label">
                                         {{line.connectedUsers}}
+                                    </span>
+                                    <span  *ngIf="isEllipsisActive('grouped-label-' + line.entityId)">
+                                      <span class="opfab-tooltip-content bottom" style="z-index:1;text-align: left;">
+                                        <div *ngFor="let user of line.connectedUsers.split(', ')">
+                                          {{user}}
+                                        </div>
                                       </span>
+                                     </span>
+                                  </div>
                                 </ng-template>
-                                <ng-template #usersDropdown>
-                                    <div *ngFor="let user of line.connectedUsers.split(', ')">
-                                      {{user}}
-                                    </div>
-                                  </ng-template>
-                                
-                                  <ng-template #disconnected>
+                                <ng-template #disconnected>
                                     <span class="opfab-rounded-badge opfab-grey-background">0</span>
                                 </ng-template>
                                 <span *ngIf="line.connectedUsersCount;then connected else disconnected"></span>

--- a/ui/main/src/app/modules/realtimeusers/realtimeusers.component.ts
+++ b/ui/main/src/app/modules/realtimeusers/realtimeusers.component.ts
@@ -18,23 +18,13 @@ import {TranslateModule} from '@ngx-translate/core';
 import {NgIf, NgFor} from '@angular/common';
 import {SpinnerComponent} from '../share/spinner/spinner.component';
 import {MultiSelectComponent} from '../share/multi-select/multi-select.component';
-import {NgbPopover} from '@ng-bootstrap/ng-bootstrap';
 
 @Component({
     selector: 'of-realtimeusers',
     templateUrl: './realtimeusers.component.html',
     styleUrls: ['./realtimeusers.component.scss'],
     standalone: true,
-    imports: [
-        TranslateModule,
-        FormsModule,
-        ReactiveFormsModule,
-        NgIf,
-        SpinnerComponent,
-        MultiSelectComponent,
-        NgFor,
-        NgbPopover
-    ]
+    imports: [TranslateModule, FormsModule, ReactiveFormsModule, NgIf, SpinnerComponent, MultiSelectComponent, NgFor]
 })
 export class RealtimeusersComponent implements OnInit, OnDestroy {
     realTimeScreensForm: FormGroup<{

--- a/ui/main/src/app/modules/share/countdown/countdown.component.html
+++ b/ui/main/src/app/modules/share/countdown/countdown.component.html
@@ -1,4 +1,4 @@
-<!-- Copyright (c) 2021-2023, RTE (http://www.rte-france.com)              -->
+<!-- Copyright (c) 2021-2024, RTE (http://www.rte-france.com)              -->
 <!-- See AUTHORS.txt                                                       -->
 <!-- This Source Code Form is subject to the terms of the Mozilla Public   -->
 <!-- License, v. 2.0. If a copy of the MPL was not distributed with this   -->
@@ -6,17 +6,11 @@
 <!-- SPDX-License-Identifier: MPL-2.0                                      -->
 <!-- This file is part of the OperatorFabric project.                      -->
 
-<ng-template #tipLttd>
-    <span translate>feed.tips.lttd</span>
-</ng-template>
 
-<span *ngIf="this.countDown.isCounting()" class="lttd-timeleft" placement="right" [ngbPopover]="tipLttd" popoverClass="opfab-popover-unclickable" container="body" triggers="mouseenter:mouseleave">{{this.countDown.getCountDown()}}<em class="far fa-clock lttd-icon lttd-timeleft"></em>
+<span *ngIf="this.countDown.isCounting()" class="opfab-tooltip lttd-timeleft">
+    {{this.countDown.getCountDown()}}<em class="far fa-clock lttd-icon lttd-timeleft"></em>
+    <div class="opfab-tooltip-content left" style="white-space: nowrap;font-size: 11pt;">  <span translate>feed.tips.lttd</span></div>
 </span>
-<span *ngIf="this.countDown.isEnded() && showExpiredIcon" placement="right" [ngbPopover]="tipLttd" popoverClass="opfab-popover-unclickable" container="body" triggers="mouseenter:mouseleave">
-        <span *ngIf="showExpiredLabel" class="lttd-text">{{translatedExpiredLabel}}</span>  
-        <span *ngIf="showExpiredIcon"><em class="far fa-clock lttd-icon" ></em></span> 
-</span>
-<span *ngIf="this.countDown.isEnded() && !showExpiredIcon">
+<span *ngIf="this.countDown.isEnded()">
     <span *ngIf="showExpiredLabel" class="lttd-text">{{translatedExpiredLabel}}</span>  
-    <span *ngIf="showExpiredIcon"><em class="far fa-clock lttd-icon" ></em></span> 
 </span>

--- a/ui/main/src/app/modules/share/countdown/countdown.component.ts
+++ b/ui/main/src/app/modules/share/countdown/countdown.component.ts
@@ -12,22 +12,20 @@ import {TranslateService, TranslateModule} from '@ngx-translate/core';
 import {ConfigService} from 'app/business/services/config.service';
 import {CountDown} from '../../../business/common/countdown/countdown';
 import {NgIf} from '@angular/common';
-import {NgbPopover} from '@ng-bootstrap/ng-bootstrap';
 
 @Component({
     selector: 'of-countdown',
     templateUrl: './countdown.component.html',
     styleUrls: ['./countdown.component.scss'],
     standalone: true,
-    imports: [TranslateModule, NgIf, NgbPopover]
+    imports: [TranslateModule, NgIf]
 })
 export class CountDownComponent implements OnInit, OnDestroy, OnChanges {
     @Input() public lttd: number;
     @Input() public expiredLabel: string;
     @Input() public showExpiredLabel: boolean = true;
-    @Input() public showExpiredIcon: boolean = true;
 
-    public countDown;
+    public countDown: CountDown;
     public translatedExpiredLabel: string;
     secondsBeforeLttdForClockDisplay: number;
 

--- a/ui/main/src/app/modules/share/light-card/light-card.component.html
+++ b/ui/main/src/app/modules/share/light-card/light-card.component.html
@@ -27,34 +27,21 @@
                 </p>
                 <div style="text-align: right;padding-right: 5px;">
                     <div>
-                        <ng-template #tipHasAResponseFromYourEntity>
-                            <span translate>feed.tips.hasAResponseFromYourEntity</span>
-                        </ng-template>
-                        <span *ngIf="lightCard.hasChildCardFromCurrentUserEntity" id="opfab-feed-lightcard-hasChildCardFromCurrentUserEntity" style="padding:.25rem"
-                            [ngbPopover]="tipHasAResponseFromYourEntity" popoverClass="opfab-popover-unclickable" container="body"
-                            triggers="mouseenter:mouseleave">
+                        <span class="opfab-tooltip" *ngIf="lightCard.hasChildCardFromCurrentUserEntity" id="opfab-feed-lightcard-hasChildCardFromCurrentUserEntity" style="padding:.25rem">
                             <em style="color: var(--opfab-color-blue);" class="fa fa-reply"></em>
+                            <div class="opfab-tooltip-content left opfab-lightcard-tooltip"><span translate>feed.tips.hasAResponseFromYourEntity</span></div>
                         </span>
-                        <ng-template #tipAcknowledged>
-                            <span translate>feed.tips.acknowledged</span>
-                        </ng-template>
-                        <span *ngIf="this.lightCard.hasBeenAcknowledged" style="padding:.25rem"
-                              [ngbPopover]="tipAcknowledged" popoverClass="opfab-popover-unclickable" container="body"
-                              triggers="mouseenter:mouseleave">
+                        <span class="opfab-tooltip" *ngIf="this.lightCard.hasBeenAcknowledged" style="padding:.25rem">
                             <em style="color: var(--opfab-color-blue);" class="fa fa-check"></em>
+                            <div class="opfab-tooltip-content left opfab-lightcard-tooltip"> <span translate>feed.tips.acknowledged</span></div>
                         </span>
-                        <ng-template #tipTags>
-                            <span translate>feed.tips.seeGroupedCards</span>
-                        </ng-template>
-                        <span *ngIf="showGroupedCardsIcon" style="padding:.25rem"
-                              [ngbPopover]="tipTags" popoverClass="opfab-popover-unclickable" container="body"
-                              triggers="mouseenter:mouseleave">
+                        <span class="opfab-tooltip" *ngIf="showGroupedCardsIcon" style="padding:.25rem">
                             <em id="opfab-feed-light-card-group-icon" style="color: var(--opfab-color-blue);" class="fa " [class.fa-angle-down]="open" [class.fa-angle-left]="!open || !groupedCardsVisible"></em>
+                            <div class="opfab-tooltip-content left opfab-lightcard-tooltip"><span translate>feed.tips.seeGroupedCards</span></div>
                         </span>
-                        <span *ngIf="isGeoMapEnabled && hasGeoLocation" (click)='zoomToLocation($event)' style="padding:.25rem"
-                              placement="right" [ngbPopover]="tipSeeGeolocation" popoverClass="opfab-popover-unclickable" container="body"
-                              triggers="mouseenter:mouseleave">
+                        <span class="opfab-tooltip" *ngIf="isGeoMapEnabled && hasGeoLocation" (click)='zoomToLocation($event)' style="padding:.25rem">
                             <em style="color: var(--opfab-color-blue);" class="fa fa-location-crosshairs"></em>
+                            <div class="opfab-tooltip-content left opfab-lightcard-tooltip"><span translate>feed.tips.seeGeolocation</span></div>
                         </span>
                     </div>
                 </div>
@@ -64,12 +51,10 @@
                 <p *ngIf="this.dateToDisplay" id="opfab-lightcard-dates" class="card-subtitle">({{this.dateToDisplay}})</p>
 
                 <div style="text-align: right;margin-top: -5px;margin-right: 5px;padding-right: 5px; ">
-                        <of-countdown  *ngIf="!!lightCard.lttd" [lttd]="lightCard.lttd" [showExpiredIcon]="showExpiredIcon" [showExpiredLabel]="showExpiredLabel" [expiredLabel]="expiredLabel"></of-countdown>
-
-                        <span *ngIf="lightCard.expirationDate" class="expiration-date" id="opfab-card-expiration-date"
-                              [ngbPopover]="this.expirationDateToDisplay" popoverClass="opfab-popover-unclickable" container="body" placement="right"
-                              triggers="mouseenter:mouseleave">
+                        <of-countdown  *ngIf="!!lightCard.lttd" [lttd]="lightCard.lttd" [showExpiredLabel]="showExpiredLabel" [expiredLabel]="expiredLabel"></of-countdown>
+                        <span class="opfab-tooltip expiration-date" *ngIf="lightCard.expirationDate" id="opfab-card-expiration-date">
                             <em style="color: var(--opfab-color-darker-orange);margin-left: 8px;" class="fa fa-hourglass"></em>
+                            <div class="opfab-tooltip-content left opfab-lightcard-tooltip"><span >{{this.expirationDateToDisplay}}</span></div>
                         </span>
                 </div>
             </div>
@@ -82,7 +67,6 @@
         <div style="width: 100%;margin-top:3px;padding:.25rem">
             <span *ngIf="open">
                 <span id="opfab-selected-card-summary">{{lightCard.summaryTranslated}}</span>
-
                 <div id="opfab-form-entity" *ngIf="fromEntity" style="font-style: italic;text-align: right;width: 100%">
                     <span style="text-transform: capitalize" translate>feed.from</span>
                     <span class="text-uppercase">&nbsp;:&nbsp;{{fromEntity}}</span>
@@ -99,7 +83,3 @@
 <div *ngIf="open && groupedCardsVisible">
     <of-grouped-card-list [lightCards]="getGroupedChildCards()" [selection]="selection"> </of-grouped-card-list>
 </div>
-
-<ng-template #tipSeeGeolocation>
-    <span translate>feed.tips.seeGeolocation</span>
-</ng-template>

--- a/ui/main/src/app/modules/share/light-card/light-card.component.scss
+++ b/ui/main/src/app/modules/share/light-card/light-card.component.scss
@@ -97,3 +97,8 @@
 #opfab-selected-card-summary {
     word-break: break-all;
 }
+
+.opfab-lightcard-tooltip {
+    white-space: nowrap;
+    min-width: unset;
+}

--- a/ui/main/src/app/modules/share/light-card/light-card.component.ts
+++ b/ui/main/src/app/modules/share/light-card/light-card.component.ts
@@ -43,7 +43,6 @@ export class LightCardComponent implements OnInit, OnDestroy {
     dateToDisplay: string;
     truncatedTitle: string;
     fromEntity = null;
-    showExpiredIcon = true;
     showExpiredLabel = true;
     expiredLabel = 'feed.lttdFinished';
     expirationDateToDisplay: string;
@@ -79,10 +78,8 @@ export class LightCardComponent implements OnInit, OnDestroy {
         ProcessesService.queryProcess(this.lightCard.process, this.lightCard.processVersion).subscribe((process) => {
             const state = process.states.get(this.lightCard.state);
             if (state.type === TypeOfStateEnum.FINISHED) {
-                this.showExpiredIcon = false;
                 this.showExpiredLabel = false;
             } else if (state.response) {
-                this.showExpiredIcon = false;
                 this.expiredLabel = 'feed.responsesClosed';
             }
         });

--- a/ui/main/src/app/modules/share/timeline-buttons/timeline-buttons.component.html
+++ b/ui/main/src/app/modules/share/timeline-buttons/timeline-buttons.component.html
@@ -10,9 +10,6 @@
     <div *ngIf='hideTimeLine || isMonitoringScreen' class="opfab-business-period">
       <span translate>timeline.businessPeriod</span> : {{startDateForBusinessPeriodDisplay}}<span *ngIf='this.currentDomainId !== "J"'> &#45;&#45;  {{endDateForBusinessPeriodDisplay}} </span>
     </div>
-
-
-
     <div id="opfab-menu-timeline-links">
 
       <ul style="padding-top: 0.15em;">
@@ -35,21 +32,17 @@
         </li>
 
         <li style="width:1.5em;cursor: pointer">
-          <span *ngIf="isTimelineLocked()" id="opfab-timeline-unlock" class="fas fa-lock" (click)="unlockTimeline()"
-                [ngbPopover]="tipLockedTimeline" popoverClass="opfab-popover-unclickable" placement="left" container="body" triggers="mouseenter:mouseleave"></span>
-          <span *ngIf="!isTimelineLocked()" id="opfab-timeline-lock" class="fas fa-lock-open" (click)="lockTimeline()"
-                [ngbPopover]="tipUnlockedTimeline" popoverClass="opfab-popover-unclickable" placement="left" container="body" triggers="mouseenter:mouseleave"></span>
-
-          <ng-template #tipLockedTimeline>
-            <span id="opfab-timeline-lock-popover" translate>timeline.lockTooltip</span>
-          </ng-template>
-
-          <ng-template #tipUnlockedTimeline>
-            <span id="opfab-timeline-unlock-popover" translate>timeline.unlockTooltip</span>
-          </ng-template>
+        <span *ngIf="isTimelineLocked()" class="opfab-tooltip" style="position:absolute">
+          <em id="opfab-timeline-unlock" class="fas fa-lock" (click)="unlockTimeline()" ></em>
+          <!-- z-index is to be set superior to navabr z-index otherwise the tooltip is partially hidden-->
+          <div class="opfab-tooltip-content left" style="z-index: 1001;"> <span translate>timeline.lockTooltip</span> </div>
+        </span>
+        <span *ngIf="!isTimelineLocked()" class="opfab-tooltip" style="position:absolute">
+          <em id="opfab-timeline-lock" class="fas fa-lock-open" (click)="lockTimeline() "></em>
+          <!-- z-index is to be set superior to navabr z-index otherwise the tooltip is partially hidden-->
+          <div class="opfab-tooltip-content left" style="z-index: 1001;"> <span translate>timeline.unlockTooltip</span> </div>
+        </span>
         </li>
-
-
       </ul>
     </div>
   </div>

--- a/ui/main/src/app/modules/share/timeline-buttons/timeline-buttons.component.ts
+++ b/ui/main/src/app/modules/share/timeline-buttons/timeline-buttons.component.ts
@@ -15,14 +15,13 @@ import {LogOption, LoggerService as logger} from 'app/business/services/logs/log
 import {RealtimeDomainService} from 'app/business/services/realtime-domain.service';
 import {NgIf, NgFor, NgClass} from '@angular/common';
 import {TranslateModule} from '@ngx-translate/core';
-import {NgbPopover} from '@ng-bootstrap/ng-bootstrap';
 
 @Component({
     selector: 'of-timeline-buttons',
     templateUrl: './timeline-buttons.component.html',
     styleUrls: ['./timeline-buttons.component.scss'],
     standalone: true,
-    imports: [NgIf, TranslateModule, NgFor, NgClass, NgbPopover]
+    imports: [NgIf, TranslateModule, NgFor, NgClass]
 })
 export class TimelineButtonsComponent implements OnInit, OnDestroy {
     public hideTimeLine = false;

--- a/ui/main/src/scss/styles.scss
+++ b/ui/main/src/scss/styles.scss
@@ -377,6 +377,13 @@ ngb-pagination {
     )
 );
 
+// this settings is necessary to have tooltips in cell that can be visible outside the cell
+.opfab-cell-overflow-visible {
+    .ag-cell-value {
+        overflow: visible;
+    }
+}
+
 .ag-theme-opfab {
     --ag-borders: none;
     --ag-header-height: 70px;

--- a/ui/main/src/shared/css/opfab-application.css
+++ b/ui/main/src/shared/css/opfab-application.css
@@ -40,6 +40,8 @@
     --opfab-popover-bgcolor: #182638;
     --opfab-tooltip-template-bgcolor: #182638;
     --opfab-tooltip-template-bgcolor-for-form-lighter: #182638;
+    --opfab-tooltip-template-border-color:#182638 ;
+    --opfab-tooltip-template-arrow-color: white;
     --opfab-feedbar-icon-color: white;
     --opfab-feedbar-icon-hover-color: white;
     --opfab-feedbar-icon-hover-bgcolor: #131d2b;
@@ -100,6 +102,8 @@
     --opfab-popover-bgcolor: #f3f2f1;
     --opfab-tooltip-template-bgcolor: white;
     --opfab-tooltip-template-bgcolor-for-form-lighter: #f3f2f1;
+    --opfab-tooltip-template-border-color: #ccc;
+    --opfab-tooltip-template-arrow-color: #ccc;
     --opfab-feedbar-icon-color: black;
     --opfab-feedbar-icon-hover-color: #212529;
     --opfab-feedbar-icon-hover-bgcolor: #f3f2f1;
@@ -804,7 +808,9 @@ input:-webkit-autofill:active {
     padding: 10px;
     border-radius: 10px;
     background: var(--opfab-tooltip-template-bgcolor);
+    border: 1px solid var(--opfab-tooltip-template-border-color);
     color: var(--opfab-text-color);
+    font-size: 15px;
     text-align: center;
     display: none; /* hide by default */
     opacity: 0;
@@ -822,10 +828,10 @@ input:-webkit-autofill:active {
     top: 50%;
     transform: translateY(-50%);
   
-
     /* the arrow */
-    border: 10px solid var(--opfab-tooltip-template-bgcolor);
-    border-color: transparent var(--opfab-tooltip-template-bgcolor) transparent transparent;
+    border: 8px solid var(--opfab-tooltip-template-arrow-color);
+    border-color:  transparent var(--opfab-tooltip-template-arrow-color) transparent transparent;
+ 
 
 }
 
@@ -870,8 +876,8 @@ input:-webkit-autofill:active {
     width: fit-content;
 
     /* the arrow */
-    border: 10px solid var(--opfab-tooltip-template-bgcolor);
-    border-color: transparent transparent transparent var(--opfab-tooltip-template-bgcolor);
+    border: 8px solid var(--opfab-tooltip-template-bgcolor);
+    border-color: transparent transparent transparent var(--opfab-tooltip-template-arrow-color);
 
 }
 
@@ -917,8 +923,8 @@ input:-webkit-autofill:active {
     width: fit-content;
 
     /* the arrow */
-    border: 10px solid var(--opfab-tooltip-template-bgcolor);
-    border-color: var(--opfab-tooltip-template-bgcolor) transparent transparent transparent;
+    border: 8px solid var(--opfab-tooltip-template-bgcolor);
+    border-color: var(--opfab-tooltip-template-arrow-color) transparent transparent;
 }
 
 .opfab-tooltip-content.bottom {
@@ -966,8 +972,8 @@ input:-webkit-autofill:active {
     width: fit-content;
 
     /* the arrow */
-    border: 10px solid var(--opfab-tooltip-template-bgcolor);
-    border-color:  transparent transparent var(--opfab-tooltip-template-bgcolor) transparent;
+    border: 8px solid var(--opfab-tooltip-template-arrow-color);
+    border-color:  transparent transparent var(--opfab-tooltip-template-arrow-color);
 }
 
 .opfab-form-lighter .opfab-tooltip-content {
@@ -986,28 +992,6 @@ input:-webkit-autofill:active {
     background: var(--opfab-tooltip-template-bgcolor-for-form-lighter);
 }
 
-.opfab-form-lighter .opfab-tooltip-content::after {
-    border: 10px solid var(--opfab-tooltip-template-bgcolor-for-form-lighter);
-    border-color: transparent var(--opfab-tooltip-template-bgcolor-for-form-lighter) transparent transparent;
-}
-
-.opfab-form-lighter .opfab-tooltip-content.left::after {
-    /* the arrow */
-    border: 10px solid var(--opfab-tooltip-template-bgcolor-for-form-lighter);
-    border-color: transparent transparent transparent var(--opfab-tooltip-template-bgcolor-for-form-lighter);
-}
-
-.opfab-form-lighter .opfab-tooltip-content.top::after {
-    /* the arrow */
-    border: 10px solid var(--opfab-tooltip-template-bgcolor-for-form-lighter);
-    border-color: var(--opfab-tooltip-template-bgcolor-for-form-lighter) transparent transparent transparent;
-}
-
-.opfab-form-lighter .opfab-tooltip-content.bottom::after {
-    /* the arrow */
-    border: 10px solid var(--opfab-tooltip-template-bgcolor-for-form-lighter);
-    border-color: transparent transparent var(--opfab-tooltip-template-bgcolor-for-form-lighter) transparent;
-}
 
 .opfab-tooltip:hover .opfab-tooltip-content {
     display: block;


### PR DESCRIPTION
Remove use of ngbPopover for tooltips, use instead template tooltips Adjust color for tooltips (Border and arrow)
Remove unneeded showExpiredIcon
Add missing tooltips for calendar and menu icons

- In release notes :
  -  In chapter : Tasks
  -  Text : #7617 Uniformize tooltips