### PR TITLE
Opfab-cli : "opfab get log-level" for external-devices failed (#7811)

### DIFF
--- a/cli/src/logCommands.js
+++ b/cli/src/logCommands.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2024, RTE (http://www.rte-france.com)
+/* Copyright (c) 2024-2025, RTE (http://www.rte-france.com)
  * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -109,6 +109,9 @@ const logCommands = {
     getServicePath(serviceName) {
         let path = serviceName + '/actuator/loggers/ROOT';
         switch (serviceName) {
+            case 'external-devices':
+                path = 'externaldevices/actuator/loggers/ROOT';
+                break;
             case 'supervisor':
             case 'cards-reminder':
             case 'cards-external-diffusion':


### PR DESCRIPTION
- In release notes :
  -  In chapter : Bugs
  -  Text : #7811 : Opfab-cli : "opfab get log-level" for external-devices failed