### PR TITLE
Card edit button should not be visible in Archives screen (#7803)

### DIFF
--- a/src/test/resources/bundles/defaultProcess_V1/template/template.handlebars
+++ b/src/test/resources/bundles/defaultProcess_V1/template/template.handlebars
@@ -1,4 +1,4 @@
-<!-- Copyright (c) 2023-2024, RTE (http://www.rte-france.com)              -->
+<!-- Copyright (c) 2023-2025, RTE (http://www.rte-france.com)              -->
 <!-- See AUTHORS.txt                                                       -->
 <!-- This Source Code Form is subject to the terms of the Mozilla Public   -->
 <!-- License, v. 2.0. If a copy of the MPL was not distributed with this   -->
@@ -8,33 +8,26 @@
 
 <h4> Hello {{userContext.login}}, you received the following message </h4>
 
-<br/>
+<br />
 
-<div class="template-style">
-<span id="richMessage">{{card.data.richMessage}}</span>
+<div class='template-style'>
+<span id='richMessage'>{{card.data.richMessage}}</span>
 </div>
 
-
-<br/>
-<br/>
-<br/>
+<br />
+<br />
+<br />
 
 <div>
-    <button id="editButton"  class="opfab-btn" onClick="editCard()">Edit</button>
+    <button id='editButton' class='opfab-btn' onClick='editCard()'>Edit</button>
 </div>
-
 
 <script>
     opfab.richTextEditor.showRichMessage(document.getElementById("richMessage"));
-
-    if (!opfab.currentCard.isUserAllowedToEdit()) {
-        console.log(new Date().toISOString(),"Hide edit button");
+    
+    if (!opfab.currentCard.isUserAllowedToEdit() || opfab.currentCard.getDisplayContext() == 'archive') { 
         document.getElementById("editButton").setAttribute('hidden', true);
     }
-    else console.log(new Date().toISOString(),"Do not hide edit button");
-
-    function editCard() {
-        opfab.currentCard.editCard();
-    }
+    function editCard() { opfab.currentCard.editCard(); }
 
 </script>


### PR DESCRIPTION
- In release notes :
  -  In chapter : Bugs
  -  Text : #7803 In archives card display edit button shall never appears in message card example