### PR TITLE
First version of custom card list screen

### DIFF
--- a/config/docker/externalJs/CustomScreenExample.js
+++ b/config/docker/externalJs/CustomScreenExample.js
@@ -1,0 +1,62 @@
+/* Copyright (c) 2025, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
+ */
+
+{
+    console.log(new Date().toISOString(), 'INFO Custom screen example loaded');
+    const customScreenExample = {
+        id: 'testId',
+        name: 'testName',
+        results: {
+            columns: [
+                {
+                    field: 'severity',
+                    cardField: 'severity',
+                    fieldType: 'SEVERITY',
+                },
+                {
+                    field: 'TIME',
+                    cardField: 'publishDate',
+                    fieldType: 'DATE_AND_TIME'
+                },
+                {
+                    field: 'testField',
+                    headerName: 'TITLE',
+                    cardField: 'titleTranslated',
+                    fieldType: 'STRING',
+                    flex: 1
+                },
+                {
+                    field: 'testField2',
+                    headerName: 'SUMMARY',
+                    cardField: 'summaryTranslated',
+                    fieldType: 'STRING',
+                    flex: 2
+                },
+                {
+                    fieldType: 'TYPE_OF_STATE',
+                    headerName: 'STATUS'
+
+                },
+                {
+                    field: 'publisher',
+                    headerName: 'EMITTER',
+                    cardField: 'publisher',
+                    fieldType: 'PUBLISHER'
+                },
+                {
+                    headerName: 'ANSWERS',
+                    fieldType: 'RESPONSES',
+                    flex: 2
+                }
+            ]
+        }
+    }
+
+    opfab.businessconfig.registerCustomScreen(customScreenExample);
+}

--- a/config/docker/ui-config/web-ui.json
+++ b/config/docker/ui-config/web-ui.json
@@ -152,8 +152,10 @@
   "usercard": {
     "useDescriptionFieldForEntityList": false
   },
-  "customJsToLoad": ["http://localhost:2002/externalJs/handlebarsExample.js","http://localhost:2002/externalJs/loadTags.js"],
   "customCssToLoad": ["http://localhost:2002/externalCss/externalStyle.css"],
+  "customJsToLoad": ["http://localhost:2002/externalJs/handlebarsExample.js",
+        "http://localhost:2002/externalJs/loadTags.js",
+        "http://localhost:2002/externalJs/CustomScreenExample.js"],
   "dashboard": {
     "processStateRedirects": [
       {

--- a/ui/main/src/app/api/businessconfig.api.ts
+++ b/ui/main/src/app/api/businessconfig.api.ts
@@ -1,4 +1,4 @@
-/* Copyright (c) 2023-2024, RTE (http://www.rte-france.com)
+/* Copyright (c) 2023-2025, RTE (http://www.rte-france.com)
  * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -8,6 +8,7 @@
  */
 
 import {BusinessDataService} from '@ofServices/businessdata/businessdata.service';
+import {CustomScreenService} from '@ofServices/customScreen/CustomScreenService';
 import {LogOption, LoggerService as logger} from 'app/services/logs/LoggerService';
 
 declare const opfab: any;
@@ -32,6 +33,13 @@ export class BusinessConfigAPI {
                 }
                 BusinessConfigAPI.getTags = getTagsFunction;
                 logger.info('Registered function to get tags', LogOption.LOCAL_AND_REMOTE);
+            },
+            registerCustomScreen: function (customScreen) {
+                if (typeof customScreen !== 'object') {
+                    throw new TypeError('registerCustomScreen : the provided object is not an object');
+                }
+                CustomScreenService.addCustomScreenDefinition(customScreen);
+                logger.info('Registered custom screen', LogOption.LOCAL_AND_REMOTE);
             }
         };
         // prevent unwanted modifications from templates code or custom scripts

--- a/ui/main/src/app/components/card/components/card-actions/card-actions.component.ts
+++ b/ui/main/src/app/components/card/components/card-actions/card-actions.component.ts
@@ -153,7 +153,8 @@ export class CardActionsComponent implements OnInit, OnChanges, OnDestroy {
         if (
             NavigationService.getCurrentPageType() !== PageType.CALENDAR &&
             NavigationService.getCurrentPageType() !== PageType.MONITORING &&
-            NavigationService.getCurrentPageType() !== PageType.DASHBOARD
+            NavigationService.getCurrentPageType() !== PageType.DASHBOARD &&
+            NavigationService.getCurrentPageType() !== PageType.CUSTOMSCREEN
         ) {
             this.editModal.result.then(
                 () => {

--- a/ui/main/src/app/components/card/components/card-body/card-body.component.ts
+++ b/ui/main/src/app/components/card/components/card-body/card-body.component.ts
@@ -119,9 +119,19 @@ export class CardBodyComponent implements OnChanges, OnInit, OnDestroy {
         this.cardBodyView = new CardBodyView(this.card, this.userWithPerimeters);
         this.integrateChildCardsInRealTime();
         const pageType = NavigationService.getCurrentPageType();
-        if (pageType === PageType.CALENDAR || pageType === PageType.MONITORING || pageType === PageType.DASHBOARD)
+        if (
+            pageType === PageType.CALENDAR ||
+            pageType === PageType.MONITORING ||
+            pageType === PageType.DASHBOARD ||
+            pageType === PageType.CUSTOMSCREEN
+        )
             this.templateOffset = 35;
-        if (pageType !== PageType.CALENDAR && pageType !== PageType.MONITORING && pageType !== PageType.DASHBOARD)
+        if (
+            pageType !== PageType.CALENDAR &&
+            pageType !== PageType.MONITORING &&
+            pageType !== PageType.DASHBOARD &&
+            pageType !== PageType.CUSTOMSCREEN
+        )
             this.showMaxAndReduceButton = true;
         this.openNextCardOnAcknowledgment =
             pageType === PageType.FEED && ConfigService.getConfigValue('settings.openNextCardOnAcknowledgment', false);

--- a/ui/main/src/app/components/customCardList/CustomCardListComponent.html
+++ b/ui/main/src/app/components/customCardList/CustomCardListComponent.html
@@ -1,0 +1,106 @@
+<!-- Copyright (c) 2025, RTE (http://www.rte-france.com)              -->
+<!-- See AUTHORS.txt                                                       -->
+<!-- This Source Code Form is subject to the terms of the Mozilla Public   -->
+<!-- License, v. 2.0. If a copy of the MPL was not distributed with this   -->
+<!-- file, You can obtain one at http://mozilla.org/MPL/2.0/.              -->
+<!-- SPDX-License-Identifier: MPL-2.0                                      -->
+<!-- This file is part of the OperatorFabric project.                      -->
+
+<div *ngIf="!isCustomScreenDefinitionExist">
+    <h1>Custom Screen {{id}} does not exist</h1>
+</div>
+
+<div *ngIf="isCustomScreenDefinitionExist">
+    <div class="opfab-custom-screen-header">
+        <div style="display: flex">
+            <form
+                class="opfab-date-range-input opfab-input"
+                style="margin-top: 28px; margin-bottom: 28px; width: 260px"
+                [formGroup]="headerForm">
+                <label class="opfab-date-range-label" for="opfab-publish-date-range" translate
+                    >shared.filters.businessDateRange</label
+                >
+                <input
+                    id="opfab-business-date-range"
+                    type="button"
+                    ngxDaterangepickerMd
+                    [locale]="dateRangePickerLocale"
+                    [ranges]="dateRangePickerCustomRanges"
+                    [alwaysShowCalendars]="true"
+                    [timePicker]="true"
+                    [timePicker24Hour]="true"
+                    [timePickerIncrement]="1"
+                    formControlName="businessDateRangesForm" />
+            </form>
+
+            <div style="margin-top: 20px; margin-bottom: 20px; margin-left: 60px; min-width: 320px">
+                <div class="form-group">
+                    <div class="opfab-buttons">
+                        <button id="opfab-monitoring-btn-search" class="opfab-btn" (click)="sendQuery()" translate>
+                            button.search
+                        </button>
+                        <button
+                            id="opfab-monitoring-btn-reset"
+                            class="opfab-btn-cancel"
+                            (click)="resetForm()"
+                            translate>
+                            button.reset
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div
+        style="
+            background-color: var(--opfab-bgcolor-darker);
+            border: solid 0px var(--opfab-bgcolor-darker);
+            margin-left: 5%;
+            margin-right: 5%;
+        ">
+        <ag-grid-angular
+            [rowData]="rowData$ | async"
+            [gridOptions]="gridOptions"
+            (gridReady)="onGridReady($event)"
+            (rowClicked)="selectCard($event.data.cardId)"
+            class="ag-theme-opfab">
+        </ag-grid-angular>
+
+        <div *ngIf="gridApi" class="opfab-pagination" style="padding-bottom: 5px">
+            <div style="white-space: nowrap; margin-top: 17px">
+                <span translate> shared.resultsNumber </span> : {{ gridApi.paginationGetRowCount() }}
+            </div>
+            <div style="width: 40%; margin-top: 5px">
+                <ngb-pagination
+                    *ngIf="gridApi.paginationGetRowCount() > 10"
+                    [collectionSize]="gridApi.paginationGetRowCount()"
+                    [page]="page"
+                    [pageSize]="gridApi.paginationGetPageSize()"
+                    (pageChange)="updateResultPage($event)"
+                    [maxSize]="3"
+                    [rotate]="true">
+                </ngb-pagination>
+            </div>
+            <div class="opfab-custom-card-list-export-div">
+                <div
+                    id="opfab-monitoring-btn-exportToExcel"
+                    class="opfab-custom-card-list-export-btn"
+                    style="cursor: pointer"
+                    (click)="export()"
+                    fileName="monitoringResults">
+                    <span class="opfab-icon-export-data"></span>
+                    <span style="font-weight: bold" translate> shared.exportToExcel </span>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<ng-template #cardDetail let-modal>
+    <div class="modal-body modal-body-squared">
+        <div>
+            <of-card [parentModalRef]="modalRef" [screenSize]="'lg'"> </of-card>
+        </div>
+    </div>
+</ng-template>

--- a/ui/main/src/app/components/customCardList/CustomCardListComponent.scss
+++ b/ui/main/src/app/components/customCardList/CustomCardListComponent.scss
@@ -1,0 +1,28 @@
+/* Copyright (c) 2025, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
+ */
+
+
+.opfab-custom-screen-header {
+    background-color: var(--opfab-bgcolor-darker);
+    margin-left: 0;
+    margin-right: 0;
+    margin-bottom: 40px;
+    padding-left: 5%;
+}
+
+.opfab-custom-card-list-export-div {
+    width: 50%;
+    text-align: right;
+    padding-right: 8px;
+}
+
+.opfab-custom-card-list-export-btn {
+    float: right;
+    margin-right: 10px;
+}

--- a/ui/main/src/app/components/customCardList/CustomCardListComponent.ts
+++ b/ui/main/src/app/components/customCardList/CustomCardListComponent.ts
@@ -1,0 +1,201 @@
+/* Copyright (c) 2025, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
+ */
+
+import {AsyncPipe, NgIf} from '@angular/common';
+import {Component, ElementRef, OnDestroy, OnInit, ViewChild} from '@angular/core';
+import {FormBuilder, FormGroup, FormsModule, ReactiveFormsModule} from '@angular/forms';
+import {ActivatedRoute} from '@angular/router';
+import {NgbModal, NgbModalOptions, NgbModalRef, NgbPagination} from '@ng-bootstrap/ng-bootstrap';
+import {TranslateModule} from '@ngx-translate/core';
+import {SelectedCardService} from '@ofServices/selectedCard/SelectedCardService';
+import {TranslationService} from '@ofServices/translation/TranslationService';
+import {CardComponent} from 'app/components/card/card.component';
+import {AgGridAngular} from 'ag-grid-angular';
+import {AllCommunityModule, GridOptions, ModuleRegistry, provideGlobalGridOptions} from 'ag-grid-community';
+import {DateRangePickerConfig} from 'app/utils/DateRangePickerConfig';
+import {ExcelExport} from 'app/utils/excel-export';
+import {CustomCardListView} from 'app/views/customCardList/CustomCardListView';
+import {NgxDaterangepickerMd} from 'ngx-daterangepicker-material';
+import {Observable, ReplaySubject, take} from 'rxjs';
+import {ResponsesCellRendererComponent} from './cellRenderers/ResponsesCellRendererComponent';
+
+@Component({
+    selector: 'of-custom-screen',
+    templateUrl: './CustomCardListComponent.html',
+    styleUrls: ['./CustomCardListComponent.scss'],
+    standalone: true,
+    imports: [
+        TranslateModule,
+        NgIf,
+        AgGridAngular,
+        AsyncPipe,
+        FormsModule,
+        NgxDaterangepickerMd,
+        ReactiveFormsModule,
+        NgbPagination,
+        CardComponent
+    ]
+})
+export class CustomScreenComponent implements OnInit, OnDestroy {
+    @ViewChild('cardDetail') cardDetailTemplate: ElementRef;
+
+    customScreenId: string;
+    customCardListView: CustomCardListView;
+    isCustomScreenDefinitionExist: boolean;
+    gridOptions: GridOptions;
+    gridApi: any;
+    page = 1;
+    private rowData = [];
+    rowData$: Observable<any>;
+    private readonly rowDataSubject = new ReplaySubject(1);
+    dateRangePickerCustomRanges: any = {};
+    dateRangePickerLocale: any = {};
+    headerForm: FormGroup;
+    modalRef: NgbModalRef;
+
+    constructor(
+        private readonly route: ActivatedRoute,
+        private readonly fb: FormBuilder,
+        private readonly modalService: NgbModal
+    ) {
+        ModuleRegistry.registerModules([AllCommunityModule]);
+        provideGlobalGridOptions({theme: 'legacy'});
+        this.dateRangePickerLocale = DateRangePickerConfig.getLocale();
+        this.dateRangePickerCustomRanges = DateRangePickerConfig.getCustomRanges();
+        this.headerForm = this.fb.group({
+            businessDateRangesForm: []
+        });
+    }
+
+    ngOnInit(): void {
+        this.route.paramMap.pipe(take(1)).subscribe((params) => {
+            this.customScreenId = params.get('id');
+            this.customCardListView = new CustomCardListView(this.customScreenId);
+
+            const severityCellClassRules = {
+                'opfab-sev-alarm': (field) => field.value === 'ALARM',
+                'opfab-sev-action': (field) => field.value === 'ACTION',
+                'opfab-sev-compliant': (field) => field.value === 'COMPLIANT',
+                'opfab-sev-information': (field) => field.value === 'INFORMATION'
+            };
+
+            const typeOfStateCellClassRules = {
+                'opfab-type-of-state-INPROGRESS': (field) => field.value === 'INPROGRESS',
+                'opfab-type-of-state-FINISHED': (field) => field.value === 'FINISHED',
+                'opfab-type-of-state-CANCELED': (field) => field.value === 'CANCELED'
+            };
+            this.isCustomScreenDefinitionExist = this.customCardListView.isCustomScreenDefinitionExist();
+            this.gridOptions = {
+                domLayout: 'autoHeight',
+                components: {
+                    responsesCellRenderer: ResponsesCellRendererComponent
+                },
+
+                defaultColDef: {
+                    editable: false
+                },
+                getLocaleText: function (params) {
+                    // To avoid clashing with opfab assets, all keys defined by ag-grid are prefixed with "ag-grid."
+                    // e.g. key "to" defined by ag-grid for use with pagination can be found under "ag-grid.to" in assets
+                    return TranslationService.getTranslation('ag-grid.' + params.key);
+                },
+
+                columnTypes: {
+                    default: {
+                        sortable: true,
+                        filter: true,
+                        resizable: false,
+                        wrapText: false
+                    },
+                    severity: {
+                        sortable: false,
+                        resizable: false,
+                        maxWidth: 18,
+                        cellClassRules: severityCellClassRules,
+                        headerClass: 'opfab-ag-header-with-no-padding'
+                    },
+                    typeOfState: {
+                        sortable: true,
+                        filter: true,
+                        resizable: false,
+                        wrapText: false,
+                        cellClassRules: typeOfStateCellClassRules
+                    },
+                    responses: {
+                        sortable: false,
+                        filter: false,
+                        resizable: false,
+                        wrapText: false,
+                        cellRenderer: 'responsesCellRenderer'
+                    }
+                },
+                ensureDomOrder: true, // rearrange row-index of rows when sorting cards (used for cypress)
+                pagination: true,
+                suppressCellFocus: true,
+                suppressPaginationPanel: true,
+                suppressHorizontalScroll: true,
+                columnDefs: this.customCardListView.getColumnsDefinitionForAgGrid(),
+                headerHeight: 70,
+                rowHeight: 45,
+                paginationPageSize: 10
+            };
+            this.rowData$ = this.rowDataSubject.asObservable();
+            this.rowDataSubject.next(this.rowData); // needed to have an empty table if no data on component init
+            this.customCardListView.getResults().subscribe((results) => {
+                this.rowData = results;
+                this.rowDataSubject.next(this.rowData);
+            });
+            this.headerForm.get('businessDateRangesForm').setValue({
+                startDate: new Date(this.customCardListView.getBusinessPeriod().startDate),
+                endDate: new Date(this.customCardListView.getBusinessPeriod().endDate)
+            });
+        });
+    }
+    onGridReady(params: any) {
+        this.gridApi = params.api;
+    }
+
+    updateResultPage(currentPage: number): void {
+        this.gridApi.paginationGoToPage(currentPage - 1);
+        this.page = currentPage;
+    }
+
+    resetForm() {
+        //TODO
+    }
+
+    sendQuery() {
+        const businessDates = this.headerForm.get('businessDateRangesForm').value;
+        const startDate = Date.parse(businessDates.startDate?.toISOString());
+        const endDate = Date.parse(businessDates.endDate?.toISOString());
+        this.customCardListView.setBusinessPeriod(startDate, endDate);
+    }
+
+    selectCard(info: string) {
+        SelectedCardService.setSelectedCardId(info);
+        const options: NgbModalOptions = {
+            size: 'fullscreen'
+        };
+        this.modalRef = this.modalService.open(this.cardDetailTemplate, options);
+
+        // Clear card selection when modal is dismissed by pressing escape key or clicking outside of modal
+        // Closing event is already handled in card detail component
+        this.modalRef.dismissed.subscribe(() => {
+            SelectedCardService.clearSelectedCardId();
+        });
+    }
+
+    export(): void {
+        ExcelExport.exportJsonToExcelFile(this.customCardListView.getDataForExport(), 'Custom');
+    }
+
+    ngOnDestroy() {
+        this.customCardListView.destroy();
+    }
+}

--- a/ui/main/src/app/components/customCardList/CustomCardListComponent.ts
+++ b/ui/main/src/app/components/customCardList/CustomCardListComponent.ts
@@ -86,7 +86,7 @@ export class CustomScreenComponent implements OnInit, OnDestroy {
             };
 
             const typeOfStateCellClassRules = {
-                'opfab-type-of-state-INPROGRESS': (field) => field.value === 'INPROGRESS',
+                'opfab-type-of-state-INPROGRESS': (field) => field.value === 'IN PROGRESS',
                 'opfab-type-of-state-FINISHED': (field) => field.value === 'FINISHED',
                 'opfab-type-of-state-CANCELED': (field) => field.value === 'CANCELED'
             };

--- a/ui/main/src/app/components/customCardList/cellRenderers/ResponsesCellRendererComponent.html
+++ b/ui/main/src/app/components/customCardList/cellRenderers/ResponsesCellRendererComponent.html
@@ -1,0 +1,39 @@
+<!-- Copyright (c) 2025, RTE (http://www.rte-france.com)                   -->
+<!-- See AUTHORS.txt                                                       -->
+<!-- This Source Code Form is subject to the terms of the Mozilla Public   -->
+<!-- License, v. 2.0. If a copy of the MPL was not distributed with this   -->
+<!-- file, You can obtain one at http://mozilla.org/MPL/2.0/.              -->
+<!-- SPDX-License-Identifier: MPL-2.0                                      -->
+<!-- This file is part of the OperatorFabric project.                      -->
+
+<span *ngIf="entities.length === 1" id="opfab-entities-dropdown">
+    <span
+        *ngFor="let entity of entities"
+        [ngStyle]="{color: 'var(--opfab-color-' + entity.color +')' , 'text-align': 'center'}">
+        &nbsp; {{ entity.name }} &nbsp;
+    </span>
+</span>
+
+<span
+    *ngIf="entities.length > 1"
+    id="opfab-entities-dropdown"
+    placement="bottom-left"
+    [ngbPopover]="entitiesDropdown"
+    container="body"
+    [autoClose]="'true'"
+    triggers="mouseenter:mouseleave"
+    popoverClass="opfab-popover-no-arrow">
+    <span
+        *ngFor="let entity of entities"
+        [ngStyle]="{color: 'var(--opfab-color-' + entity.color +')' , 'text-align': 'center'}">
+        &nbsp; {{ entity.name }} &nbsp;
+    </span>
+</span>
+
+<ng-template #entitiesDropdown>
+    <div
+        *ngFor="let entity of entities"
+        [ngStyle]="{color: 'var(--opfab-color-' + entity.color +')' , 'text-align': 'left'}">
+        &nbsp; {{ entity.name }} &nbsp;
+    </div>
+</ng-template>

--- a/ui/main/src/app/components/customCardList/cellRenderers/ResponsesCellRendererComponent.ts
+++ b/ui/main/src/app/components/customCardList/cellRenderers/ResponsesCellRendererComponent.ts
@@ -1,0 +1,37 @@
+/* Copyright (c) 2025, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
+ */
+
+import {Component} from '@angular/core';
+import {ICellRendererAngularComp} from 'ag-grid-angular';
+import {ICellRendererParams} from 'ag-grid-community';
+import {TranslateModule} from '@ngx-translate/core';
+import {NgFor, NgIf, NgStyle} from '@angular/common';
+import {NgbPopover} from '@ng-bootstrap/ng-bootstrap';
+
+@Component({
+    selector: 'of-responses-renderer',
+    templateUrl: './ResponsesCellRendererComponent.html',
+    standalone: true,
+    imports: [TranslateModule, NgIf, NgbPopover, NgFor, NgStyle]
+})
+export class ResponsesCellRendererComponent implements ICellRendererAngularComp {
+    public entities: any[];
+
+    agInit(params: any): void {
+        this.entities = params.data.responses;
+    }
+
+    // noinspection JSUnusedLocalSymbols
+    /** This method returns true to signal to the grid that this renderer doesn't need to be recreated if the underlying data changes
+     *  See https://www.ag-grid.com/documentation/angular/component-cell-renderer/#handling-refresh
+     * */
+    refresh(params: ICellRendererParams): boolean {
+        return true;
+    }
+}

--- a/ui/main/src/app/components/share/archives-logging-filters/archives-logging-filters.component.ts
+++ b/ui/main/src/app/components/share/archives-logging-filters/archives-logging-filters.component.ts
@@ -35,7 +35,7 @@ import {TranslateModule} from '@ngx-translate/core';
 import {NgIf, NgClass} from '@angular/common';
 import {MultiSelectComponent} from '../multi-select/multi-select.component';
 import {NgxDaterangepickerMd} from 'ngx-daterangepicker-material';
-import {TranslationService} from '@ofServices/translation/TranslationService';
+import {DateRangePickerConfig} from 'app/utils/DateRangePickerConfig';
 
 @Component({
     selector: 'of-archives-logging-filters',
@@ -137,38 +137,8 @@ export class ArchivesLoggingFiltersComponent implements OnInit, OnChanges, OnDes
                 this.hasCurrentUserRightsToViewAllArchivedCardsInHisPerimeters) &&
             seeOnlyCardsForWhichUserIsRecipientInStorage === 'false';
 
-        this.locale = {
-            format: 'YYYY-MM-DD HH:mm',
-            applyLabel: TranslationService.getTranslation('datePicker.applyLabel'),
-            daysOfWeek: TranslationService.getTranslation('datePicker.daysOfWeek'),
-            monthNames: TranslationService.getTranslation('datePicker.monthNames')
-        };
-
-        const currentDate = new Date(),
-            y = currentDate.getFullYear(),
-            m = currentDate.getMonth();
-        const startCurrentMonth = new Date(y, m, 1);
-        const endCurrentMonth = new Date(y, m + 1, 1);
-        const startPreviousMonth = new Date(y, m - 1, 1);
-
-        const todayTranslation = TranslationService.getTranslation('datePicker.today');
-        const yesterdayTranslation = TranslationService.getTranslation('datePicker.yesterday');
-        const last7DaysTranslation = TranslationService.getTranslation('datePicker.last7Days');
-        const last30DaysTranslation = TranslationService.getTranslation('datePicker.last30Days');
-        const thisMonthTranslation = TranslationService.getTranslation('datePicker.thisMonth');
-        const lastMonthTranslation = TranslationService.getTranslation('datePicker.lastMonth');
-
-        this.ranges = {
-            [todayTranslation]: [new Date().setHours(0, 0, 0, 0), new Date().setHours(24, 0, 0, 0)],
-            [yesterdayTranslation]: [sub(new Date().setHours(0, 0, 0, 0), {days: 1}), new Date().setHours(0, 0, 0, 0)],
-            [last7DaysTranslation]: [sub(new Date(), {days: 7}).setHours(0, 0, 0, 0), new Date().setHours(24, 0, 0, 0)],
-            [last30DaysTranslation]: [
-                sub(new Date(), {days: 30}).setHours(0, 0, 0, 0),
-                new Date().setHours(24, 0, 0, 0)
-            ],
-            [thisMonthTranslation]: [startCurrentMonth, endCurrentMonth],
-            [lastMonthTranslation]: [startPreviousMonth, startCurrentMonth]
-        };
+        this.locale = DateRangePickerConfig.getLocale();
+        this.ranges = DateRangePickerConfig.getCustomRanges();
     }
 
     ngOnChanges(changes: SimpleChanges): void {

--- a/ui/main/src/app/model/PublisherType.ts
+++ b/ui/main/src/app/model/PublisherType.ts
@@ -8,7 +8,7 @@
  */
 
 export enum PublisherType {
-    EXTERNAL,
-    ENTITY,
-    USER
+    EXTERNAL = 'EXTERNAL',
+    ENTITY = 'ENTITY',
+    USER = 'USER'
 }

--- a/ui/main/src/app/services/customScreen/CustomScreenService.ts
+++ b/ui/main/src/app/services/customScreen/CustomScreenService.ts
@@ -1,0 +1,24 @@
+/* Copyright (c) 2025, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
+ */
+
+import {CustomScreenDefinition} from './model/CustomScreenDefinition';
+
+export class CustomScreenService {
+    private static readonly customScreenDefinitions = new Map<string, CustomScreenDefinition>();
+
+    public static addCustomScreenDefinition(customScreenDefinition: CustomScreenDefinition) {
+        CustomScreenService.customScreenDefinitions.set(customScreenDefinition.id, customScreenDefinition);
+    }
+    public static getCustomScreenDefinition(customScreenId: string): CustomScreenDefinition {
+        return CustomScreenService.customScreenDefinitions.get(customScreenId);
+    }
+    public static clearCustomScreenDefinitions() {
+        CustomScreenService.customScreenDefinitions.clear();
+    }
+}

--- a/ui/main/src/app/services/customScreen/model/CustomScreenDefinition.ts
+++ b/ui/main/src/app/services/customScreen/model/CustomScreenDefinition.ts
@@ -1,0 +1,38 @@
+/* Copyright (c) 2025, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
+ */
+
+export class CustomScreenDefinition {
+    id: string;
+    name: string;
+    cardProcessIds: string[];
+    header: {
+        searchFields: string[];
+    };
+    results: {
+        columns: Column[];
+    };
+}
+
+export class Column {
+    field?: string;
+    headerName?: string;
+    cardField?: string;
+    fieldType: FieldType;
+    flex?: number;
+}
+
+export enum FieldType {
+    STRING = 'STRING',
+    DATE_AND_TIME = 'DATE_AND_TIME',
+    ARRAY = 'ARRAY',
+    SEVERITY = 'SEVERITY',
+    PUBLISHER = 'PUBLISHER',
+    TYPE_OF_STATE = 'TYPE_OF_STATE',
+    RESPONSES = 'RESPONSES'
+}

--- a/ui/main/src/app/services/entities/model/Entity.ts
+++ b/ui/main/src/app/services/entities/model/Entity.ts
@@ -1,4 +1,4 @@
-/* Copyright (c) 2018-2024, RTE (http://www.rte-france.com)
+/* Copyright (c) 2018-2025, RTE (http://www.rte-france.com)
  * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -13,9 +13,9 @@ export class Entity {
     public constructor(
         readonly id: string,
         readonly name: string,
-        readonly description: string,
-        readonly roles: RoleEnum[],
-        readonly labels: string[],
-        readonly parents: string[]
+        readonly description?: string,
+        readonly roles?: RoleEnum[],
+        readonly labels?: string[],
+        readonly parents?: string[]
     ) {}
 }

--- a/ui/main/src/app/services/navigation/NavigationService.ts
+++ b/ui/main/src/app/services/navigation/NavigationService.ts
@@ -21,7 +21,8 @@ export enum PageType {
     CALENDAR,
     MONITORING,
     USERCARD,
-    DASHBOARD
+    DASHBOARD,
+    CUSTOMSCREEN
 }
 export class NavigationService {
     private static router: ApplicationRouter;
@@ -36,7 +37,8 @@ export class NavigationService {
         ['calendar', PageType.CALENDAR],
         ['monitoring', PageType.MONITORING],
         ['usercard', PageType.USERCARD],
-        ['dashboard', PageType.DASHBOARD]
+        ['dashboard', PageType.DASHBOARD],
+        ['customscreen', PageType.CUSTOMSCREEN]
     ]);
 
     public static setApplicationRouter(router: ApplicationRouter) {

--- a/ui/main/src/app/services/navigation/router/AngularApplicationRouter.module.ts
+++ b/ui/main/src/app/services/navigation/router/AngularApplicationRouter.module.ts
@@ -126,6 +126,11 @@ const routes: Routes = [
             import('../../../components/useractionlogs/useractionlogs.component').then((m) => m.UserActionLogsComponent)
     },
     {
+        path: 'customscreen/:id',
+        loadComponent: () =>
+            import('../../../components/customCardList/CustomCardListComponent').then((m) => m.CustomScreenComponent)
+    },
+    {
         path: 'devtools/richtext',
         loadComponent: () =>
             import('../../../components/devtools/richtext/richtext.component').then((m) => m.RichTextComponent)

--- a/ui/main/src/app/services/realTimeDomain/NearestDomainId.spec.ts
+++ b/ui/main/src/app/services/realTimeDomain/NearestDomainId.spec.ts
@@ -1,0 +1,76 @@
+/* Copyright (c) 2025, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
+ */
+
+import {NearestDomainId} from './NearestDomainId';
+
+describe('NearestDomainId', () => {
+    let nearestDomainId: NearestDomainId;
+    const startDate: number = new Date().getTime();
+    const twelveHoursInMillis = 1000 * 60 * 60 * 12;
+    const threeMonthsInMillis = 1000 * 60 * 60 * 24 * 30 * 3;
+    const oneAndHalfDaysInMillis = 1000 * 60 * 60 * 24 * 1.5;
+
+    beforeEach(() => {
+        nearestDomainId = new NearestDomainId();
+    });
+
+    it('should return the domain if there is only one domain', () => {
+        nearestDomainId.setDomainList(['Y']);
+        const endDate = startDate + twelveHoursInMillis - 1;
+        expect(nearestDomainId.getNearestDomainId(startDate, endDate)).toEqual('Y');
+    });
+
+    it('should return RT if period is less than 12 hours and RT exists', () => {
+        nearestDomainId.setDomainList(['D', 'RT']);
+        const endDate = startDate + twelveHoursInMillis - 1;
+        expect(nearestDomainId.getNearestDomainId(startDate, endDate)).toEqual('RT');
+    });
+
+    it('should return D if period is less than 12 hours and RT does not exist', () => {
+        nearestDomainId.setDomainList(['D']);
+        const endDate = startDate + twelveHoursInMillis - 1;
+        expect(nearestDomainId.getNearestDomainId(startDate, endDate)).toEqual('D');
+    });
+
+    it('should return 7D if period is less than 12 hours and RT, J do not exist but 7D exists', () => {
+        nearestDomainId.setDomainList(['7D', 'M', 'Y']);
+        const endDate = startDate + twelveHoursInMillis - 1;
+        expect(nearestDomainId.getNearestDomainId(startDate, endDate)).toEqual('7D');
+    });
+
+    it('should return W if period is less than 12 hours and RT, J, 7D do not exist but W exists', () => {
+        nearestDomainId.setDomainList(['W', 'M', 'Y']);
+        const endDate = startDate + twelveHoursInMillis - 1;
+        expect(nearestDomainId.getNearestDomainId(startDate, endDate)).toEqual('W');
+    });
+
+    it('should return D if period is greater than 12 hours', () => {
+        nearestDomainId.setDomainList(['D', 'RT']);
+        const endDate = startDate + twelveHoursInMillis + 1;
+        expect(nearestDomainId.getNearestDomainId(startDate, endDate)).toEqual('D');
+    });
+
+    it('should return Y if period is greater than 3 months and Y domain exists', () => {
+        nearestDomainId.setDomainList(['M', 'Y']);
+        const endDate = startDate + threeMonthsInMillis + 1;
+        expect(nearestDomainId.getNearestDomainId(startDate, endDate)).toEqual('Y');
+    });
+
+    it('should return M if period is greater than 3 months and Y domain does not exist', () => {
+        nearestDomainId.setDomainList(['RT', 'M']);
+        const endDate = startDate + threeMonthsInMillis + 1;
+        expect(nearestDomainId.getNearestDomainId(startDate, endDate)).toEqual('M');
+    });
+
+    it('should return 7D if period is greater than 1.5 days and 7D exists', () => {
+        nearestDomainId.setDomainList(['RT', 'D', '7D', 'W']);
+        const endDate = startDate + oneAndHalfDaysInMillis + 1;
+        expect(nearestDomainId.getNearestDomainId(startDate, endDate)).toEqual('7D');
+    });
+});

--- a/ui/main/src/app/services/realTimeDomain/NearestDomainId.ts
+++ b/ui/main/src/app/services/realTimeDomain/NearestDomainId.ts
@@ -1,0 +1,39 @@
+/* Copyright (c) 2025, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
+ */
+
+export class NearestDomainId {
+    private domainOrderedList: Array<any>;
+
+    private static readonly MS_PER_HOUR = 1000 * 60 * 60;
+    private static readonly MS_PER_DAY = NearestDomainId.MS_PER_HOUR * 24;
+    private static readonly MS_PER_MONTH = NearestDomainId.MS_PER_DAY * 30;
+
+    public setDomainList(domainList: Array<string>): void {
+        this.domainOrderedList = [
+            {id: 'RT', threshold: NearestDomainId.MS_PER_HOUR * 12},
+            {id: 'D', threshold: NearestDomainId.MS_PER_HOUR * 36},
+            {id: '7D', threshold: NearestDomainId.MS_PER_DAY * 10},
+            {id: 'W', threshold: NearestDomainId.MS_PER_DAY * 10},
+            {id: 'M', threshold: NearestDomainId.MS_PER_MONTH * 3},
+            {id: 'Y', threshold: undefined}
+        ].filter((domain) => domainList.includes(domain.id));
+    }
+
+    public getNearestDomainId(startDate: number, endDate: number): string {
+        const period = endDate - startDate;
+        if (this.domainOrderedList.length === 1) {
+            return this.domainOrderedList[0].id;
+        }
+        for (const domain of this.domainOrderedList) {
+            if (period <= domain.threshold) return domain.id;
+        }
+
+        return this.domainOrderedList[this.domainOrderedList.length - 1].id;
+    }
+}

--- a/ui/main/src/app/services/realTimeDomain/NearestDomainId.ts
+++ b/ui/main/src/app/services/realTimeDomain/NearestDomainId.ts
@@ -27,9 +27,6 @@ export class NearestDomainId {
 
     public getNearestDomainId(startDate: number, endDate: number): string {
         const period = endDate - startDate;
-        if (this.domainOrderedList.length === 1) {
-            return this.domainOrderedList[0].id;
-        }
         for (const domain of this.domainOrderedList) {
             if (period <= domain.threshold) return domain.id;
         }

--- a/ui/main/src/app/store/lightcards/lightcards-store.ts
+++ b/ui/main/src/app/store/lightcards/lightcards-store.ts
@@ -438,6 +438,10 @@ export class LightCardsStore {
         return this.childCards.get(parentCardId);
     }
 
+    public getAllChildCards() {
+        return new Map(this.childCards);
+    }
+
     public getLoadingInProgress() {
         return this.loadingInProgress.asObservable();
     }

--- a/ui/main/src/app/utils/DateRangePickerConfig.ts
+++ b/ui/main/src/app/utils/DateRangePickerConfig.ts
@@ -1,0 +1,49 @@
+/* Copyright (c) 2025, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
+ */
+
+import {TranslationService} from '@ofServices/translation/TranslationService';
+import {sub} from 'date-fns';
+
+export class DateRangePickerConfig {
+    public static getLocale() {
+        return {
+            format: 'YYYY-MM-DD HH:mm',
+            applyLabel: TranslationService.getTranslation('datePicker.applyLabel'),
+            daysOfWeek: TranslationService.getTranslation('datePicker.daysOfWeek'),
+            monthNames: TranslationService.getTranslation('datePicker.monthNames')
+        };
+    }
+
+    public static getCustomRanges() {
+        const currentDate = new Date(),
+            y = currentDate.getFullYear(),
+            m = currentDate.getMonth();
+        const startCurrentMonth = new Date(y, m, 1);
+        const endCurrentMonth = new Date(y, m + 1, 1);
+        const startPreviousMonth = new Date(y, m - 1, 1);
+
+        const todayTranslation = TranslationService.getTranslation('datePicker.today');
+        const yesterdayTranslation = TranslationService.getTranslation('datePicker.yesterday');
+        const last7DaysTranslation = TranslationService.getTranslation('datePicker.last7Days');
+        const last30DaysTranslation = TranslationService.getTranslation('datePicker.last30Days');
+        const thisMonthTranslation = TranslationService.getTranslation('datePicker.thisMonth');
+        const lastMonthTranslation = TranslationService.getTranslation('datePicker.lastMonth');
+        return {
+            [todayTranslation]: [new Date().setHours(0, 0, 0, 0), new Date().setHours(24, 0, 0, 0)],
+            [yesterdayTranslation]: [sub(new Date().setHours(0, 0, 0, 0), {days: 1}), new Date().setHours(0, 0, 0, 0)],
+            [last7DaysTranslation]: [sub(new Date(), {days: 7}).setHours(0, 0, 0, 0), new Date().setHours(24, 0, 0, 0)],
+            [last30DaysTranslation]: [
+                sub(new Date(), {days: 30}).setHours(0, 0, 0, 0),
+                new Date().setHours(24, 0, 0, 0)
+            ],
+            [thisMonthTranslation]: [startCurrentMonth, endCurrentMonth],
+            [lastMonthTranslation]: [startPreviousMonth, startCurrentMonth]
+        };
+    }
+}

--- a/ui/main/src/app/views/customCardList/CustomCardListView.spec.ts
+++ b/ui/main/src/app/views/customCardList/CustomCardListView.spec.ts
@@ -1,0 +1,200 @@
+/* Copyright (c) 2025, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
+ */
+
+import {CustomScreenDefinition, FieldType} from '@ofServices/customScreen/model/CustomScreenDefinition';
+import {CustomCardListView} from './CustomCardListView';
+import {CustomScreenService} from '@ofServices/customScreen/CustomScreenService';
+import {OpfabEventStreamServerMock} from '@tests/mocks/opfab-event-stream.server.mock';
+import {OpfabEventStreamService} from '@ofServices/events/OpfabEventStreamService';
+import {OpfabStore} from '@ofStore/opfabStore';
+import {getOneLightCard, setEntities, setUserPerimeter} from '@tests/helpers';
+import {firstValueFrom} from 'rxjs';
+import {FilteredLightCardsStore} from '@ofStore/lightcards/lightcards-feed-filter-store';
+import {FilterType} from '@ofStore/lightcards/model/Filter';
+import {RealTimeDomainService} from '@ofServices/realTimeDomain/RealTimeDomainService';
+import {RoleEnum} from '@ofServices/entities/model/RoleEnum';
+import {Severity} from 'app/model/Severity';
+
+describe('CustomScreenView', () => {
+    let opfabEventStreamServerMock: OpfabEventStreamServerMock;
+    let filteredLightCardStore: FilteredLightCardsStore;
+
+    beforeEach(() => {
+        CustomScreenService.clearCustomScreenDefinitions();
+        opfabEventStreamServerMock = new OpfabEventStreamServerMock();
+        OpfabEventStreamService.setEventStreamServer(opfabEventStreamServerMock);
+        OpfabStore.reset();
+        RealTimeDomainService.init();
+        RealTimeDomainService.setStartAndEndPeriod(0, new Date().valueOf() + 1000);
+        filteredLightCardStore = OpfabStore.getFilteredLightCardStore();
+    });
+    it('should return false if custom screen defintion does not exist', () => {
+        const customScreenDefinition = new CustomScreenDefinition();
+        customScreenDefinition.id = 'testId';
+        customScreenDefinition.name = 'testName';
+        const customScreenView = new CustomCardListView('unexistingId');
+        expect(customScreenView.isCustomScreenDefinitionExist()).toEqual(false);
+    });
+    it('should return true if custom screen definition exists', () => {
+        const customScreenDefinition = new CustomScreenDefinition();
+        customScreenDefinition.id = 'testId';
+        customScreenDefinition.name = 'testName';
+        CustomScreenService.addCustomScreenDefinition(customScreenDefinition);
+        const customScreenView = new CustomCardListView('testId');
+        expect(customScreenView.isCustomScreenDefinitionExist()).toEqual(true);
+    });
+    it('should return columDefinition for agGrid', () => {
+        const customScreenDefinition = new CustomScreenDefinition();
+        customScreenDefinition.id = 'testId';
+        customScreenDefinition.name = 'testName';
+        customScreenDefinition.results = {
+            columns: [
+                {
+                    field: 'testField',
+                    headerName: 'Process',
+                    cardField: 'processId',
+                    fieldType: FieldType.STRING,
+                    flex: 2
+                },
+                {
+                    field: 'testField2',
+                    headerName: 'Start Date',
+                    cardField: 'startDate',
+                    fieldType: FieldType.DATE_AND_TIME,
+                    flex: 1
+                }
+            ]
+        };
+        CustomScreenService.addCustomScreenDefinition(customScreenDefinition);
+        const customScreenView = new CustomCardListView('testId');
+        expect(customScreenView.getColumnsDefinitionForAgGrid()).toEqual([
+            {field: 'testField', headerName: 'Process', type: 'default', flex: 2},
+            {field: 'testField2', headerName: 'Start Date', type: 'default', flex: 1}
+        ]);
+    });
+    it('should return data array from light cards store', async () => {
+        // this is necessary to set the user perimeter for child card
+        // to be processed correctly by the ligthcard store
+        await setUserPerimeter({
+            computedPerimeters: [],
+            userData: {
+                login: 'test',
+                firstName: 'firstName',
+                lastName: 'lastName',
+                entities: []
+            }
+        });
+
+        setEntities([
+            {
+                id: 'entity1',
+                name: 'entity1 name',
+                roles: [RoleEnum.CARD_SENDER]
+            }
+        ]);
+        const customScreenDefinition = new CustomScreenDefinition();
+        customScreenDefinition.id = 'testId';
+        customScreenDefinition.results = {
+            columns: [
+                {
+                    field: 'testField',
+                    headerName: 'Process',
+                    cardField: 'process',
+                    fieldType: FieldType.STRING,
+                    flex: 2
+                },
+                {
+                    field: 'responses',
+                    headerName: 'Responses',
+                    fieldType: FieldType.RESPONSES
+                }
+            ]
+        };
+        CustomScreenService.addCustomScreenDefinition(customScreenDefinition);
+        const customScreenView = new CustomCardListView('testId');
+
+        const card = getOneLightCard({
+            process: 'process1',
+            state: 'state1',
+            entitiesAllowedToRespond: ['entity1'],
+            id: 'id1'
+        });
+        const childCard = getOneLightCard({
+            process: 'process1',
+            state: 'state1',
+            parentCardId: 'id1',
+            id: 'id2',
+            publisher: 'entity1',
+            severity: Severity.COMPLIANT
+        });
+        opfabEventStreamServerMock.sendLightCard(card);
+        opfabEventStreamServerMock.sendLightCard(childCard);
+        const result = await firstValueFrom(customScreenView.getResults());
+        expect(result).toEqual([
+            {
+                cardId: 'id1',
+                testField: 'process1',
+                responses: [{name: 'entity1 name', color: 'green'}]
+            }
+        ]);
+    });
+
+    it('should convert data for export', async () => {
+        const customScreenDefinition = new CustomScreenDefinition();
+        customScreenDefinition.id = 'testId';
+        customScreenDefinition.name = 'testName';
+        customScreenDefinition.results = {
+            columns: [
+                {
+                    field: 'testField',
+                    headerName: 'Process header',
+                    cardField: 'process',
+                    fieldType: FieldType.STRING,
+                    flex: 2
+                },
+                {
+                    field: 'testField2',
+                    headerName: 'State header',
+                    cardField: 'state',
+                    fieldType: FieldType.STRING,
+                    flex: 1
+                }
+            ]
+        };
+        CustomScreenService.addCustomScreenDefinition(customScreenDefinition);
+        const customScreenView = new CustomCardListView('testId');
+
+        const card = getOneLightCard({
+            process: 'process1',
+            state: 'state1',
+            id: 'id1'
+        });
+
+        const card2 = getOneLightCard({
+            process: 'process2',
+            state: 'state2',
+            id: 'id2'
+        });
+        opfabEventStreamServerMock.sendLightCard(card);
+        opfabEventStreamServerMock.sendLightCard(card2);
+
+        filteredLightCardStore.updateFilter(
+            FilterType.BUSINESSDATE_FILTER,
+            true,
+            filteredLightCardStore.getBusinessDateFilter().status
+        );
+        await firstValueFrom(customScreenView.getResults());
+        const result = customScreenView.getDataForExport();
+
+        expect(result).toEqual([
+            {'Process header': 'process1', 'State header': 'state1'},
+            {'Process header': 'process2', 'State header': 'state2'}
+        ]);
+    });
+});

--- a/ui/main/src/app/views/customCardList/CustomCardListView.ts
+++ b/ui/main/src/app/views/customCardList/CustomCardListView.ts
@@ -67,7 +67,7 @@ export class CustomCardListView {
         const result = [];
         this.results.forEach((line) => {
             const row = {};
-            this.customScreenDefinition.results.columns.forEach((column) => {
+            this.resultTable.getColumnsDefinitionForAgGrid().forEach((column) => {
                 row[column.headerName] = line[column.field];
             });
             result.push(row);

--- a/ui/main/src/app/views/customCardList/ResultTable.spec.ts
+++ b/ui/main/src/app/views/customCardList/ResultTable.spec.ts
@@ -167,6 +167,31 @@ describe('CustomScreenView - ResultTable', () => {
         ]);
     });
 
+    it('should get nested fields defines in state screen defintion + cardId', () => {
+        const resultTable = getResultTable({
+            columns: [
+                {
+                    field: 'nestedField',
+                    headerName: 'Test',
+                    cardField: 'data.test',
+                    fieldType: FieldType.STRING,
+                    flex: 2
+                }
+            ]
+        });
+        const cards = [
+            getOneLightCard({
+                process: 'processId1',
+                startDate: new Date(),
+                state: 'state1',
+                id: 'id1',
+                data: {test: 'testData'}
+            })
+        ];
+        const dataArray = resultTable.getDataArrayFromCards(cards, emptyChildCardsList);
+        expect(dataArray).toEqual([{cardId: 'id1', nestedField: 'testData'}]);
+    });
+
     it('should get filter card by business period startDate', () => {
         const resultTable = getResultTable({
             columns: [
@@ -369,10 +394,10 @@ describe('CustomScreenView - ResultTable', () => {
         const process = [new Process('myProcess', '1', null, null, states)];
         setProcessConfiguration(process);
         const dataArray = resultTable.getDataArrayFromCards(cards, emptyChildCardsList);
-        expect(dataArray).toEqual([{cardId: 'card1', typeOfState: 'INPROGRESS'}]);
+        expect(dataArray).toEqual([{cardId: 'card1', typeOfState: 'IN PROGRESS'}]);
     });
     describe('If field type is Responses', () => {
-        it('Should return entity required and allowed to reponse in alphabetical order and in grey if there is no responses', () => {
+        it('Should return entities required to reponse in alphabetical order and in grey if there is no responses', () => {
             const resultTable = getResultTable({
                 columns: [
                     {
@@ -397,12 +422,42 @@ describe('CustomScreenView - ResultTable', () => {
                     cardId: 'card1',
                     responses: [
                         {name: 'entity1 name', color: 'grey'},
+                        {name: 'entity3 name', color: 'grey'}
+                    ]
+                }
+            ]);
+        });
+        it('Should return entities allowed to reponse in alphabetical order if there is no entities required to respond', () => {
+            const resultTable = getResultTable({
+                columns: [
+                    {
+                        field: 'responses',
+                        headerName: 'Responses',
+                        fieldType: FieldType.RESPONSES
+                    }
+                ]
+            });
+            const cards = [
+                getOneLightCard({
+                    id: 'card1',
+                    publisher: 'entity1',
+                    publisherType: 'ENTITY',
+                    entitiesAllowedToRespond: ['entity3', 'entity2', 'entity1']
+                })
+            ];
+            const dataArray = resultTable.getDataArrayFromCards(cards, emptyChildCardsList);
+            expect(dataArray).toEqual([
+                {
+                    cardId: 'card1',
+                    responses: [
+                        {name: 'entity1 name', color: 'grey'},
                         {name: 'entity2 name', color: 'grey'},
                         {name: 'entity3 name', color: 'grey'}
                     ]
                 }
             ]);
         });
+
         it('Should not return entity it entity not allowed to send card', () => {
             const resultTable = getResultTable({
                 columns: [

--- a/ui/main/src/app/views/customCardList/ResultTable.spec.ts
+++ b/ui/main/src/app/views/customCardList/ResultTable.spec.ts
@@ -1,0 +1,508 @@
+/* Copyright (c) 2025, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
+ */
+
+import {CustomScreenDefinition, FieldType} from '@ofServices/customScreen/model/CustomScreenDefinition';
+import {ResultTable} from './ResultTable';
+import {getOneLightCard, setEntities, setProcessConfiguration} from '@tests/helpers';
+import {ConfigService} from '@ofServices/config/ConfigService';
+import {DateTimeFormatterService} from '@ofServices/dateTimeFormatter/DateTimeFormatterService';
+import {ConfigServerMock} from '@tests/mocks/configServer.mock';
+import {Process, State, TypeOfStateEnum} from '@ofServices/processes/model/Processes';
+import {Card} from 'app/model/Card';
+import {RoleEnum} from '@ofServices/entities/model/RoleEnum';
+import {Severity} from 'app/model/Severity';
+
+describe('CustomScreenView - ResultTable', () => {
+    const getResultTable = (customScreenDefintionResults: any) => {
+        const customScreenDefinition = new CustomScreenDefinition();
+        customScreenDefinition.id = 'testId';
+        customScreenDefinition.name = 'testName';
+        customScreenDefinition.results = customScreenDefintionResults;
+        return new ResultTable(customScreenDefinition);
+    };
+
+    const emptyChildCardsList = new Map<string, Array<Card>>();
+
+    beforeAll(() => {
+        setEntities([
+            {
+                id: 'entity1',
+                name: 'entity1 name',
+                roles: [RoleEnum.CARD_SENDER]
+            },
+            {
+                id: 'entity2',
+                name: 'entity2 name',
+                roles: [RoleEnum.CARD_SENDER]
+            },
+            {
+                id: 'entity3',
+                name: 'entity3 name',
+                roles: [RoleEnum.CARD_SENDER]
+            },
+            {
+                id: 'entity_not_allowed_to_send_card',
+                name: 'entity not allowed to send card'
+            },
+            {
+                id: 'parent_entity',
+                name: 'parent entity'
+            },
+            {
+                id: 'child_entity',
+                name: 'child entity',
+                roles: [RoleEnum.CARD_SENDER],
+                parents: ['parent_entity']
+            }
+        ]);
+    });
+    beforeEach(() => {
+        ConfigService.setConfigServer(new ConfigServerMock());
+        DateTimeFormatterService.init();
+    });
+
+    it('should return columDefinition for agGrid', () => {
+        const resultTable = getResultTable({
+            columns: [
+                {
+                    field: 'testField',
+                    headerName: 'Process',
+                    cardField: 'processId',
+                    fieldType: FieldType.STRING,
+                    flex: 2
+                },
+                {
+                    field: 'testField2',
+                    headerName: 'Start Date',
+                    cardField: 'startDate',
+                    fieldType: FieldType.DATE_AND_TIME,
+                    flex: 1
+                },
+                {
+                    headerName: 'Responses',
+                    fieldType: FieldType.RESPONSES,
+                    flex: 2
+                }
+            ]
+        });
+        expect(resultTable.getColumnsDefinitionForAgGrid()).toEqual([
+            {field: 'testField', headerName: 'Process', type: 'default', flex: 2},
+            {field: 'testField2', headerName: 'Start Date', type: 'default', flex: 1},
+            {field: 'responses', headerName: 'Responses', type: 'responses', flex: 2}
+        ]);
+    });
+
+    it('should return specific columDefinition for agGrid with severity', () => {
+        const resultTable = getResultTable({
+            columns: [
+                {
+                    field: 'severity',
+                    cardField: 'processId',
+                    fieldType: FieldType.SEVERITY
+                }
+            ]
+        });
+
+        expect(resultTable.getColumnsDefinitionForAgGrid()).toEqual([
+            {field: 'severity', headerName: '', type: 'severity'}
+        ]);
+    });
+    it('should return specific columDefinition for agGrid with type_of_state', () => {
+        const resultTable = getResultTable({
+            columns: [
+                {
+                    headerName: 'Status',
+                    fieldType: FieldType.TYPE_OF_STATE
+                }
+            ]
+        });
+        expect(resultTable.getColumnsDefinitionForAgGrid()).toEqual([
+            {field: 'typeOfState', headerName: 'Status', type: 'typeOfState', flex: undefined}
+        ]);
+    });
+
+    it('should get only card fields defines in state screen defintion + cardId', () => {
+        const resultTable = getResultTable({
+            columns: [
+                {
+                    field: 'testField',
+                    headerName: 'Process',
+                    cardField: 'process',
+                    fieldType: FieldType.STRING,
+                    flex: 2
+                },
+                {
+                    field: 'testField2',
+                    headerName: 'State',
+                    cardField: 'state',
+                    fieldType: FieldType.STRING,
+                    flex: 1
+                }
+            ]
+        });
+        const cards = [
+            getOneLightCard({
+                process: 'processId1',
+                startDate: new Date(),
+                state: 'state1',
+                id: 'id1'
+            }),
+            getOneLightCard({
+                process: 'processId2',
+                startDate: new Date(),
+                state: 'state2',
+                id: 'id2'
+            })
+        ];
+        const dataArray = resultTable.getDataArrayFromCards(cards, emptyChildCardsList);
+        expect(dataArray).toEqual([
+            {cardId: 'id1', testField: 'processId1', testField2: 'state1'},
+            {cardId: 'id2', testField: 'processId2', testField2: 'state2'}
+        ]);
+    });
+
+    it('should get filter card by business period startDate', () => {
+        const resultTable = getResultTable({
+            columns: [
+                {
+                    field: 'testField',
+                    headerName: 'Process',
+                    cardField: 'process',
+                    fieldType: FieldType.STRING,
+                    flex: 2
+                }
+            ]
+        });
+
+        resultTable.setBusinessDateFilter(10, 200);
+        const cards = [
+            getOneLightCard({
+                process: 'processId0',
+                startDate: 5,
+                id: 'id0'
+            }),
+            getOneLightCard({
+                process: 'processId1',
+                startDate: 100,
+                id: 'id1'
+            }),
+            getOneLightCard({
+                process: 'processId2',
+                startDate: 1000,
+                id: 'id2'
+            })
+        ];
+        const dataArray = resultTable.getDataArrayFromCards(cards, emptyChildCardsList);
+        expect(dataArray).toEqual([{cardId: 'id1', testField: 'processId1'}]);
+    });
+
+    it('should get filter card by business period startDate and endDate', () => {
+        const resultTable = getResultTable({
+            columns: [
+                {
+                    field: 'testField',
+                    headerName: 'Process',
+                    cardField: 'process',
+                    fieldType: FieldType.STRING,
+                    flex: 2
+                }
+            ]
+        });
+        resultTable.setBusinessDateFilter(10, 200);
+        const cards = [
+            getOneLightCard({
+                process: 'processId0',
+                startDate: 5,
+                endDate: 50,
+                id: 'id0'
+            }),
+            getOneLightCard({
+                process: 'processId1',
+                startDate: 5,
+                endDate: 8,
+                id: 'id1'
+            }),
+            getOneLightCard({
+                process: 'processId2',
+                startDate: 5,
+                endDate: 2000,
+                id: 'id2'
+            })
+        ];
+        const dataArray = resultTable.getDataArrayFromCards(cards, emptyChildCardsList);
+        expect(dataArray).toEqual([
+            {cardId: 'id0', testField: 'processId0'},
+            {cardId: 'id2', testField: 'processId2'}
+        ]);
+    });
+
+    it('should return the entity name if field type is publisher', () => {
+        const resultTable = getResultTable({
+            columns: [
+                {
+                    field: 'publisher',
+                    cardField: 'publisher',
+                    fieldType: FieldType.PUBLISHER
+                }
+            ]
+        });
+        const cards = [
+            getOneLightCard({
+                id: 'card1',
+                publisher: 'entity1',
+                publisherType: 'ENTITY'
+            })
+        ];
+        const dataArray = resultTable.getDataArrayFromCards(cards, emptyChildCardsList);
+        expect(dataArray).toEqual([{cardId: 'card1', publisher: 'entity1 name'}]);
+    });
+    it('Should return the publisher field if field type is publisher and publisher type is not ENTITY', () => {
+        const resultTable = getResultTable({
+            columns: [
+                {
+                    field: 'publisher',
+                    cardField: 'publisher',
+                    fieldType: FieldType.PUBLISHER
+                }
+            ]
+        });
+        const cards = [
+            getOneLightCard({
+                id: 'card1',
+                publisher: 'entity1',
+                publisherType: 'EXTERNAL'
+            })
+        ];
+        const dataArray = resultTable.getDataArrayFromCards(cards, emptyChildCardsList);
+        expect(dataArray).toEqual([{cardId: 'card1', publisher: 'entity1'}]);
+    });
+    it('Should return the representative user if representative user is defined', () => {
+        const resultTable = getResultTable({
+            columns: [
+                {
+                    field: 'publisher',
+                    cardField: 'publisher',
+                    fieldType: FieldType.PUBLISHER
+                }
+            ]
+        });
+        const cards = [
+            getOneLightCard({
+                id: 'card1',
+                publisher: 'entity1',
+                publisherType: 'ENTITY',
+                representative: 'user1'
+            })
+        ];
+        const dataArray = resultTable.getDataArrayFromCards(cards, emptyChildCardsList);
+        expect(dataArray).toEqual([{cardId: 'card1', publisher: 'entity1 name (user1)'}]);
+    });
+
+    it('Should return the representative entity if representative entity is defined', () => {
+        const resultTable = getResultTable({
+            columns: [
+                {
+                    field: 'publisher',
+                    cardField: 'publisher',
+                    fieldType: FieldType.PUBLISHER
+                }
+            ]
+        });
+        const cards = [
+            getOneLightCard({
+                id: 'card1',
+                publisher: 'entity1',
+                publisherType: 'ENTITY',
+                representative: 'entity2',
+                representativeType: 'ENTITY'
+            })
+        ];
+        const dataArray = resultTable.getDataArrayFromCards(cards, emptyChildCardsList);
+        expect(dataArray).toEqual([{cardId: 'card1', publisher: 'entity1 name (entity2 name)'}]);
+    });
+    it('Should return formatted date if field type is DATE_AND_TIME', () => {
+        const resultTable = getResultTable({
+            columns: [
+                {
+                    field: 'date',
+                    cardField: 'startDate',
+                    fieldType: FieldType.DATE_AND_TIME
+                }
+            ]
+        });
+        const cards = [
+            getOneLightCard({
+                id: 'card1',
+                startDate: new Date('2021-01-01T02:00')
+            })
+        ];
+        const dataArray = resultTable.getDataArrayFromCards(cards, emptyChildCardsList);
+        expect(dataArray).toEqual([{cardId: 'card1', date: '01/01/2021 2:00 AM'}]);
+    });
+
+    it('should return the type of state if field type is type_of_state', () => {
+        const resultTable = getResultTable({
+            columns: [
+                {
+                    headerName: 'Status',
+                    fieldType: FieldType.TYPE_OF_STATE
+                }
+            ]
+        });
+        const cards = [
+            getOneLightCard({
+                id: 'card1',
+                publisher: 'entity1',
+                publisherType: 'ENTITY',
+                state: 'myState',
+                process: 'myProcess'
+            })
+        ];
+        const states = new Map<string, State>();
+        states.set('myState', {type: TypeOfStateEnum.INPROGRESS});
+        const process = [new Process('myProcess', '1', null, null, states)];
+        setProcessConfiguration(process);
+        const dataArray = resultTable.getDataArrayFromCards(cards, emptyChildCardsList);
+        expect(dataArray).toEqual([{cardId: 'card1', typeOfState: 'INPROGRESS'}]);
+    });
+    describe('If field type is Responses', () => {
+        it('Should return entity required and allowed to reponse in alphabetical order and in grey if there is no responses', () => {
+            const resultTable = getResultTable({
+                columns: [
+                    {
+                        field: 'responses',
+                        headerName: 'Responses',
+                        fieldType: FieldType.RESPONSES
+                    }
+                ]
+            });
+            const cards = [
+                getOneLightCard({
+                    id: 'card1',
+                    publisher: 'entity1',
+                    publisherType: 'ENTITY',
+                    entitiesAllowedToRespond: ['entity2'],
+                    entitiesRequiredToRespond: ['entity1', 'entity3']
+                })
+            ];
+            const dataArray = resultTable.getDataArrayFromCards(cards, emptyChildCardsList);
+            expect(dataArray).toEqual([
+                {
+                    cardId: 'card1',
+                    responses: [
+                        {name: 'entity1 name', color: 'grey'},
+                        {name: 'entity2 name', color: 'grey'},
+                        {name: 'entity3 name', color: 'grey'}
+                    ]
+                }
+            ]);
+        });
+        it('Should not return entity it entity not allowed to send card', () => {
+            const resultTable = getResultTable({
+                columns: [
+                    {
+                        field: 'responses',
+                        headerName: 'Responses',
+                        fieldType: FieldType.RESPONSES
+                    }
+                ]
+            });
+            const cards = [
+                getOneLightCard({
+                    id: 'card1',
+                    publisher: 'entity1',
+                    publisherType: 'ENTITY',
+                    entitiesAllowedToRespond: ['entity_not_allowed_to_send_card']
+                })
+            ];
+            const dataArray = resultTable.getDataArrayFromCards(cards, emptyChildCardsList);
+            expect(dataArray).toEqual([{cardId: 'card1', responses: []}]);
+        });
+        it('Should include child entity if parent entity is not allowed to send card', () => {
+            const resultTable = getResultTable({
+                columns: [
+                    {
+                        field: 'responses',
+                        headerName: 'Responses',
+                        fieldType: FieldType.RESPONSES
+                    }
+                ]
+            });
+            const cards = [
+                getOneLightCard({
+                    id: 'card1',
+                    publisher: 'entity1',
+                    publisherType: 'ENTITY',
+                    entitiesAllowedToRespond: ['parent_entity']
+                })
+            ];
+            const dataArray = resultTable.getDataArrayFromCards(cards, emptyChildCardsList);
+            expect(dataArray).toEqual([
+                {
+                    cardId: 'card1',
+                    responses: [{name: 'child entity', color: 'grey'}]
+                }
+            ]);
+        });
+        it('Should set color entity according to child card severity if child card if present for entity', () => {
+            const resultTable = getResultTable({
+                columns: [
+                    {
+                        field: 'responses',
+                        headerName: 'Responses',
+                        fieldType: FieldType.RESPONSES
+                    }
+                ]
+            });
+            const cards = [
+                getOneLightCard({
+                    id: 'card1',
+                    publisher: 'entity1',
+                    publisherType: 'ENTITY',
+                    entitiesAllowedToRespond: ['entity1', 'entity2', 'entity3', 'child_entity']
+                })
+            ];
+            const childCards = new Map<string, Array<Card>>();
+            childCards.set('card1', [
+                getOneLightCard({
+                    publisher: 'entity1',
+                    publisherType: 'ENTITY',
+                    severity: Severity.ALARM
+                }),
+                getOneLightCard({
+                    publisher: 'entity2',
+                    publisherType: 'ENTITY',
+                    severity: Severity.ACTION
+                }),
+                getOneLightCard({
+                    publisher: 'entity3',
+                    publisherType: 'ENTITY',
+                    severity: Severity.COMPLIANT
+                }),
+                getOneLightCard({
+                    publisher: 'child_entity',
+                    publisherType: 'ENTITY',
+                    severity: Severity.INFORMATION
+                })
+            ]);
+            const dataArray = resultTable.getDataArrayFromCards(cards, childCards);
+            expect(dataArray).toEqual([
+                {
+                    cardId: 'card1',
+                    responses: [
+                        {name: 'child entity', color: 'blue'},
+                        {name: 'entity1 name', color: 'red'},
+                        {name: 'entity2 name', color: 'orange'},
+                        {name: 'entity3 name', color: 'green'}
+                    ]
+                }
+            ]);
+        });
+    });
+});

--- a/ui/main/src/app/views/customCardList/ResultTable.ts
+++ b/ui/main/src/app/views/customCardList/ResultTable.ts
@@ -1,0 +1,171 @@
+/* Copyright (c) 2025, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
+ */
+
+import {CustomScreenDefinition, FieldType} from '@ofServices/customScreen/model/CustomScreenDefinition';
+import {DateTimeFormatterService} from '@ofServices/dateTimeFormatter/DateTimeFormatterService';
+import {EntitiesService} from '@ofServices/entities/EntitiesService';
+import {ProcessesService} from '@ofServices/processes/ProcessesService';
+import {Card} from 'app/model/Card';
+import {PublisherType} from 'app/model/PublisherType';
+import {Severity} from 'app/model/Severity';
+
+export class ResultTable {
+    private readonly customScreenDefinition: CustomScreenDefinition;
+    private startDate: number;
+    private endDate: number;
+
+    constructor(customScreenDefinition: CustomScreenDefinition) {
+        this.customScreenDefinition = customScreenDefinition;
+    }
+
+    public getColumnsDefinitionForAgGrid(): any[] {
+        const agGridColumns = [];
+        if (this.customScreenDefinition) {
+            this.customScreenDefinition.results.columns.forEach((column) => {
+                switch (column.fieldType) {
+                    case FieldType.SEVERITY:
+                        agGridColumns.push({
+                            field: column.field,
+                            headerName: '',
+                            type: 'severity'
+                        });
+                        break;
+                    case FieldType.TYPE_OF_STATE:
+                        agGridColumns.push({
+                            field: 'typeOfState',
+                            headerName: column.headerName,
+                            type: 'typeOfState',
+                            flex: column.flex
+                        });
+                        break;
+                    case FieldType.RESPONSES:
+                        agGridColumns.push({
+                            field: 'responses',
+                            headerName: column.headerName,
+                            type: 'responses',
+                            flex: column.flex
+                        });
+                        break;
+                    default:
+                        agGridColumns.push({
+                            field: column.field,
+                            headerName: column.headerName,
+                            type: 'default',
+                            flex: column.flex
+                        });
+                }
+            });
+        }
+        return agGridColumns;
+    }
+
+    public setBusinessDateFilter(startDate: number, endDate: number) {
+        this.startDate = startDate;
+        this.endDate = endDate;
+    }
+
+    public getDataArrayFromCards(cards: Card[], childCards: Map<string, Array<Card>>): any[] {
+        const dataArray = [];
+        cards.forEach((card) => {
+            if (!this.isCardInDateRange(card)) return;
+            const data = {};
+            this.customScreenDefinition.results.columns.forEach((column) => {
+                switch (column.fieldType) {
+                    case FieldType.PUBLISHER:
+                        data[column.field] = this.getPublisherLabel(card);
+                        break;
+                    case FieldType.DATE_AND_TIME:
+                        data[column.field] = DateTimeFormatterService.getFormattedDateAndTime(card[column.cardField]);
+                        break;
+                    case FieldType.TYPE_OF_STATE:
+                        data['typeOfState'] = this.getTypeOfState(card);
+                        break;
+                    case FieldType.RESPONSES:
+                        data['responses'] = this.getResponses(card, childCards.get(card.id));
+                        break;
+                    default:
+                        data[column.field] = card[column.cardField];
+                }
+            });
+            data['cardId'] = card.id;
+            dataArray.push(data);
+        });
+        return dataArray;
+    }
+
+    private isCardInDateRange(card: Card): boolean {
+        if (!this.startDate || !this.endDate) return true;
+        if (card.startDate > this.endDate) return false;
+        if (card.endDate) {
+            return card.endDate >= this.startDate;
+        }
+        return card.startDate >= this.startDate;
+    }
+
+    private getPublisherLabel(card: Card): string {
+        let publisherLabel = card.publisher;
+        if (card.publisherType === PublisherType.ENTITY) {
+            publisherLabel = EntitiesService.getEntityName(card.publisher);
+        }
+        if (card.representative) {
+            if (card.representativeType === PublisherType.ENTITY) {
+                publisherLabel += ` (${EntitiesService.getEntityName(card.representative)})`;
+            } else publisherLabel += ` (${card.representative})`;
+        }
+        return publisherLabel;
+    }
+
+    private getTypeOfState(card: Card): string {
+        return ProcessesService.getProcess(card.process)?.states?.get(card.state)?.type;
+    }
+
+    private getResponses(card: Card, childCards: Array<Card>): Array<any> {
+        const entities = new Array();
+
+        const entitiesAllowedOrRequiredToRespond = new Array();
+        if (card.entitiesAllowedToRespond) {
+            entitiesAllowedOrRequiredToRespond.push(...card.entitiesAllowedToRespond);
+        }
+        if (card.entitiesRequiredToRespond) {
+            entitiesAllowedOrRequiredToRespond.push(...card.entitiesRequiredToRespond);
+        }
+
+        EntitiesService.resolveEntitiesAllowedToSendCards(
+            EntitiesService.getEntitiesFromIds(entitiesAllowedOrRequiredToRespond)
+        ).forEach((entity) => {
+            let color = 'grey';
+            if (childCards) {
+                const childCard = childCards.find((childCard) => childCard.publisher === entity.id);
+                if (childCard) {
+                    color = this.getColorForSeverity(childCard.severity);
+                }
+            }
+
+            entities.push({
+                name: entity.name,
+                color
+            });
+        });
+        entities.sort((a, b) => a.name?.localeCompare(b.name));
+        return entities;
+    }
+
+    private getColorForSeverity(severity: Severity): string {
+        switch (severity) {
+            case Severity.ALARM:
+                return 'red';
+            case Severity.ACTION:
+                return 'orange';
+            case Severity.COMPLIANT:
+                return 'green';
+            default:
+                return 'blue';
+        }
+    }
+}

--- a/ui/main/src/assets/i18n/en.json
+++ b/ui/main/src/assets/i18n/en.json
@@ -23,7 +23,8 @@
             "selectStateText": "Select a State",
             "selectTagText": "Select a Tag",
             "toDateBeforeFromDate": "'To' date must be after 'From' date.",
-            "publishDateRange": "PUBLISH DATE RANGE",
+            "businessDateRange": "BUSINESS DATE RANGE",
+            "publishDateRange":"PUBLISH DATE RANGE",
             "activeDateRange": "ACTIVE DATE RANGE"
         },
         "result": {

--- a/ui/main/src/assets/i18n/fr.json
+++ b/ui/main/src/assets/i18n/fr.json
@@ -23,6 +23,7 @@
             "selectStateText": "Sélectionner un État",
             "selectTagText": "Sélectionner une Étiquette",
             "toDateBeforeFromDate": "La date 'Jusqu'à' doit être postérieure à la date 'À partir de'.",
+            "businessDateRange": "PÉRIODE MÉTIER",
             "publishDateRange": "PÉRIODE DE PUBLICATION",
             "activeDateRange": "PÉRIODE D'ACTIVITÉ"
         },

--- a/ui/main/src/assets/i18n/nl.json
+++ b/ui/main/src/assets/i18n/nl.json
@@ -23,6 +23,7 @@
             "selectStateText": "Selecteer een Status",
             "selectTagText": "Selecteer een Label",
             "toDateBeforeFromDate": "'Tot' moet na 'Van' liggen.",
+            "businessDateRange": "BEDRIJFSDATUMBEREIK",
             "publishDateRange": "PUBLICATIEDATUMBEREIK",
             "activeDateRange": "ACTIEVE DATUMBEREIK"
         },

--- a/ui/main/src/tests/helpers.ts
+++ b/ui/main/src/tests/helpers.ts
@@ -64,7 +64,7 @@ export function getOneLightCard(lightCardTemplate?: any): Card {
         getI18nData('testSummary'),
         'testTitleTranslated',
         'testSummaryTranslated',
-        null,
+        lightCardTemplate.data ?? null,
         null,
         null,
         lightCardTemplate.entityRecipients ?? null,

--- a/ui/main/src/tests/helpers.ts
+++ b/ui/main/src/tests/helpers.ts
@@ -50,7 +50,7 @@ export function getOneLightCard(lightCardTemplate?: any): Card {
         lightCardTemplate.publisherVersion ?? 'testPublisherVersion',
         lightCardTemplate.publishDate ?? today,
         lightCardTemplate.startDate ?? startTime,
-        lightCardTemplate.endDate ?? startTime + 1 * NB_SECONDS_IN_ONE_MINUTE * NB_MILLIS_IN_ONE_SECOND,
+        lightCardTemplate.endDate ?? null,
         lightCardTemplate.expirationDate ?? startTime + 1 * NB_SECONDS_IN_ONE_MINUTE * NB_MILLIS_IN_ONE_SECOND,
         lightCardTemplate.severity ?? Severity.ALARM,
         lightCardTemplate.hasBeenAcknowledged ?? false,


### PR DESCRIPTION
- In release notes :
  -  In chapter : Features  
  -  Text : #7881 Add the possibility to define custom card list screens 

**Tips for review :** 

To test : http://localhost:4200/#/customscreen/testId

The definition of the custom screen is done on application loading via a js file that use the api method `opfab.businessconfig.registerCustomScreen` 
 -> an example for testing is in the file config/docker/externalJs/CustomScreenExample.js . The structure of the configuration is define in CustomScreenDefinition.ts 

When user navigate in the custom screen , the date range is set to the current domain ('RT','D',... ) , when the user change the values it changes the domain and so we endup with a none standard domain. We need to keep a standard domain so that when the user go back to feed it does not radically change period or when the user reload the custom screen it set a period near the previous one . That is the objectif of the NearstDomainId class .

Factorize date range picker config in DateRangePickerConfig.ts

Reset button not used yet 

**TO DO LATER :** 

- Documentation
- Cypress test 
- Add the custom screen example in the menu
- Add process filter
- Implement reset filter
