### PR TITLE
Monitoring screen clicking on unlock icon is not updating monitoring result (#7799)

### DIFF
--- a/ui/main/src/app/components/share/timeline-buttons/timeline-buttons.component.ts
+++ b/ui/main/src/app/components/share/timeline-buttons/timeline-buttons.component.ts
@@ -1,4 +1,4 @@
-/* Copyright (c) 2021-2024, RTE (http://www.rte-france.com)
+/* Copyright (c) 2021-2025, RTE (http://www.rte-france.com)
  * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -185,6 +185,7 @@ export class TimelineButtonsComponent implements OnInit, OnDestroy {
         RealTimeDomainService.unlockTimeline();
         // Restore default domain when the user unlocks the timeline
         this.currentDomain = RealTimeDomainService.setDefaultStartAndEndDomain();
+        this.domainChange.emit(true);
     }
 
     moveDomain(moveForward: boolean): void {


### PR DESCRIPTION
- In release notes :
  -  In chapter : Bugs
  -  Text : #7799 : Monitoring screen clicking on unlock icon is not updating monitoring result