### PR TITLE
Custom card list screen : add the possibility to put user input in responses

### DIFF
--- a/config/docker/externalJs/CustomScreenExample.js
+++ b/config/docker/externalJs/CustomScreenExample.js
@@ -123,6 +123,11 @@
                     headerName: 'ANSWERS',
                     fieldType: 'RESPONSES',
                     flex: 2
+                },
+                {
+                    fieldType: 'INPUT',
+                    field: 'comment',
+                    headerName: 'COMMENT'
                 }
             ]
         },
@@ -130,10 +135,14 @@
             {
                 id: 'button1',
                 label: 'Accept proposals',
-                getUserResponses: (cards) => {
+                getUserResponses: (cards, responsesData) => {
                     const responseCards = [];
-                    const responseData = { "choice1": ["on"], "choice2": ["on"], "choice3": ["on"] }
+
                     cards.forEach((card) => {
+
+                        const userInputs = responsesData.get(card.id);
+                        const comment = userInputs?.comment ?? '';
+                        const responseData = { "choice1": "on", "choice2": "on", "choice3": "on", "comment": comment }
                         responseCards.push({ data: responseData });
                     });
                     return { valid: true, errorMsg: '', responseCards: responseCards };
@@ -142,12 +151,21 @@
             {
                 id: 'button2',
                 label: 'Refuse proposals',
-                getUserResponses: (cards) => {
+                getUserResponses: (cards, responsesData) => {
                     const responseCards = [];
-                    const responseData = {}
+                    let hasAlwaysComment = true;
                     cards.forEach((card) => {
+                        const userInputs = responsesData.get(card.id);
+                        const comment = userInputs?.comment ?? '';
+                        if (comment === '') {
+                            hasAlwaysComment = false;
+                        }
+                        const responseData = { "comment": comment }
                         responseCards.push({ data: responseData });
                     });
+                    if (!hasAlwaysComment) {
+                        return { valid: false, errorMsg: 'Please fill in the comment field for all cards' };
+                    }
                     return { valid: true, errorMsg: '', responseCards: responseCards };
                 }
             }

--- a/src/docs/asciidoc/reference_doc/ui_customization.adoc
+++ b/src/docs/asciidoc/reference_doc/ui_customization.adoc
@@ -411,6 +411,7 @@ For each field you want to display in the result table, define a column object. 
 
 - `COLORED_CIRCLE`: Displays a colored circle. The color is defined with a custom method `getValue` defined in the field definition.
 - `DATE_AND_TIME`: Displays the date and time formatted according to the user's locale.
+- `INPUT`: Displays an input field. The value of the input field will be used for response cards if the custom screen has response buttons (see below).
 - `PUBLISHER`: Displays the publisher entity if the card is published by an entity, otherwise displays the user who published the card.
 - `RESPONSES`: Displays the list of entities that must respond, with the color indicating the severity of the response if the entity has responded. It uses the `entitiesRequiredToRespond` field of the card. If this field is empty, it will use the `entitiesAllowedToRespond` field of the card.
 - `RESPONSE_FROM_MY_ENTITIES`: Displays a blue arrow if one of the user's entity has responded to the card.
@@ -426,16 +427,24 @@ The `flex` field sets the CSS flex property for the column.
 
 === Response buttons 
 
-It is possible to define custom response buttons for the custom screen, this allows the user to send multiple responses at once.
+It is possible to define custom response buttons for the custom screen allowing the user to send multiple responses at once.
 
 To do this, add a `responseButtons` array to the custom screen object. Each button object must contain the following fields:
 
 - `id`: The button identifier.
 - `label`: The button label.
-- `getUserResponses: A function that takes an array of cards as a parameter and returns an object containing the following fields:
-  - `valid`: A boolean indicating if the action is valid.
-  - `errorMsg`: An error message to display if the action is not valid.
-  - `responseCards`: An array of response cards to send with a `data` field containing the response card data field.
+- `getUserResponses`: a function that retrieves data for response cards.
+
+The getUserResponses function takes two parameters: 
+
+- an array of cards
+- a map of responseInput indexed by card id. The responseInput is an object containing the response input fields and their values.
+
+The method shall return an object containing the following fields:
+
+- `valid`: A boolean indicating if the action is valid.
+- `errorMsg`: An error message to display if the action is not valid.
+- `responseCards`: An array of response cards to send, each containing a `data` field containing a response card data .
 
  
 
@@ -447,15 +456,19 @@ const customScreenExample = {
         name: 'testName',
 
         .....
-     
+
         responseButtons: [
             {
                 id: 'button1',
                 label: 'Accept proposals',
-                getUserResponses: (cards) => {
+                getUserResponses: (cards, responsesData) => {
                     const responseCards = [];
-                    const responseData = { "choice1": ["on"], "choice2": ["on"], "choice3": ["on"] }
+
                     cards.forEach((card) => {
+
+                        const userInputs = responsesData.get(card.id);
+                        const comment = userInputs?.comment ?? '';
+                        const responseData = { "choice1": "on", "choice2": "on", "choice3": "on", "comment": comment }
                         responseCards.push({ data: responseData });
                     });
                     return { valid: true, errorMsg: '', responseCards: responseCards };
@@ -464,17 +477,37 @@ const customScreenExample = {
             {
                 id: 'button2',
                 label: 'Refuse proposals',
-                getUserResponses: (cards) => {
+                getUserResponses: (cards, responsesData) => {
                     const responseCards = [];
-                    const responseData = {}
+                    let hasAlwaysComment = true;
                     cards.forEach((card) => {
+                        const userInputs = responsesData.get(card.id);
+                        const comment = userInputs?.comment ?? '';
+                        if (comment === '') {
+                            hasAlwaysComment = false;
+                        }
+                        const responseData = { "comment": comment }
                         responseCards.push({ data: responseData });
                     });
+                    if (!hasAlwaysComment) {
+                        return { valid: false, errorMsg: 'Please fill in the comment field for all cards' };
+                    }
                     return { valid: true, errorMsg: '', responseCards: responseCards };
                 }
             }
         ]
 
+----
+
+The input fields are to be defined in the columns definition with fieldType set to `INPUT` , for example :  
+
+----
+{
+    field: 'comment',
+    headerName: 'Comment',
+    fieldType: 'INPUT',
+    flex: 1
+}
 ----
 
 === Card data fields
@@ -508,3 +541,5 @@ Then you have to add the fields in the `results.columns` field in the custom scr
                 },
                 ...
 ----
+
+

--- a/src/test/resources/bundles/defaultProcess_V1/template/question.handlebars
+++ b/src/test/resources/bundles/defaultProcess_V1/template/question.handlebars
@@ -22,7 +22,12 @@
                 type="checkbox" id="choice3" name="choice3"> <span id="question-choice3"
                 class="opfab-checkbox-checkmark"> </span> </label>
     </div>
-    <div id="responseRequired"></div>
+
+      <div class="opfab-input" style="margin-top:20px;margin-bottom:10px;width:500px">
+          <label> Comment </label>
+          <input id="comment" name="comment">
+      </div>
+        <div id="responseRequired"></div>
     <div id="responseDisabled" class="opfab-color-danger"></div>
 </form>
 
@@ -60,6 +65,7 @@
                 responses += ' <th> ' + date1 + ' 8AM-10AM </th>';
                 responses += ' <th> ' + date1 + ' 10AM-12PM </th>';
                 responses += ' <th> ' + date2 + ' 8AM-10AM </th>';
+                responses += ' <th> Comment </th>';
                 responses += ' </tr>';
 
                 childCards.forEach((c, i) => {
@@ -71,6 +77,8 @@
                     else responses += "<td> NOK </td>";
                     if (c.data.choice3) responses += "<td> OK </td>";
                     else responses += "<td> NOK </td>";
+                    if (c.data.comment) responses += `<td> ${c.data.comment} </td>`;
+                    else responses += "<td>  </td>";
                     responses += "</tr>";
                 });
 
@@ -88,22 +96,29 @@
         //tag::opfab.currentCard.registerFunctionToGetUserResponse_example[]
         opfab.currentCard.registerFunctionToGetUserResponse(() => {
 
-            const responseCardData = {};
-            const formElement = document.getElementById('question-form');
-            for (const [key, value] of [... new FormData(formElement)]) {
-                (key in responseCardData) ? responseCardData[key].push(value) : responseCardData[key] = [value];
-            }
 
+            const choice1 = document.getElementById('choice1').checked;
+            const choice2 = document.getElementById('choice2').checked;
+            const choice3 = document.getElementById('choice3').checked;
+            const comment = document.getElementById('comment').value;
             const result = {
                 valid: true,
                 responseCard:{
-                    data: responseCardData
+                    data: {
+                    choice1: choice1,
+                    choice2: choice2, 
+                    choice3: choice3,
+                    comment: comment
+                    }
                 } 
             };
 
             // If the user chose several options, we decide to move the process to a specific state, for example to ask a follow-up question (what's their preferred option).
-            const choiceRequiresFollowUp = Object.entries(responseCardData).length > 1;
-            if (choiceRequiresFollowUp) result.responseCard['state'] = 'multipleOptionsResponseState';
+            let choiceOnNumber = 0;
+            if (choice1) choiceOnNumber++;
+            if (choice2) choiceOnNumber++;
+            if (choice3) choiceOnNumber++;
+            if (choiceOnNumber>1) result.responseCard['state'] = 'multipleOptionsResponseState';
 
             return result;
 
@@ -114,12 +129,14 @@
             document.getElementById('choice1').disabled = true;
             document.getElementById('choice2').disabled = true;
             document.getElementById('choice3').disabled = true;
+            document.getElementById('comment').disabled = true;
         });
 
         opfab.currentCard.listenToResponseUnlock(() => {
             document.getElementById('choice1').disabled = false;
             document.getElementById('choice2').disabled = false;
             document.getElementById('choice3').disabled = false;
+            document.getElementById('comment').disabled = false;
 
         });
 

--- a/src/test/resources/cardsForStressTests/defaultProcess/question.json
+++ b/src/test/resources/cardsForStressTests/defaultProcess/question.json
@@ -13,7 +13,6 @@
 		"summary" : {"key" : "message.summary"},
 		"title" : {"key" : "question.title"},
 		"data" : {"message":" Action Card"},
-		"lttd" :  180000		,
 		"timeSpans" : [
 			{"start" :  14400000}
 			]

--- a/ui/main/src/app/components/customCardList/CustomCardListComponent.html
+++ b/ui/main/src/app/components/customCardList/CustomCardListComponent.html
@@ -111,7 +111,7 @@
             [gridOptions]="gridOptions"
             [rowSelection]="rowSelection"
             (gridReady)="onGridReady($event)"
-            (rowClicked)="selectCard($event.data.cardId)"
+            (cellClicked)="selectCard($event)"
             class="ag-theme-opfab">
         </ag-grid-angular>
 

--- a/ui/main/src/app/components/customCardList/CustomCardListComponent.scss
+++ b/ui/main/src/app/components/customCardList/CustomCardListComponent.scss
@@ -42,3 +42,4 @@
     float: right;
     margin-left: 10px;
 }
+

--- a/ui/main/src/app/components/customCardList/cellRenderers/InputCellRendererComponent.html
+++ b/ui/main/src/app/components/customCardList/cellRenderers/InputCellRendererComponent.html
@@ -1,0 +1,13 @@
+<!-- Copyright (c) 2025, RTE (http://www.rte-france.com) -->
+<!-- See AUTHORS.txt                                                       -->
+<!-- This Source Code Form is subject to the terms of the Mozilla Public   -->
+<!-- License, v. 2.0. If a copy of the MPL was not distributed with this   -->
+<!-- file, You can obtain one at http://mozilla.org/MPL/2.0/.              -->
+<!-- SPDX-License-Identifier: MPL-2.0                                      -->
+<!-- This file is part of the OperatorFabric project.                      -->
+
+<div *ngIf="isInputFieldVisible" style="margin: 3px; align-items: center">
+    <div>
+        <input [formControl]="cardInputControl" type="text" style="height: 35px; width: 80%" size="30" />
+    </div>
+</div>

--- a/ui/main/src/app/components/customCardList/cellRenderers/InputCellRendererComponent.ts
+++ b/ui/main/src/app/components/customCardList/cellRenderers/InputCellRendererComponent.ts
@@ -1,0 +1,47 @@
+/* Copyright (c) 2025, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
+ */
+
+import {Component} from '@angular/core';
+import {ICellRendererAngularComp} from 'ag-grid-angular';
+import {ICellRendererParams} from 'ag-grid-community';
+import {NgIf} from '@angular/common';
+import {FormControl, ReactiveFormsModule} from '@angular/forms';
+
+@Component({
+    selector: 'of-has-response-cell-renderer',
+    templateUrl: './InputCellRendererComponent.html',
+    standalone: true,
+    imports: [NgIf, ReactiveFormsModule]
+})
+export class InputCellRendererComponent implements ICellRendererAngularComp {
+    public params: any;
+    public isInputFieldVisible = false;
+    cardInputControl: FormControl = new FormControl('');
+
+    agInit(params: any): void {
+        this.params = params;
+    }
+
+    /** This method returns true to signal to the grid that this renderer doesn't need to be recreated if the underlying data changes
+     *  See https://www.ag-grid.com/documentation/angular/component-cell-renderer/#handling-refresh
+     * */
+    refresh(params: ICellRendererParams): boolean {
+        return true;
+    }
+
+    activateInput() {
+        this.isInputFieldVisible = true;
+    }
+    deactivateInput() {
+        this.isInputFieldVisible = false;
+    }
+    getInputValue() {
+        return this.cardInputControl.value;
+    }
+}

--- a/ui/main/src/app/services/customScreen/model/CustomScreenDefinition.ts
+++ b/ui/main/src/app/services/customScreen/model/CustomScreenDefinition.ts
@@ -32,7 +32,7 @@ export class Column {
 export class ResponseButton {
     id: string;
     label: string;
-    getUserResponses: (selectedCards: Card[]) => any;
+    getUserResponses: (selectedCards: Card[], userInputs: Map<string, any>) => any;
 }
 
 export class UserResponse {
@@ -50,7 +50,8 @@ export enum FieldType {
     TYPE_OF_STATE = 'TYPE_OF_STATE',
     RESPONSES = 'RESPONSES',
     COLORED_CIRCLE = 'COLORED_CIRCLE',
-    RESPONSE_FROM_MY_ENTITIES = 'RESPONSE_FROM_MY_ENTITIES'
+    RESPONSE_FROM_MY_ENTITIES = 'RESPONSE_FROM_MY_ENTITIES',
+    INPUT = 'INPUT'
 }
 
 export enum HeaderFilter {

--- a/ui/main/src/app/views/customCardList/CustomCardListView-Response.spec.ts
+++ b/ui/main/src/app/views/customCardList/CustomCardListView-Response.spec.ts
@@ -29,8 +29,10 @@ import {ServerResponse, ServerResponseStatus} from 'app/server/ServerResponse';
 import {CardsServerMock} from '@tests/mocks/CardsServer.mock';
 import {CardsService} from '@ofServices/cards/CardsService';
 import {NotificationDecision} from '@ofServices/notifications/NotificationDecision';
-import {firstValueFrom} from 'rxjs';
+import {ReplaySubject, firstValueFrom} from 'rxjs';
 import {CardTemplateGateway} from '@ofServices/templateGateway/CardTemplateGateway';
+import {Message, MessageLevel} from '@ofServices/alerteMessage/model/Message';
+import {AlertMessageService} from '@ofServices/alerteMessage/AlertMessageService';
 
 describe('CustomCardListView - Responses', () => {
     let opfabEventStreamServerMock: OpfabEventStreamServerMock;
@@ -54,223 +56,196 @@ describe('CustomCardListView - Responses', () => {
         RealTimeDomainService.setStartAndEndPeriod(0, new Date().valueOf() + 1000);
         filteredLightCardStore = OpfabStore.getFilteredLightCardStore();
     });
-    const customScreenDefinition = {
-        id: 'testId',
-        name: 'name',
-        cardProcessIds: [],
-        headerFilters: [],
-        results: {
-            columns: []
-        },
-        responseButtons: [
-            {
-                id: 'button1',
-                label: 'label1',
-                getUserResponses: (cards) => {
-                    const responseCards = [];
-                    cards.forEach((card) => {
-                        responseCards.push({data: card.id});
-                    });
-                    return {valid: true, errorMsg: '', responseCards: responseCards};
-                }
+    const customScreenDefinition = getCustomScreenDefinitionExample();
+
+    function getCustomScreenDefinitionExample(): CustomScreenDefinition {
+        return {
+            id: 'testId',
+            name: 'name',
+            cardProcessIds: [],
+            headerFilters: [],
+            results: {
+                columns: []
             },
-            {
-                id: 'button2',
-                label: 'label2',
-                getUserResponses: (cards) => {
-                    return {valid: true, errorMsg: '', responseCards: {}};
+            responseButtons: [
+                {
+                    id: 'button1',
+                    label: 'label1',
+                    getUserResponses: (cards: any[], responsesData: Map<string, any>) => {
+                        const responseCards = [];
+                        cards.forEach((card: any) => {
+                            const userInputs = responsesData.get(card.id);
+                            let comment = '';
+                            if (userInputs) {
+                                comment = userInputs.comment ?? '';
+                            }
+                            responseCards.push({data: {parentCard: card.id, comment: comment}});
+                        });
+                        return {valid: true, errorMsg: '', responseCards: responseCards};
+                    }
+                },
+                {
+                    id: 'button2',
+                    label: 'label2',
+                    getUserResponses: (_cards: any) => {
+                        return {valid: false, errorMsg: 'Error test', responseCards: {}};
+                    }
                 }
-            }
-        ]
-    };
+            ]
+        };
+    }
 
-    it('should get button list', () => {
-        CustomScreenService.addCustomScreenDefinition(customScreenDefinition);
-        const view = new CustomCardListView('testId');
+    describe('When get responses buttons', () => {
+        it('should get button list', () => {
+            CustomScreenService.addCustomScreenDefinition(customScreenDefinition);
+            const view = new CustomCardListView('testId');
 
-        const result = view.getResponseButtons();
-        expect(result).toEqual([
-            {
-                id: 'button1',
-                label: 'label1'
-            },
-            {
-                id: 'button2',
-                label: 'label2'
-            }
-        ]);
-    });
-    it('should get empty button list if no button list defined', () => {
-        const noButtonsCustomScreenDefinition = new CustomScreenDefinition();
-        noButtonsCustomScreenDefinition.id = 'testId';
-        noButtonsCustomScreenDefinition.name = 'testName';
-
-        CustomScreenService.addCustomScreenDefinition(noButtonsCustomScreenDefinition);
-        const view = new CustomCardListView('testId');
-
-        const result = view.getResponseButtons();
-        expect(result).toEqual([]);
-    });
-
-    it('response possible should be true if user is allowed to respond ', async () => {
-        CustomScreenService.addCustomScreenDefinition(customScreenDefinition);
-        const view = new CustomCardListView('testId');
-
-        const myState = new State();
-        myState.response = {state: 'myState'};
-
-        const statesList = new Map();
-        statesList.set('myState', myState);
-
-        const process = [new Process('myProcess', '1', 'my process label', null, statesList)];
-        setProcessConfiguration(process);
-
-        setEntities([
-            {
-                id: 'entity1',
-                name: 'entity1 name',
-                roles: [RoleEnum.CARD_SENDER]
-            }
-        ]);
-
-        await setUserPerimeter({
-            computedPerimeters: [new ComputedPerimeter('myProcess', 'myState', RightEnum.ReceiveAndWrite)],
-            userData: {
-                login: 'test',
-                firstName: 'firstName',
-                lastName: 'lastName',
-                entities: ['entity1']
-            }
+            const result = view.getResponseButtons();
+            expect(result).toEqual([
+                {
+                    id: 'button1',
+                    label: 'label1'
+                },
+                {
+                    id: 'button2',
+                    label: 'label2'
+                }
+            ]);
         });
+        it('should get empty button list if no button list defined', () => {
+            const noButtonsCustomScreenDefinition = new CustomScreenDefinition();
+            noButtonsCustomScreenDefinition.id = 'testId';
 
-        const card = getOneLightCard({
-            publisher: 'entity0',
-            publisherType: 'ENTITY',
-            process: 'myProcess',
-            state: 'myState',
-            entitiesAllowedToRespond: ['entity1'],
-            id: 'id1'
+            CustomScreenService.addCustomScreenDefinition(noButtonsCustomScreenDefinition);
+            const view = new CustomCardListView('testId');
+
+            const result = view.getResponseButtons();
+            expect(result).toEqual([]);
         });
-        opfabEventStreamServerMock.sendLightCard(card);
-
-        await firstValueFrom(filteredLightCardStore.getFilteredLightCards());
-
-        const responsePossible = view.isResponsePossibleForCard('id1');
-        expect(responsePossible).toBeTrue();
-    });
-    it('response possible should be false if user is not allowed to respond ', async () => {
-        CustomScreenService.addCustomScreenDefinition(customScreenDefinition);
-        const view = new CustomCardListView('testId');
-
-        const myState = new State();
-        myState.response = {state: 'myState'};
-
-        const statesList = new Map();
-        statesList.set('myState', myState);
-
-        const process = [new Process('myProcess', '1', 'my process label', null, statesList)];
-        setProcessConfiguration(process);
-
-        setEntities([
-            {
-                id: 'entity1',
-                name: 'entity1 name',
-                roles: [RoleEnum.CARD_SENDER]
-            }
-        ]);
-
-        await setUserPerimeter({
-            computedPerimeters: [],
-            userData: {
-                login: 'test',
-                firstName: 'firstName',
-                lastName: 'lastName',
-                entities: ['entity1']
-            }
-        });
-
-        const card = getOneLightCard({
-            publisher: 'entity0',
-            publisherType: 'ENTITY',
-            process: 'myProcess',
-            state: 'myState',
-            entitiesAllowedToRespond: ['entity1'],
-            id: 'id1'
-        });
-        opfabEventStreamServerMock.sendLightCard(card);
-
-        await firstValueFrom(filteredLightCardStore.getFilteredLightCards());
-
-        const responsePossible = view.isResponsePossibleForCard('id1');
-        expect(responsePossible).toBeFalse();
     });
 
-    it('should send response card', async () => {
-        CustomScreenService.addCustomScreenDefinition(customScreenDefinition);
-        const view = new CustomCardListView('testId');
+    describe('Response card should', () => {
+        let view: CustomCardListView;
+        let cardServerMock: CardsServerMock;
+        beforeEach(async () => {
+            CustomScreenService.addCustomScreenDefinition(customScreenDefinition);
+            view = new CustomCardListView('testId');
 
-        const cardServerMock = new CardsServerMock();
-        cardServerMock.setResponseFunctionForPostCard(() => new ServerResponse(undefined, ServerResponseStatus.OK, ''));
-        CardsService.setCardsServer(cardServerMock);
+            cardServerMock = new CardsServerMock();
+            cardServerMock.setResponseFunctionForPostCard(
+                () => new ServerResponse(undefined, ServerResponseStatus.OK, '')
+            );
+            CardsService.setCardsServer(cardServerMock);
 
-        const myState = new State();
-        myState.response = {state: 'myState'};
+            configureProcesses();
+            configureEntities();
+            await configureUserPerimeter();
+            await sendTwoCards();
 
-        const statesList = new Map();
-        statesList.set('myState', myState);
-
-        const process = [new Process('myProcess', '1', 'my process label', null, statesList)];
-        setProcessConfiguration(process);
-
-        setEntities([
-            {
-                id: 'entity1',
-                name: 'entity1 name',
-                roles: [RoleEnum.CARD_SENDER]
+            async function configureUserPerimeter() {
+                await setUserPerimeter({
+                    computedPerimeters: [new ComputedPerimeter('myProcess', 'myState', RightEnum.ReceiveAndWrite)],
+                    userData: {
+                        login: 'test',
+                        firstName: 'firstName',
+                        lastName: 'lastName',
+                        entities: ['entity1']
+                    }
+                });
             }
-        ]);
 
-        await setUserPerimeter({
-            computedPerimeters: [new ComputedPerimeter('myProcess', 'myState', RightEnum.ReceiveAndWrite)],
-            userData: {
-                login: 'test',
-                firstName: 'firstName',
-                lastName: 'lastName',
-                entities: ['entity1']
+            function configureEntities() {
+                setEntities([
+                    {
+                        id: 'entity1',
+                        name: 'entity1 name',
+                        roles: [RoleEnum.CARD_SENDER]
+                    }
+                ]);
+            }
+
+            function configureProcesses() {
+                const myState = new State();
+                myState.response = {state: 'myState'};
+
+                const statesList = new Map();
+                statesList.set('myState', myState);
+
+                const process = [new Process('myProcess', '1', 'my process label', null, statesList)];
+                setProcessConfiguration(process);
+            }
+
+            async function sendTwoCards() {
+                const card = getOneLightCard({
+                    publisher: 'entity0',
+                    publisherType: 'ENTITY',
+                    process: 'myProcess',
+                    state: 'myState',
+                    entitiesAllowedToRespond: ['entity1'],
+                    id: 'id1'
+                });
+
+                const card2 = getOneLightCard({
+                    publisher: 'entity0',
+                    publisherType: 'ENTITY',
+                    process: 'myProcess',
+                    state: 'myState',
+                    entitiesAllowedToRespond: ['entity1'],
+                    id: 'id2'
+                });
+                opfabEventStreamServerMock.sendLightCard(card);
+                opfabEventStreamServerMock.sendLightCard(card2);
+
+                await firstValueFrom(filteredLightCardStore.getFilteredLightCards());
             }
         });
+        it('be send', async () => {
+            const responseData = new Map<string, any>();
+            responseData.set('id1', {});
+            responseData.set('id2', {});
+            await view.clickOnButton('button1', responseData);
 
-        const card = getOneLightCard({
-            publisher: 'entity0',
-            publisherType: 'ENTITY',
-            process: 'myProcess',
-            state: 'myState',
-            entitiesAllowedToRespond: ['entity1'],
-            id: 'id1'
+            expect(cardServerMock.cardsPosted[0].process).toBe('myProcess');
+            expect(cardServerMock.cardsPosted[0].state).toBe('myState');
+            expect(cardServerMock.cardsPosted[0].data).toEqual({parentCard: 'id1', comment: ''});
+            expect(cardServerMock.cardsPosted[0].parentCardId).toBe('id1');
+            expect(cardServerMock.cardsPosted[1].process).toBe('myProcess');
+            expect(cardServerMock.cardsPosted[1].state).toBe('myState');
+            expect(cardServerMock.cardsPosted[1].data).toEqual({parentCard: 'id2', comment: ''});
+            expect(cardServerMock.cardsPosted[1].parentCardId).toBe('id2');
         });
 
-        const card2 = getOneLightCard({
-            publisher: 'entity0',
-            publisherType: 'ENTITY',
-            process: 'myProcess',
-            state: 'myState',
-            entitiesAllowedToRespond: ['entity1'],
-            id: 'id2'
+        it('be sent with user input', async () => {
+            const responseData = new Map<string, any>();
+            responseData.set('id1', {comment: 'comment1'});
+            responseData.set('id2', {comment: 'comment2'});
+            await view.clickOnButton('button1', responseData);
+
+            expect(cardServerMock.cardsPosted[0].process).toBe('myProcess');
+            expect(cardServerMock.cardsPosted[0].state).toBe('myState');
+            expect(cardServerMock.cardsPosted[0].data).toEqual({parentCard: 'id1', comment: 'comment1'});
+            expect(cardServerMock.cardsPosted[0].parentCardId).toBe('id1');
+            expect(cardServerMock.cardsPosted[1].process).toBe('myProcess');
+            expect(cardServerMock.cardsPosted[1].state).toBe('myState');
+            expect(cardServerMock.cardsPosted[1].data).toEqual({parentCard: 'id2', comment: 'comment2'});
+            expect(cardServerMock.cardsPosted[1].parentCardId).toBe('id2');
         });
-        opfabEventStreamServerMock.sendLightCard(card);
-        opfabEventStreamServerMock.sendLightCard(card2);
+        it('should not be sent and it should show alert to user if custom code return an error', async () => {
+            const responseData = new Map<string, any>();
+            responseData.set('id1', {comment: 'comment1'});
+            responseData.set('id2', {comment: 'comment2'});
 
-        await firstValueFrom(filteredLightCardStore.getFilteredLightCards());
+            const alertSubject = new ReplaySubject<Message>();
+            AlertMessageService.getAlertMessage().subscribe((Message) => {
+                alertSubject.next(Message);
+            });
 
-        await view.clickOnButton('button1', ['id1', 'id2']);
+            await view.clickOnButton('button2', responseData);
+            const message = await firstValueFrom(alertSubject.asObservable());
+            expect(message.message).toEqual('Error test');
+            expect(message.level).toEqual(MessageLevel.ERROR);
 
-        expect(cardServerMock.cardsPosted[0].process).toBe('myProcess');
-        expect(cardServerMock.cardsPosted[0].state).toBe('myState');
-        expect(cardServerMock.cardsPosted[0].data).toBe('id1');
-        expect(cardServerMock.cardsPosted[0].parentCardId).toBe('id1');
-        expect(cardServerMock.cardsPosted[1].process).toBe('myProcess');
-        expect(cardServerMock.cardsPosted[1].state).toBe('myState');
-        expect(cardServerMock.cardsPosted[1].data).toBe('id2');
-        expect(cardServerMock.cardsPosted[1].parentCardId).toBe('id2');
+            expect(cardServerMock.cardsPosted.length).toBe(0);
+        });
     });
 });

--- a/ui/main/src/app/views/customCardList/CustomCardListView.spec.ts
+++ b/ui/main/src/app/views/customCardList/CustomCardListView.spec.ts
@@ -158,6 +158,15 @@ describe('CustomCardListView', () => {
     });
     describe('Should return custom screen data', () => {
         beforeEach(() => {
+            const myState = new State();
+            myState.response = {state: 'state1'};
+
+            const statesList = new Map();
+            statesList.set('state1', myState);
+
+            const process = [new Process('process1', '1', 'my process label', null, statesList)];
+            setProcessConfiguration(process);
+
             setEntities([
                 {
                     id: 'entity1',
@@ -221,7 +230,8 @@ describe('CustomCardListView', () => {
                 {
                     cardId: 'id1',
                     testField: 'process1',
-                    responses: [{name: 'entity1 name', color: 'green'}]
+                    responses: [{name: 'entity1 name', color: 'green'}],
+                    isResponsePossible: false
                 }
             ]);
         });
@@ -272,7 +282,8 @@ describe('CustomCardListView', () => {
             expect(result).toEqual([
                 {
                     cardId: 'id1',
-                    testField: 'process1'
+                    testField: 'process1',
+                    isResponsePossible: false
                 }
             ]);
         });

--- a/ui/main/src/app/views/customCardList/CustomCardListView.ts
+++ b/ui/main/src/app/views/customCardList/CustomCardListView.ts
@@ -56,7 +56,7 @@ export class CustomCardListView {
                 );
                 const endTimer = Date.now();
                 LoggerService.info(`Custom card list - Time to process data: ${endTimer - startTimer}ms`);
-                return this.results;
+                return this.responses.addIsResponsePossibleForCardToResults(this.results);
             })
         );
     }
@@ -135,12 +135,8 @@ export class CustomCardListView {
         return this.responses.getResponseButtons();
     }
 
-    public isResponsePossibleForCard(cardId: string) {
-        return this.responses.isResponsePossibleForCard(cardId);
-    }
-
-    public async clickOnButton(buttonId: string, selectedCards: string[]) {
-        await this.responses.sendResponse(buttonId, selectedCards);
+    public async clickOnButton(buttonId: string, responsesData: Map<string, any>) {
+        await this.responses.sendResponsesWhenUserClicksOnResponseButton(buttonId, responsesData);
     }
 
     public destroy() {

--- a/ui/main/src/app/views/customCardList/Responses.spec.ts
+++ b/ui/main/src/app/views/customCardList/Responses.spec.ts
@@ -1,0 +1,155 @@
+/* Copyright (c) 2025, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
+ */
+
+import {CustomScreenService} from '@ofServices/customScreen/CustomScreenService';
+import {OpfabEventStreamServerMock} from '@tests/mocks/opfab-event-stream.server.mock';
+import {OpfabEventStreamService} from '@ofServices/events/OpfabEventStreamService';
+import {OpfabStore} from '@ofStore/opfabStore';
+import {RealTimeDomainService} from '@ofServices/realTimeDomain/RealTimeDomainService';
+import {TranslationService} from '@ofServices/translation/TranslationService';
+import {TranslationLibMock} from '@tests/mocks/TranslationLib.mock';
+import {ConfigService} from '@ofServices/config/ConfigService';
+import {DateTimeFormatterService} from '@ofServices/dateTimeFormatter/DateTimeFormatterService';
+import {ConfigServerMock} from '@tests/mocks/configServer.mock';
+import {FilteredLightCardsStore} from '@ofStore/lightcards/lightcards-feed-filter-store';
+import {getOneLightCard, setEntities, setProcessConfiguration, setUserPerimeter} from '@tests/helpers';
+import {RoleEnum} from '@ofServices/entities/model/RoleEnum';
+import {RightEnum} from '@ofServices/perimeters/model/Perimeter';
+import {ComputedPerimeter} from '@ofServices/users/model/UserWithPerimeters';
+import {Process, State} from '@ofServices/processes/model/Processes';
+import {NotificationDecision} from '@ofServices/notifications/NotificationDecision';
+import {firstValueFrom} from 'rxjs';
+import {CardTemplateGateway} from '@ofServices/templateGateway/CardTemplateGateway';
+import {Responses} from './Responses';
+
+describe('CustomCardListView - Response possible', () => {
+    let opfabEventStreamServerMock: OpfabEventStreamServerMock;
+    let filteredLightCardStore: FilteredLightCardsStore;
+
+    beforeAll(() => {
+        TranslationService.setTranslationLib(new TranslationLibMock());
+        ConfigService.setConfigServer(new ConfigServerMock());
+        DateTimeFormatterService.init();
+        NotificationDecision.init();
+        CardTemplateGateway.init();
+        CardTemplateGateway.initTemplateFunctions();
+    });
+
+    beforeEach(() => {
+        CustomScreenService.clearCustomScreenDefinitions();
+        opfabEventStreamServerMock = new OpfabEventStreamServerMock();
+        OpfabEventStreamService.setEventStreamServer(opfabEventStreamServerMock);
+        OpfabStore.reset();
+        RealTimeDomainService.init();
+        RealTimeDomainService.setStartAndEndPeriod(0, Date.now() + 1000);
+        filteredLightCardStore = OpfabStore.getFilteredLightCardStore();
+        const myState = new State();
+        myState.response = {state: 'myState'};
+
+        const statesList = new Map();
+        statesList.set('myState', myState);
+
+        const process = [new Process('myProcess', '1', 'my process label', null, statesList)];
+        setProcessConfiguration(process);
+
+        setEntities([
+            {
+                id: 'entity1',
+                name: 'entity1 name',
+                roles: [RoleEnum.CARD_SENDER]
+            }
+        ]);
+    });
+    const customScreenDefinition = {
+        id: 'testId',
+        name: 'name',
+        cardProcessIds: [],
+        headerFilters: [],
+        results: {
+            columns: []
+        },
+        responseButtons: [
+            {
+                id: 'button1',
+                label: 'label1',
+                getUserResponses: (cards: any) => {
+                    const responseCards = [];
+                    cards.forEach((card: any) => {
+                        responseCards.push({data: card.id});
+                    });
+                    return {valid: true, errorMsg: '', responseCards: responseCards};
+                }
+            },
+            {
+                id: 'button2',
+                label: 'label2',
+                getUserResponses: (_cards: any) => {
+                    return {valid: true, errorMsg: '', responseCards: {}};
+                }
+            }
+        ]
+    };
+
+    it('should be true if user is allowed to respond ', async () => {
+        const responses = new Responses(customScreenDefinition);
+
+        await setUserPerimeter({
+            computedPerimeters: [new ComputedPerimeter('myProcess', 'myState', RightEnum.ReceiveAndWrite)],
+            userData: {
+                login: 'test',
+                firstName: 'firstName',
+                lastName: 'lastName',
+                entities: ['entity1']
+            }
+        });
+
+        const card = getOneLightCard({
+            publisher: 'entity0',
+            publisherType: 'ENTITY',
+            process: 'myProcess',
+            state: 'myState',
+            entitiesAllowedToRespond: ['entity1'],
+            id: 'id1'
+        });
+        opfabEventStreamServerMock.sendLightCard(card);
+
+        await firstValueFrom(filteredLightCardStore.getFilteredLightCards());
+
+        const resultTable = responses.addIsResponsePossibleForCardToResults([{cardId: 'id1'}]);
+        expect(resultTable).toEqual([{cardId: 'id1', isResponsePossible: true}]);
+    });
+    it('should be false if user is not allowed to respond ', async () => {
+        const responses = new Responses(customScreenDefinition);
+
+        await setUserPerimeter({
+            computedPerimeters: [],
+            userData: {
+                login: 'test',
+                firstName: 'firstName',
+                lastName: 'lastName',
+                entities: ['entity1']
+            }
+        });
+
+        const card = getOneLightCard({
+            publisher: 'entity0',
+            publisherType: 'ENTITY',
+            process: 'myProcess',
+            state: 'myState',
+            entitiesAllowedToRespond: ['entity1'],
+            id: 'id1'
+        });
+        opfabEventStreamServerMock.sendLightCard(card);
+
+        await firstValueFrom(filteredLightCardStore.getFilteredLightCards());
+
+        const resultTable = responses.addIsResponsePossibleForCardToResults([{cardId: 'id1'}]);
+        expect(resultTable).toEqual([{cardId: 'id1', isResponsePossible: false}]);
+    });
+});

--- a/ui/main/src/app/views/customCardList/Responses.ts
+++ b/ui/main/src/app/views/customCardList/Responses.ts
@@ -14,6 +14,8 @@ import {OpfabStore} from '@ofStore/opfabStore';
 import {UserPermissionsService} from '@ofServices/userPermissions/UserPermissionsService';
 import {UsersService} from '@ofServices/users/UsersService';
 import {ProcessesService} from '@ofServices/processes/ProcessesService';
+import {AlertMessageService} from '@ofServices/alerteMessage/AlertMessageService';
+import {Message, MessageLevel} from '@ofServices/alerteMessage/model/Message';
 
 export class Responses {
     private readonly customScreenDefinition: CustomScreenDefinition;
@@ -34,7 +36,17 @@ export class Responses {
         });
     }
 
-    public isResponsePossibleForCard(cardId: string): boolean {
+    public addIsResponsePossibleForCardToResults(results: any[]): any[] {
+        return results.map((result) => {
+            const isResponsePossible = this.isResponsePossibleForCard(result.cardId);
+            return {
+                ...result,
+                isResponsePossible
+            };
+        });
+    }
+
+    private isResponsePossibleForCard(cardId: string): boolean {
         const card = OpfabStore.getLightCardStore().getLightCard(cardId);
         if (!card) {
             return false;
@@ -46,30 +58,45 @@ export class Responses {
         );
     }
 
-    public async sendResponse(buttonId: string, selectedCardIds: string[]): Promise<void> {
+    public async sendResponsesWhenUserClicksOnResponseButton(
+        buttonId: string,
+        responsesData: Map<string, unknown>
+    ): Promise<void> {
         const button = this.customScreenDefinition.responseButtons.find(
             (button: ResponseButton) => button.id === buttonId
         );
         if (button) {
-            const selectedCards = this.getCards(selectedCardIds);
-            const responses = button.getUserResponses(selectedCards);
-            if (responses?.responseCards) {
-                for (let index = 0; index < responses.responseCards.length; index++) {
-                    const response = responses.responseCards[index];
+            const selectedCards = this.getCards(responsesData);
+            const responses = button.getUserResponses(selectedCards, responsesData);
+            if (responses.valid) {
+                await this.sendResponseCards(responses, selectedCards);
+            } else {
+                AlertMessageService.sendAlertMessage(new Message(responses.errorMsg, MessageLevel.ERROR));
+            }
+        }
+    }
+
+    private async sendResponseCards(responses: any, selectedCards: Card[]) {
+        if (responses?.responseCards) {
+            for (const [index, response] of responses.responseCards.entries()) {
+                try {
                     await CardResponseService.sendResponse(selectedCards[index], response);
+                } catch (error) {
+                    AlertMessageService.sendAlertMessage(new Message(error.message, MessageLevel.ERROR));
                 }
             }
         }
     }
 
-    private getCards(selectedCardIds: string[]): Card[] {
+    private getCards(responsesData: Map<string, unknown>): Card[] {
         const cards: Card[] = [];
-        selectedCardIds.forEach((cardId) => {
-            const card = OpfabStore.getLightCardStore().getLightCard(cardId);
+        responsesData.forEach((_value, key) => {
+            const card = OpfabStore.getLightCardStore().getLightCard(key);
             if (card) {
                 cards.push(card);
             }
         });
+
         return cards;
     }
 }

--- a/ui/main/src/app/views/customCardList/ResultTable.spec.ts
+++ b/ui/main/src/app/views/customCardList/ResultTable.spec.ts
@@ -101,6 +101,11 @@ describe('CustomScreenView - ResultTable', () => {
                         field: 'coloredCircleTest',
                         headerName: 'circle',
                         fieldType: FieldType.COLORED_CIRCLE
+                    },
+                    {
+                        field: 'comment',
+                        headerName: 'Comment',
+                        fieldType: FieldType.INPUT
                     }
                 ]
             });
@@ -109,7 +114,8 @@ describe('CustomScreenView - ResultTable', () => {
                 {field: 'testField2', headerName: 'Start Date', type: 'dateAndTime', flex: 1},
                 {field: 'responses', headerName: 'Responses', type: 'responses', flex: 2},
                 {field: 'responseFromMyEntities', headerName: '', type: 'responseFromMyEntities'},
-                {field: 'coloredCircleTest', headerName: 'circle', type: 'coloredCircle', flex: undefined}
+                {field: 'coloredCircleTest', headerName: 'circle', type: 'coloredCircle', flex: undefined},
+                {field: 'comment', headerName: 'Comment', type: 'input', flex: undefined}
             ]);
         });
 

--- a/ui/main/src/app/views/customCardList/ResultTable.ts
+++ b/ui/main/src/app/views/customCardList/ResultTable.ts
@@ -98,6 +98,14 @@ export class ResultTable {
                             flex: column.flex
                         });
                         break;
+                    case FieldType.INPUT:
+                        agGridColumns.push({
+                            field: column.field,
+                            headerName: column.headerName,
+                            type: 'input',
+                            flex: column.flex
+                        });
+                        break;
                     default:
                         agGridColumns.push({
                             field: column.field,
@@ -283,6 +291,7 @@ export class ResultTable {
     }
 
     private getNestedField(obj: any, path: string): any {
+        if (!path) return '';
         return path.split('.').reduce((acc, part) => acc?.[part], obj);
     }
 

--- a/ui/main/src/scss/styles.scss
+++ b/ui/main/src/scss/styles.scss
@@ -21,8 +21,6 @@ p {
   margin-top: 0;
 }
 
-
-
 body {
     color: #bababa;
     padding: 80px 0 30px;


### PR DESCRIPTION
When the user send responses via a button define in the custom screen , it is now possible to add inputs via the use of a field type INPUT 

The inputs appears when the user select the row (if selectable)

To test : http://localhost:2002/#/customscreen/testId2 with operator1_fr

You can send a group of question card via the sendNcard.sh script :

Example : 
operatorfabric-core/src/test/resources/cardsForStressTests$ ./sendNCards.sh 5 defaultProcess/question.json


To be noted : 
- In the provided example , if the user click on the refuse button het must fill the comments otherwise there is an error message and the reponses are not sent
- A comment field to the question example has been added to be able to use it for custom screen (add some refactoring to do that)
- The input field is not display yet with opfab style (To be done in another issue)
- The comment field in the example does not contains the existing response (to be done in another issue) 




In release notes :
  -  In chapter : Features  
  -  Text : #7976 Custom card list screen : add the possibility to put user input in responses