### PR TITLE
Set chidlcard startDate to parent startDate, do not take into account the parent publish date (#7875)

### DIFF
--- a/services/cards-publication/src/main/java/org/opfab/cards/publication/services/CardProcessingService.java
+++ b/services/cards-publication/src/main/java/org/opfab/cards/publication/services/CardProcessingService.java
@@ -217,17 +217,13 @@ public class CardProcessingService {
             if (!shouldKeepChildCards(card)) {
                 deleteCards(childCards.get(), card.getPublishDate(), jwt);
             } else {
-                cardRepository.setChildCardDates(card.getId(), getChildStartDateFromParent(card),
+                cardRepository.setChildCardDates(card.getId(),card.getStartDate(),
                         getChildEndDateFromParent(card));
             }
         }
         return null;
     }
 
-
-    private Instant getChildStartDateFromParent(Card parent) {
-        return parent.getStartDate().isBefore(parent.getPublishDate()) ? parent.getStartDate() : parent.getPublishDate();
-    }
 
     private Instant getChildEndDateFromParent(Card parent) {
         if (parent.getEndDate() != null) {
@@ -251,7 +247,7 @@ public class CardProcessingService {
     private void processChildCard(Card card) {
         if (card.getParentCardId() != null) {
             Card parentCard = getExistingCard(card.getParentCardId(), false);
-            card.setStartDate(getChildStartDateFromParent(parentCard));
+            card.setStartDate(parentCard.getStartDate());
             card.setEndDate(getChildEndDateFromParent(parentCard));
         }
     }

--- a/services/cards-publication/src/test/java/org/opfab/cards/publication/services/CardProcessServiceShould.java
+++ b/services/cards-publication/src/test/java/org/opfab/cards/publication/services/CardProcessServiceShould.java
@@ -344,28 +344,10 @@ class CardProcessServiceShould {
                         cardProcessingService.processCard(card);
 
                         Assertions.assertThat(TestHelpers.checkCardCount(cardRepositoryMock, 2)).isTrue();
-                        Assertions.assertThat(childCard.getStartDate()).isEqualTo(card.getPublishDate());
+                        Assertions.assertThat(childCard.getStartDate()).isEqualTo(card.getStartDate());
                         Assertions.assertThat(childCard.getEndDate()).isEqualTo(card.getEndDate());
                 }
 
-                @Test
-                void GIVEN_a_child_card_WHEN_updating_parent_card_with_KEEP_CHILD_CARDS_action_and_startDate_before_publishDate_THEN_child_card_has_startDate_and_endDate_correctly_updated() {
-                        Assertions.assertThatCode(
-                                        () -> cardProcessingService.processUserCard(childCard,
-                                                        currentUserWithPerimeters,
-                                                        token))
-                                        .doesNotThrowAnyException();
-                        Assertions.assertThat(TestHelpers.checkCardCount(cardRepositoryMock, 2)).isTrue();
-
-                        card.setActions(List.of(CardActionEnum.KEEP_CHILD_CARDS));
-                        card.setStartDate(Instant.now().minus(1, ChronoUnit.DAYS));
-
-                        cardProcessingService.processCard(card);
-
-                        Assertions.assertThat(TestHelpers.checkCardCount(cardRepositoryMock, 2)).isTrue();
-                        Assertions.assertThat(childCard.getStartDate()).isEqualTo(card.getStartDate());
-                        Assertions.assertThat(childCard.getEndDate()).isEqualTo(card.getPublishDate());
-                }
         }
 
         @Test


### PR DESCRIPTION
… 

After analysis the use of publish date is not needed , it was suppose to cover edge cases with card requesting in the feed but in fact just setting the childcard startDate to the parent startDate is suffisant.

- In release notes :
  -  In chapter : Feature
  -  Text : #7875 Always set child card startDate to parent startDate
