### PR TITLE
Do not erase entity/group membership when updating an entity/group via API (#7997)

### DIFF
--- a/services/users/src/main/java/org/opfab/users/model/Entity.java
+++ b/services/users/src/main/java/org/opfab/users/model/Entity.java
@@ -1,4 +1,4 @@
-/* Copyright (c) 2018-2024, RTE (http://www.rte-france.com)
+/* Copyright (c) 2018-2025, RTE (http://www.rte-france.com)
  * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -142,12 +142,17 @@ public class Entity {
     }
 
     public List<String> getUsers() {
-        if (users == null)
-            return Collections.emptyList();
+        if (users == null) {
+            // we need to return null in case 'users' field is not in the post query, to differentiate with an empty
+            // array of users
+            return null;//NOSONAR
+        }
         return new ArrayList<>(users);
     }
 
     public void setUsers(List<String> users) {
-        this.users = new HashSet<>(users);
+        if (users != null) {
+            this.users = new HashSet<>(users);
+        }
     }
 }

--- a/services/users/src/main/java/org/opfab/users/model/Group.java
+++ b/services/users/src/main/java/org/opfab/users/model/Group.java
@@ -1,4 +1,4 @@
-/* Copyright (c) 2018-2024, RTE (http://www.rte-france.com)
+/* Copyright (c) 2018-2025, RTE (http://www.rte-france.com)
  * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -132,12 +132,17 @@ public class Group {
     }
 
     public List<String> getUsers() {
-        if (users == null)
-            return Collections.emptyList();
+        if (users == null) {
+            // we need to return null in case 'users' field is not in the post query, to differentiate with an empty
+            // array of users
+            return null;//NOSONAR
+        }
         return new ArrayList<>(users);
     }
 
     public void setUsers(List<String> users) {
-        this.users = new HashSet<>(users);
+        if (users != null) {
+            this.users = new HashSet<>(users);
+        }
     }
 }

--- a/services/users/src/main/java/org/opfab/users/services/EntitiesService.java
+++ b/services/users/src/main/java/org/opfab/users/services/EntitiesService.java
@@ -1,4 +1,4 @@
-/* Copyright (c) 2022-2024, RTE (http://www.rte-france.com)
+/* Copyright (c) 2022-2025, RTE (http://www.rte-france.com)
  * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -65,7 +65,11 @@ public class EntitiesService {
             }
             boolean isAlreadyExisting = entityRepository.findById(entity.getId()).isPresent();
             Entity newEntity = entityRepository.save(entity);
-            updateEntityUsers(newEntity.getId(), entity.getUsers());
+
+            if (entity.getUsers() != null) {
+                updateEntityUsers(newEntity.getId(), entity.getUsers());
+            }
+
             notificationService.publishUpdatedConfigMessage();
             EntityCreationReport<Entity> report = new EntityCreationReport<>(isAlreadyExisting, newEntity);
             return new OperationResult<>(report, true, null, null);

--- a/services/users/src/main/java/org/opfab/users/services/GroupsService.java
+++ b/services/users/src/main/java/org/opfab/users/services/GroupsService.java
@@ -1,4 +1,4 @@
-/* Copyright (c) 2022-2024, RTE (http://www.rte-france.com)
+/* Copyright (c) 2022-2025, RTE (http://www.rte-france.com)
  * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -71,7 +71,10 @@ public class GroupsService {
             if (foundPerimetersResult.isSuccess()) {
                 boolean isAlreadyExisting = groupRepository.findById(group.getId()).isPresent();
                 Group newGroup = groupRepository.save(group);
-                updateGroupUsers(newGroup.getId(), group.getUsers());
+
+                if (group.getUsers() != null) {
+                    updateGroupUsers(newGroup.getId(), group.getUsers());
+                }
                 notificationService.publishUpdatedGroupMessage(group.getId());
                 EntityCreationReport<Group> report = new EntityCreationReport<>(isAlreadyExisting, newGroup);
                 return new OperationResult<>(report, true, null, null);

--- a/services/users/src/test/java/org/opfab/users/services/EntitiesServiceShould.java
+++ b/services/users/src/test/java/org/opfab/users/services/EntitiesServiceShould.java
@@ -1,4 +1,4 @@
-/* Copyright (c) 2022-2024, RTE (http://www.rte-france.com)
+/* Copyright (c) 2022-2025, RTE (http://www.rte-france.com)
  * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -11,14 +11,7 @@ package org.opfab.users.services;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-import java.util.SortedSet;
-import java.util.TreeSet;
+import java.util.*;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -129,6 +122,55 @@ class EntitiesServiceShould {
             assertThat(result.getResult().getEntity().getId()).isEqualTo("entity1");
             assertThat(result.getResult().getEntity().getName()).isEqualTo("newEntityName");
             assertThat(entityRepositoryStub.findById("entity1").get().getName()).isEqualTo("newEntityName");
+        }
+
+        @Test
+        void GIVEN_A_Valid_Entity_WHEN_Create_An_Already_Existing_Entity_With_Users_Field_THEN_Entity_Is_Updated_And_Users_Are_Updated() {
+            Entity entity = new Entity("entity1", "newEntityName", null, null, null, null);
+            entity.setUsers(Arrays.asList("user2"));
+
+            OperationResult<EntityCreationReport<Entity>> result = entitiesService.createEntity(entity);
+            assertThat(result.isSuccess()).isTrue();
+            assertThat(result.getResult().isUpdate()).isTrue();
+            assertThat(result.getResult().getEntity().getId()).isEqualTo("entity1");
+            assertThat(result.getResult().getEntity().getUsers()).hasSize(1);
+            assertThat(result.getResult().getEntity().getUsers()).contains("user2");
+            assertThat(userRepositoryStub.findById("user1").get().getEntities()).hasSize(1);
+            assertThat(userRepositoryStub.findById("user1").get().getEntities()).contains("entity2");
+            assertThat(userRepositoryStub.findById("user2").get().getEntities()).hasSize(2);
+            assertThat(userRepositoryStub.findById("user2").get().getEntities()).contains("entity2", "entity1");
+        }
+
+        @Test
+        void GIVEN_A_Valid_Entity_WHEN_Create_An_Already_Existing_Entity_Without_Users_Field_THEN_Entity_Is_Updated_And_Users_Are_Not_Deleted() {
+            Entity entity = new Entity("entity1", "newEntityName", null, null, null, null);
+            entity.setUsers(null);
+
+            OperationResult<EntityCreationReport<Entity>> result = entitiesService.createEntity(entity);
+            assertThat(result.isSuccess()).isTrue();
+            assertThat(result.getResult().isUpdate()).isTrue();
+            assertThat(result.getResult().getEntity().getId()).isEqualTo("entity1");
+            assertThat(result.getResult().getEntity().getUsers()).isNull();
+            assertThat(userRepositoryStub.findById("user1").get().getEntities()).hasSize(2);
+            assertThat(userRepositoryStub.findById("user1").get().getEntities()).contains("entity1", "entity2");
+            assertThat(userRepositoryStub.findById("user2").get().getEntities()).hasSize(1);
+            assertThat(userRepositoryStub.findById("user2").get().getEntities()).contains("entity2");
+        }
+
+        @Test
+        void GIVEN_A_Valid_Entity_WHEN_Create_An_Already_Existing_Entity_With_Users_Field_Empty_THEN_Entity_Is_Updated_And_Users_Are_Empty() {
+            Entity entity = new Entity("entity1", "newEntityName", null, null, null, null);
+            entity.setUsers(Collections.emptyList());
+
+            OperationResult<EntityCreationReport<Entity>> result = entitiesService.createEntity(entity);
+            assertThat(result.isSuccess()).isTrue();
+            assertThat(result.getResult().isUpdate()).isTrue();
+            assertThat(result.getResult().getEntity().getId()).isEqualTo("entity1");
+            assertThat(result.getResult().getEntity().getUsers()).isEmpty();
+            assertThat(userRepositoryStub.findById("user1").get().getEntities()).hasSize(1);
+            assertThat(userRepositoryStub.findById("user1").get().getEntities()).contains("entity2");
+            assertThat(userRepositoryStub.findById("user2").get().getEntities()).hasSize(1);
+            assertThat(userRepositoryStub.findById("user2").get().getEntities()).contains("entity2");
         }
 
         @Test


### PR DESCRIPTION
- In release notes :
  -  In chapter : Features
  -  Text : #7997 : Do not erase entity/group membership when updating an entity/group via API