### PR TITLE
Conference template example does not work (#8268)

### DIFF
--- a/src/test/resources/bundles/conferenceAndITIncidentExample/template/conference.handlebars
+++ b/src/test/resources/bundles/conferenceAndITIncidentExample/template/conference.handlebars
@@ -1,4 +1,4 @@
-<!-- Copyright (c) 2020, RTE (http://www.rte-france.com)              -->
+<!-- Copyright (c) 2020-2025, RTE (http://www.rte-france.com)              -->
 <!-- See AUTHORS.txt                                                       -->
 <!-- This Source Code Form is subject to the terms of the Mozilla Public   -->
 <!-- License, v. 2.0. If a copy of the MPL was not distributed with this   -->
@@ -9,7 +9,7 @@
 <br/>
 <br/>
 
-<h2>  You are invited to a conference call at {{dateFormat  card.startDate format="MMMM Do YYYY, h:mm: a"}}</h2>
+<h2>  You are invited to a conference call on {{dateFormat  card.startDate format="dd/MM/yyyy, hh:mm"}}</h2>
 <br/>
 <br/>
 


### PR DESCRIPTION
- In release notes :
  -  In chapter : Bugs
  -  Text : #8268 : Conference template example does not work