### PR TITLE
Solve issue : show spinner in card content when processInstanceId contains a space (#8356)

### DIFF
--- a/ui/main/src/app/services/navigation/NavigationService.ts
+++ b/ui/main/src/app/services/navigation/NavigationService.ts
@@ -91,7 +91,7 @@ export class NavigationService {
     }
 
     public static navigateToCard(cardId: string) {
-        NavigationService.navigateTo('/feed/cards/' + encodeURIComponent(cardId));
+        NavigationService.navigateTo('/feed/cards/' + cardId);
     }
 
     public static navigateToFeedWithProcessStateFilter(processFilter: string, stateFilter: string) {


### PR DESCRIPTION
Will be in release notz for version patch 4.7.1 