### PR TITLE
Authorize special characters in processInstanceId (#8361)

### DIFF
--- a/node-services/cards-external-diffusion/src/domain/application/cardsDiffusionControl.ts
+++ b/node-services/cards-external-diffusion/src/domain/application/cardsDiffusionControl.ts
@@ -93,6 +93,16 @@ export default class CardsDiffusionControl {
         }
     }
 
+    protected base64urlEncode(str: string) {
+        const base64 = btoa(str);
+        // Replace '+' with '-', '/' with '_' and remove trailing '=' to convert base64 to base64url
+        let base64url = base64.replace(/\+/g, '-').replace(/\//g, '_');
+        while (base64url.endsWith('=')) {
+            base64url = base64url.slice(0, base64url.length - 1);
+        }
+        return base64url;
+    }
+
     protected escapeHtml(text: string | undefined): string {
         if (text == null) return '';
         return text

--- a/node-services/cards-external-diffusion/src/domain/application/realTimeCardsDiffusionControl.ts
+++ b/node-services/cards-external-diffusion/src/domain/application/realTimeCardsDiffusionControl.ts
@@ -223,7 +223,7 @@ export default class RealTimeCardsDiffusionControl extends CardsDiffusionControl
             ' <a href=" ' +
             this.opfabUrlInMailContent +
             '/#/feed/cards/' +
-            card.id +
+            this.base64urlEncode(card.id) +
             ' ">' +
             this.escapeHtml(card.titleTranslated) +
             ' - ' +
@@ -263,16 +263,6 @@ export default class RealTimeCardsDiffusionControl extends CardsDiffusionControl
             this.logger.warn(`Couldn't parse email for : ${card.state}, `, e);
         }
         return cardBodyHtml;
-    }
-
-    escapeHtml(text: string | undefined): string {
-        if (text == null) return '';
-        return text
-            .replace(/&/g, '&amp;')
-            .replace(/</g, '&lt;')
-            .replace(/>/g, '&gt;')
-            .replace(/"/g, '&quot;')
-            .replace(/'/g, '&#39;');
     }
 
     async cleanCardsAlreadySent(): Promise<void> {

--- a/node-services/cards-external-diffusion/src/domain/application/recapCardsDiffusionControl.ts
+++ b/node-services/cards-external-diffusion/src/domain/application/recapCardsDiffusionControl.ts
@@ -1,4 +1,4 @@
-/* Copyright (c) 2024, RTE (http://www.rte-france.com)
+/* Copyright (c) 2024-2025, RTE (http://www.rte-france.com)
  * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -153,7 +153,7 @@ export default class RecapCardsDiffusionControl extends CardsDiffusionControl {
                 '<a href=" ' +
                 this.opfabUrlInMailContent +
                 '/#/feed/cards/' +
-                card.id +
+                this.base64urlEncode(card.id) +
                 ' ">' +
                 this.escapeHtml(card.titleTranslated) +
                 ' - ' +

--- a/node-services/cards-external-diffusion/src/tests/realTimeCardsDiffusionControl.test.ts
+++ b/node-services/cards-external-diffusion/src/tests/realTimeCardsDiffusionControl.test.ts
@@ -22,6 +22,9 @@ import {
 
 const logger = getLogger();
 
+// URL BASE 64 encoding of "defaultProcess.process1"
+const BASE64URL_ENCODED_CARDID = 'ZGVmYXVsdFByb2Nlc3MucHJvY2VzczE';
+
 describe('Cards external diffusion', function () {
     let realTimeCardsDiffusionControl: RealTimeCardsDiffusionControl;
     let opfabServicesInterfaceStub: OpfabServicesInterfaceStub;
@@ -101,7 +104,7 @@ describe('Cards external diffusion', function () {
         expect(mailService.sent[0].fromAddress).toEqual('test@opfab.com');
         expect(mailService.sent[0].toAddress).toEqual('operator_2@opfab.com');
         expect(mailService.sent[0].body).toEqual(
-            'Prefix <a href=" http://localhost/#/feed/cards/defaultProcess.process1 ">Title1 - Summary1 - ' +
+            `Prefix <a href=" http://localhost/#/feed/cards/${BASE64URL_ENCODED_CARDID} ">Title1 - Summary1 - ` +
                 startDateString +
                 ' - </a> <br><br>Postfix'
         );
@@ -158,7 +161,7 @@ describe('Cards external diffusion', function () {
         expect(mailService.sent[0].fromAddress).toEqual('test@opfab.com');
         expect(mailService.sent[0].toAddress).toEqual('operator_1@opfab.com');
         expect(mailService.sent[0].body).toEqual(
-            'Prefix <a href=" http://localhost/#/feed/cards/defaultProcess.process1 ">Title1 - Summary1 - ' +
+            `Prefix <a href=" http://localhost/#/feed/cards/${BASE64URL_ENCODED_CARDID} ">Title1 - Summary1 - ` +
                 startDateString +
                 ' - ' +
                 '</a> <br> Title1 Param1 <br><br>Postfix'
@@ -269,7 +272,7 @@ describe('Cards external diffusion', function () {
 
         expect(mailService.numberOfMailsSent).toEqual(1);
         expect(mailService.sent[0].body).toEqual(
-            'Prefix <a href=" http://localhost/#/feed/cards/defaultProcess.process1 ">Title1 &amp; &lt;br&gt; - &quot; Summary1 &lt;br&gt; - ' +
+            `Prefix <a href=" http://localhost/#/feed/cards/${BASE64URL_ENCODED_CARDID} ">Title1 &amp; &lt;br&gt; - &quot; Summary1 &lt;br&gt; - ` +
                 startDateString +
                 ' - ' +
                 '</a> <br> Title1 &amp; &lt;br&gt; <br><br>Sent by ENTITY2 name. <br><br>Postfix'
@@ -325,7 +328,7 @@ describe('Cards external diffusion', function () {
 
         expect(mailService.numberOfMailsSent).toEqual(1);
         expect(mailService.sent[0].body).toEqual(
-            'Prefix <a href=" http://localhost/#/feed/cards/defaultProcess.process1 ">Title1 &amp; &lt;br&gt; - &quot; ' +
+            `Prefix <a href=" http://localhost/#/feed/cards/${BASE64URL_ENCODED_CARDID} ">Title1 &amp; &lt;br&gt; - &quot; ` +
                 'Summary1 &lt;br&gt; - ' +
                 startDateString +
                 ' - </a> <br> Title1 &amp; &lt;br&gt; <br><br>Postfix'

--- a/node-services/cards-external-diffusion/src/tests/recapCardsDiffusionControl.test.ts
+++ b/node-services/cards-external-diffusion/src/tests/recapCardsDiffusionControl.test.ts
@@ -1,4 +1,4 @@
-/* Copyright (c) 2024, RTE (http://www.rte-france.com)
+/* Copyright (c) 2024-2025, RTE (http://www.rte-france.com)
  * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -19,6 +19,11 @@ import {
 
 const MILLISECONDS_IN_A_DAY = 24 * 60 * 60 * 1000;
 const MILLISECONDS_IN_A_WEEK = 7 * MILLISECONDS_IN_A_DAY;
+
+// URL BASE 64 encoding of "defaultProcess.process1"
+const BASE64URL_ENCODED_CARDID_FOR_PROCESS1 = 'ZGVmYXVsdFByb2Nlc3MucHJvY2VzczE';
+// URL BASE 64 encoding of "defaultProcess.process2"
+const BASE64URL_ENCODED_CARDID_FOR_PROCESS2 = 'ZGVmYXVsdFByb2Nlc3MucHJvY2VzczI';
 
 const logger = getLogger();
 
@@ -208,10 +213,10 @@ describe('Cards external diffusion', function () {
         expect(mailService.sent[0].toAddress).toEqual('operator_2@opfab.com');
         expect(mailService.sent[0].body).toMatch(`Daily Email Body Prefix`);
         expect(mailService.sent[0].body).toMatch(
-            `INFORMATION - <a href=" http://localhost/#/feed/cards/defaultProcess.process1 ">Title1 - Summary1</a>`
+            `INFORMATION - <a href=" http://localhost/#/feed/cards/${BASE64URL_ENCODED_CARDID_FOR_PROCESS1} ">Title1 - Summary1</a>`
         );
         expect(mailService.sent[0].body).toMatch(
-            `ALARM - <a href=" http://localhost/#/feed/cards/defaultProcess.process2 ">Title1 - Summary1</a>`
+            `ALARM - <a href=" http://localhost/#/feed/cards/${BASE64URL_ENCODED_CARDID_FOR_PROCESS2} ">Title1 - Summary1</a>`
         );
         expect(mailService.sent[0].body).toMatch(`Email Body Postfix`);
     });

--- a/services/cards-consultation/src/main/java/org/opfab/cards/consultation/configuration/webflux/WebSecurityConfiguration.java
+++ b/services/cards-consultation/src/main/java/org/opfab/cards/consultation/configuration/webflux/WebSecurityConfiguration.java
@@ -1,4 +1,4 @@
-/* Copyright (c) 2018-2024, RTE (http://www.rte-france.com)
+/* Copyright (c) 2018-2025, RTE (http://www.rte-france.com)
  * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -6,8 +6,6 @@
  * SPDX-License-Identifier: MPL-2.0
  * This file is part of the OperatorFabric project.
  */
-
-
 
 package org.opfab.cards.consultation.configuration.webflux;
 
@@ -20,11 +18,11 @@ import org.springframework.security.config.annotation.web.reactive.EnableWebFlux
 import org.springframework.security.config.web.server.ServerHttpSecurity;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.web.server.SecurityWebFilterChain;
+import org.springframework.security.web.server.firewall.StrictServerWebExchangeFirewall;
 import org.opfab.springtools.configuration.oauth.CustomAccessDeniedHandler;
 import org.opfab.springtools.configuration.oauth.CustomAuthenticationEntryPoint;
 
 import reactor.core.publisher.Mono;
-
 
 @Configuration
 @EnableWebFluxSecurity
@@ -36,7 +34,6 @@ public class WebSecurityConfiguration {
     public static final String CONNECTIONS_PATH = "/connections**";
     public static final String MESSAGE_TO_SUBSCRIPTIONS = "/messageToSubscriptions";
     public static final String ADMIN_ROLE = "ADMIN";
-
 
     /**
      * Secures access (all uris are secured)
@@ -51,8 +48,8 @@ public class WebSecurityConfiguration {
         configureCommon(http);
         http
                 .oauth2ResourceServer(oauth2ResourceServer -> oauth2ResourceServer
-                    .jwt(jwt -> jwt
-                        .jwtAuthenticationConverter(opfabReactiveJwtConverter))
+                        .jwt(jwt -> jwt
+                                .jwtAuthenticationConverter(opfabReactiveJwtConverter))
                         .authenticationEntryPoint(new CustomAuthenticationEntryPoint()));
 
         return http.build();
@@ -65,19 +62,27 @@ public class WebSecurityConfiguration {
     public static void configureCommon(final ServerHttpSecurity http) {
         http
                 .headers(headers -> headers
-                    .frameOptions(ServerHttpSecurity.HeaderSpec.FrameOptionsSpec::disable
-                    )
-                )
+                        .frameOptions(ServerHttpSecurity.HeaderSpec.FrameOptionsSpec::disable))
                 .exceptionHandling(exceptionHandling -> exceptionHandling
-                    .accessDeniedHandler(new CustomAccessDeniedHandler())
-                    .authenticationEntryPoint(new CustomAuthenticationEntryPoint()))
+                        .accessDeniedHandler(new CustomAccessDeniedHandler())
+                        .authenticationEntryPoint(new CustomAuthenticationEntryPoint()))
                 .authorizeExchange(authorizeExchange -> authorizeExchange
-                    .pathMatchers(HttpMethod.GET, PROMETHEUS_PATH).permitAll()
-                    .pathMatchers(HttpMethod.GET, CONNECTIONS).authenticated()
-                    .pathMatchers(CONNECTIONS_PATH).hasRole(ADMIN_ROLE)
-                    .pathMatchers(LOGGERS_PATH).hasRole(ADMIN_ROLE)
-                    .pathMatchers(MESSAGE_TO_SUBSCRIPTIONS).hasRole(ADMIN_ROLE)
-                    .anyExchange().authenticated()
-                );
+                        .pathMatchers(HttpMethod.GET, PROMETHEUS_PATH).permitAll()
+                        .pathMatchers(HttpMethod.GET, CONNECTIONS).authenticated()
+                        .pathMatchers(CONNECTIONS_PATH).hasRole(ADMIN_ROLE)
+                        .pathMatchers(LOGGERS_PATH).hasRole(ADMIN_ROLE)
+                        .pathMatchers(MESSAGE_TO_SUBSCRIPTIONS).hasRole(ADMIN_ROLE)
+                        .anyExchange().authenticated());
     }
+
+    @Bean
+    public StrictServerWebExchangeFirewall httpFirewall() {
+        StrictServerWebExchangeFirewall firewall = new StrictServerWebExchangeFirewall();
+        // The two following lines are necessary because we can get a card with its
+        // id in the url and the id may contain special characters
+        firewall.setAllowUrlEncodedPercent(true);
+        firewall.setAllowBackSlash(true);
+        return firewall;
+    }
+
 }

--- a/services/cards-publication/src/main/java/org/opfab/cards/publication/configuration/SecurityFilterConfiguration.java
+++ b/services/cards-publication/src/main/java/org/opfab/cards/publication/configuration/SecurityFilterConfiguration.java
@@ -1,4 +1,4 @@
-/* Copyright (c) 2023-2024, RTE (http://www.rte-france.com)
+/* Copyright (c) 2023-2025, RTE (http://www.rte-france.com)
  * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -21,8 +21,12 @@ public class SecurityFilterConfiguration {
         StrictHttpFirewall firewall = new StrictHttpFirewall();
         // It is necessary to allow semi-colons because ids in url may contain some
         firewall.setAllowSemicolon(true);
+
+        // The two following lines are necessary because we can delete a card with its
+        // id in the url and the id may contain special characters
+        firewall.setAllowUrlEncodedPercent(true);
+        firewall.setAllowBackSlash(true);
         return firewall;
     }
 
 }
-

--- a/services/cards-publication/src/main/java/org/opfab/cards/publication/services/CardValidationService.java
+++ b/services/cards-publication/src/main/java/org/opfab/cards/publication/services/CardValidationService.java
@@ -99,11 +99,15 @@ public class CardValidationService {
             throw new ConstraintViolationException(
                     "constraint violation : character '.' is forbidden in process and state", null);
 
-        // constraint check : process and processInstanceId must not contain
+        // constraint check process must not contain
         // ('#','?','/')
-        if (!checkForbiddenChars(c))
+        if (!checkForbiddenCharsInProcess(c))
             throw new ConstraintViolationException(
-                    "constraint violation : forbidden characters ('#','?','/') in process or processInstanceId", null);
+                    "constraint violation : forbidden characters ('#','?','/') in process", null);
+
+        if (checkSlashInProcessInstanceId(c))
+            throw new ConstraintViolationException(
+                    "constraint violation : forbidden characters '/' in processInstanceId", null);
     }
 
     void checkIsCardAChildCard(Card card) {
@@ -141,13 +145,16 @@ public class CardValidationService {
                 (!cardRepository.findArchivedCardByUid(initialParentCardUid).isPresent()));
     }
 
-    boolean checkForbiddenChars(Card card) {
+    boolean checkForbiddenCharsInProcess(Card card) {
         for (char ch : FORBIDDEN_CHARS) {
-            if (card.process.contains(Character.toString(ch))
-                    || card.processInstanceId.contains(Character.toString(ch)))
+            if (card.process.contains(Character.toString(ch)))
                 return false;
         }
         return true;
+    }
+
+    boolean checkSlashInProcessInstanceId(Card card) {
+        return card.processInstanceId.contains("/");
     }
 
     boolean checkIsDotCharacterNotInProcessAndState(Card c) {

--- a/services/cards-publication/src/test/java/org/opfab/cards/publication/services/CardProcessServiceShould.java
+++ b/services/cards-publication/src/test/java/org/opfab/cards/publication/services/CardProcessServiceShould.java
@@ -362,28 +362,14 @@ class CardProcessServiceShould {
     }
 
     @Test
-    void GIVEN_a_card_with_forbidden_characters_in_processInstanceId_WHEN_sending_card_THEN_card_is_rejected() {
+    void GIVEN_a_card_with_slash_in_processInstanceId_WHEN_sending_card_THEN_card_is_rejected() {
         Card card = TestHelpers.generateOneCard("entity2");
-        card.processInstanceId = "processinstance" + "#123";
+        card.processInstanceId = "processinstance/123";
 
         Assertions.assertThatThrownBy(() -> cardProcessingService.processCard(card))
                 .isInstanceOf(ConstraintViolationException.class)
                 .hasMessage(
-                        "constraint violation : forbidden characters ('#','?','/') in process or processInstanceId");
-
-        card.processInstanceId = "processinstance" + "?123";
-
-        Assertions.assertThatThrownBy(() -> cardProcessingService.processCard(card))
-                .isInstanceOf(ConstraintViolationException.class)
-                .hasMessage(
-                        "constraint violation : forbidden characters ('#','?','/') in process or processInstanceId");
-
-        card.processInstanceId = "processinstance" + "/123";
-
-        Assertions.assertThatThrownBy(() -> cardProcessingService.processCard(card))
-                .isInstanceOf(ConstraintViolationException.class)
-                .hasMessage(
-                        "constraint violation : forbidden characters ('#','?','/') in process or processInstanceId");
+                        "constraint violation : forbidden characters '/' in processInstanceId");
 
         Assertions.assertThat(TestHelpers.checkCardCount(cardRepositoryMock, 0)).isTrue();
         Assertions.assertThat(checkArchiveCount(0)).isTrue();
@@ -397,21 +383,21 @@ class CardProcessServiceShould {
         Assertions.assertThatThrownBy(() -> cardProcessingService.processCard(card))
                 .isInstanceOf(ConstraintViolationException.class)
                 .hasMessage(
-                        "constraint violation : forbidden characters ('#','?','/') in process or processInstanceId");
+                        "constraint violation : forbidden characters ('#','?','/') in process");
 
         card.process = "process" + "?123";
 
         Assertions.assertThatThrownBy(() -> cardProcessingService.processCard(card))
                 .isInstanceOf(ConstraintViolationException.class)
                 .hasMessage(
-                        "constraint violation : forbidden characters ('#','?','/') in process or processInstanceId");
+                        "constraint violation : forbidden characters ('#','?','/') in process");
 
         card.process = "process" + "/123";
 
         Assertions.assertThatThrownBy(() -> cardProcessingService.processCard(card))
                 .isInstanceOf(ConstraintViolationException.class)
                 .hasMessage(
-                        "constraint violation : forbidden characters ('#','?','/') in process or processInstanceId");
+                        "constraint violation : forbidden characters ('#','?','/') in process");
 
         Assertions.assertThat(TestHelpers.checkCardCount(cardRepositoryMock, 0)).isTrue();
         Assertions.assertThat(checkArchiveCount(0)).isTrue();

--- a/src/docs/asciidoc/reference_doc/card_structure.adoc
+++ b/src/docs/asciidoc/reference_doc/card_structure.adoc
@@ -29,6 +29,9 @@ The publisher field bears the identifier of the emitter of the card, be it an en
 This field indicates which process the card is attached to. This information is used to resolve the presentation
 resources (bundle) used to render the card and card details.
 
+[WARNING]
+The use of '/','#' or '?' in process field is forbidden.
+
 [[card_process_version]]
 ==== Process Version (`processVersion`)
 The rendering of cards of a given process can evolve over time. To allow for this while making sure previous cards
@@ -39,6 +42,9 @@ The `processVersion` field indicate which version of the process should be used 
 ==== Process Instance Identifier (`processInstanceId`)
 A card is associated to a given process, which defines how it is rendered, but it is also more precisely associated to
 a *specific instance* of this process. The `processInstanceId` field contains the unique identifier of the process instance.
+
+[WARNING]
+The use of '/' in the processInstanceId field is forbidden.
 
 ==== State in the process (`state`)
 The card represents a specific state in the process. In addition to the process, this information is used to resolve the presentation
@@ -215,10 +221,6 @@ Determines where custom information is store. The content in this attribute, is 
 This content, as long as it's in `json` format can be used to display details. For the way the details are
 displayed, see below.
 
-
-[WARNING]
-You must not use dot in json field names. In this case, the card will be refused with following message :
-"Error, unable to handle pushed Cards: Map key xxx.xxx contains dots but no replacement was configured!""
 
 == Presentation Information of the card
 

--- a/src/test/api/karate/cards-external-diffusion/cardsExternalDiffusion.feature
+++ b/src/test/api/karate/cards-external-diffusion/cardsExternalDiffusion.feature
@@ -198,7 +198,8 @@ Scenario: Check mail for operator 1 is sent
     And match response.items[0].Content.Headers.Content-Type[0] == 'text/html; charset=utf-8'
     And match response.items[0].Content.Headers.Subject[0].indexOf('Opfab card received  - card Title - card summary') == 0
     And match response.items[0].Content.Body contains 'A MESSAGE'
-    And match response.items[0].Content.Body contains '/api_test.process1'
+    # api_test.process1 is in urlbase64 : YXBpX3Rlc3QucHJvY2VzczE
+    And match response.items[0].Content.Body contains 'YXBpX3Rlc3QucHJvY2VzczE' 
 
     # Delete sent email
     Given url 'http://localhost:8025/api/v1/messages'
@@ -287,7 +288,8 @@ Scenario: Check daily recap email is being sent
     And match response.items[0].To[0].Domain == 'opfab.com'
     And match response.items[0].Content.Headers.Content-Type[0] == 'text/html; charset=utf-8'
     And match response.items[0].Content.Headers.Subject[0].indexOf('Cards received during the day') == 0
-    And match response.items[0].Content.Body contains 'api_test.process1'
+    # api_test.process1 is in urlbase64 : YXBpX3Rlc3QucHJvY2VzczE
+    And match response.items[0].Content.Body contains 'YXBpX3Rlc3QucHJvY2VzczE'
 
     # Delete sent email
     Given url 'http://localhost:8025/api/v1/messages'
@@ -314,7 +316,8 @@ Scenario: Check weekly recap email is being sent
     And match response.items[0].To[0].Domain == 'opfab.com'
     And match response.items[0].Content.Headers.Content-Type[0] == 'text/html; charset=utf-8'
     And match response.items[0].Content.Headers.Subject[0].indexOf('Cards received during the week') == 0
-    And match response.items[0].Content.Body contains 'api_test.process1'
+    # api_test.process1 is in urlbase64 : YXBpX3Rlc3QucHJvY2VzczE
+    And match response.items[0].Content.Body contains 'YXBpX3Rlc3QucHJvY2VzczE'
 
     # Delete sent email
     Given url 'http://localhost:8025/api/v1/messages'

--- a/src/test/cypress/cypress/integration/Acknowledgment.spec.js
+++ b/src/test/cypress/cypress/integration/Acknowledgment.spec.js
@@ -7,14 +7,14 @@
  * This file is part of the OperatorFabric project.
  */
 
-import {UserCardCommands} from '../support/userCardCommands';
-import {OpfabGeneralCommands} from '../support/opfabGeneralCommands';
-import {ActivityAreaCommands} from '../support/activityAreaCommands';
-import {FeedCommands} from '../support/feedCommands';
-import {ScriptCommands} from '../support/scriptCommands';
-import {CardCommands} from '../support/cardCommands';
+import { UserCardCommands } from '../support/userCardCommands';
+import { OpfabGeneralCommands } from '../support/opfabGeneralCommands';
+import { ActivityAreaCommands } from '../support/activityAreaCommands';
+import { FeedCommands } from '../support/feedCommands';
+import { ScriptCommands } from '../support/scriptCommands';
+import { CardCommands } from '../support/cardCommands';
 
-describe('Acknowledgment tests', function () {
+describe('Acknowledgment tests', function() {
     const usercard = new UserCardCommands();
     const opfab = new OpfabGeneralCommands();
     const activityArea = new ActivityAreaCommands();
@@ -22,7 +22,7 @@ describe('Acknowledgment tests', function () {
     const script = new ScriptCommands();
     const card = new CardCommands();
 
-    before('Set up configuration', function () {
+    before('Set up configuration', function() {
         // This can stay in a `before` block rather than `beforeEach` as long as the test does not change configuration
         script.resetUIConfigurationFiles();
         script.deleteAllSettings();
@@ -58,7 +58,7 @@ describe('Acknowledgment tests', function () {
         script.sendCard('cypress/ack/message6.json');
     });
 
-    it('Check acknowledgment for operator 1', function () {
+    it('Check acknowledgment for operator 1', function() {
         opfab.loginWithUser('operator1_fr');
 
         // Wait for all cards to be loaded (check the last one is present)
@@ -158,7 +158,7 @@ describe('Acknowledgment tests', function () {
         cy.get('#opfab-feed-light-card-cypress-message4 .fa-check').should('not.exist');
     });
 
-    it('Check acknowledgment for operator 1 after re-logging  ', function () {
+    it('Check acknowledgment for operator 1 after re-logging  ', function() {
         opfab.loginWithUser('operator1_fr');
 
         // Set feed filter to see all card
@@ -171,7 +171,7 @@ describe('Acknowledgment tests', function () {
         cy.get('#opfab-feed-light-card-cypress-message4 .fa-check').should('not.exist');
     });
 
-    it('Check no acknowledgment for operator 2  ', function () {
+    it('Check no acknowledgment for operator 2  ', function() {
         opfab.loginWithUser('operator2_fr');
 
         // Set feed filter to see all card
@@ -181,7 +181,7 @@ describe('Acknowledgment tests', function () {
         cy.get('.fa-check').should('not.exist');
     });
 
-    it('Check cancel ack not possible when cancelAcknowledgmentAllowed is false', function () {
+    it('Check cancel ack not possible when cancelAcknowledgmentAllowed is false', function() {
         opfab.loginWithUser('operator1_fr');
 
         // Set feed filter to see all card
@@ -198,7 +198,7 @@ describe('Acknowledgment tests', function () {
         cy.get('#opfab-card-details-btn-unack').should('contain.text', 'CANCEL ACKNOWLEDGMENT');
     });
 
-    it('Check entities acknowledgments for a usercard created by operator1_fr', function () {
+    it('Check entities acknowledgments for a usercard created by operator1_fr', function() {
         // Clean up existing cards
         script.deleteAllCards();
         script.send6TestCards();
@@ -318,7 +318,7 @@ describe('Acknowledgment tests', function () {
         cy.get('#opfab-not-acknowledged-list').find('span').should('have.length', 12);
     });
 
-    it('operator4_fr (member of 4 FR entities) acknowledges the previous card created by operator1_fr ', function () {
+    it('operator4_fr (member of 4 FR entities) acknowledges the previous card created by operator1_fr ', function() {
         opfab.loginWithUser('operator4_fr');
 
         cy.get('of-light-card').should('have.length', 7);
@@ -557,7 +557,7 @@ describe('Acknowledgment tests', function () {
         activityArea.save();
     });
 
-    it('Check operator1_fr see the entities acknowledgments done by operator4_fr for the previous card', function () {
+    it('Check operator1_fr see the entities acknowledgments done by operator4_fr for the previous card', function() {
         opfab.loginWithUser('operator1_fr');
 
         feed.sortByReceptionDate();
@@ -642,7 +642,7 @@ describe('Acknowledgment tests', function () {
             .and('have.css', 'color', 'rgb(255, 102, 0)');
     });
 
-    it('Check acknowledgements are received also in real-time', function () {
+    it('Check acknowledgements are received also in real-time', function() {
         script.sendCard('cypress/entitiesAcks/message1.json');
 
         opfab.loginWithUser('operator4_fr');
@@ -702,7 +702,7 @@ describe('Acknowledgment tests', function () {
         });
     });
 
-    it('Check spinner is displayed when ack/unack request is delayed and that spinner disappears once the request arrived ', function () {
+    it('Check spinner is displayed when ack/unack request is delayed and that spinner disappears once the request arrived ', function() {
         script.deleteAllCards();
 
         opfab.loginWithUser('operator1_fr');
@@ -735,7 +735,7 @@ describe('Acknowledgment tests', function () {
         opfab.checkLoadingSpinnerIsNotDisplayed();
     });
 
-    it('Check pinned card', function () {
+    it('Check pinned card', function() {
         script.deleteAllCards();
         // Send card with automaticPinWhenAcknowledged = true
         script.sendCard('defaultProcess/contingencies.json');
@@ -752,7 +752,7 @@ describe('Acknowledgment tests', function () {
             .invoke('attr', 'data-urlId')
             .then((urlId) => {
                 cy.waitDefaultTime();
-                cy.hash().should('eq', '#/feed/cards/' + urlId);
+                cy.hash().should('eq', '#/feed/cards/' + opfab.base64urlEncode(urlId));
                 card.acknowledge();
                 //The card is pinned
                 cy.get('#of-pinned-cards').find('.opfab-pinned-card').should('have.length', 1);
@@ -788,7 +788,7 @@ describe('Acknowledgment tests', function () {
             .invoke('attr', 'data-urlId')
             .then((urlId) => {
                 cy.waitDefaultTime();
-                cy.hash().should('eq', '#/feed/cards/' + urlId);
+                cy.hash().should('eq', '#/feed/cards/' + opfab.base64urlEncode(urlId));
                 card.acknowledge();
                 //The card is pinned
                 cy.get('#of-pinned-cards').find('.opfab-pinned-card').should('have.length', 1);
@@ -803,7 +803,7 @@ describe('Acknowledgment tests', function () {
         cy.get('#of-pinned-cards').find('.opfab-pinned-card').should('have.length', 0);
     });
 
-    it('Check pinned card is removed after end date', function () {
+    it('Check pinned card is removed after end date', function() {
         const SECONDS = 1000;
         const MINUTES = 60000;
         const HOURS = 3600000;
@@ -853,15 +853,15 @@ describe('Acknowledgment tests', function () {
         cy.get('#of-pinned-cards').find('.opfab-pinned-card').should('have.length', 0);
     });
 
-    it('Check when many pinned cards', function () {
+    it('Check when many pinned cards', function() {
         script.deleteAllCards();
         // Send 6 card with automaticPinWhenAcknowledged = true
-        script.sendCard('cypress/ack/pinned.json', {processInstanceId: 'pinned1'});
-        script.sendCard('cypress/ack/pinned.json', {processInstanceId: 'pinned2'});
-        script.sendCard('cypress/ack/pinned.json', {processInstanceId: 'pinned3'});
-        script.sendCard('cypress/ack/pinned.json', {processInstanceId: 'pinned4'});
-        script.sendCard('cypress/ack/pinned.json', {processInstanceId: 'pinned5'});
-        script.sendCard('cypress/ack/pinned.json', {processInstanceId: 'pinned6'});
+        script.sendCard('cypress/ack/pinned.json', { processInstanceId: 'pinned1' });
+        script.sendCard('cypress/ack/pinned.json', { processInstanceId: 'pinned2' });
+        script.sendCard('cypress/ack/pinned.json', { processInstanceId: 'pinned3' });
+        script.sendCard('cypress/ack/pinned.json', { processInstanceId: 'pinned4' });
+        script.sendCard('cypress/ack/pinned.json', { processInstanceId: 'pinned5' });
+        script.sendCard('cypress/ack/pinned.json', { processInstanceId: 'pinned6' });
 
         opfab.loginWithUser('operator1_fr');
 
@@ -876,7 +876,7 @@ describe('Acknowledgment tests', function () {
         //There are 6 pinned cards
         cy.get('#of-pinned-cards').find('.opfab-pinned-card').should('have.length', 6);
 
-        script.sendCard('cypress/ack/pinned.json', {processInstanceId: 'pinned7'});
+        script.sendCard('cypress/ack/pinned.json', { processInstanceId: 'pinned7' });
 
         // Open and ack the new card
         cy.get('of-light-card')
@@ -886,7 +886,7 @@ describe('Acknowledgment tests', function () {
             .invoke('attr', 'data-urlId')
             .then((urlId) => {
                 cy.waitDefaultTime();
-                cy.hash().should('eq', '#/feed/cards/' + urlId);
+                cy.hash().should('eq', '#/feed/cards/' + opfab.base64urlEncode(urlId));
                 card.acknowledge();
                 //The are still 6 pinned cards visible plus "..." popover
                 cy.get('#of-pinned-cards').find('.opfab-pinned-card').should('have.length', 6);
@@ -906,7 +906,7 @@ describe('Acknowledgment tests', function () {
             });
     });
 
-    it('Check display of acknowledgments footer for parameter "showAcknowledgmentFooter" set to "OnlyForEmittingEntity"', function () {
+    it('Check display of acknowledgments footer for parameter "showAcknowledgmentFooter" set to "OnlyForEmittingEntity"', function() {
         // Clean up existing cards
         script.deleteAllCards();
         opfab.loginWithUser('operator1_fr');
@@ -958,7 +958,7 @@ describe('Acknowledgment tests', function () {
         cy.get('#opfab-card-acknowledged-footer').should('not.exist');
     });
 
-    it('Check display of acknowledgments footer for parameter "showAcknowledgmentFooter" set to "Never"', function () {
+    it('Check display of acknowledgments footer for parameter "showAcknowledgmentFooter" set to "Never"', function() {
         // Clean up existing cards
         script.deleteAllCards();
         opfab.loginWithUser('operator1_fr');
@@ -983,7 +983,7 @@ describe('Acknowledgment tests', function () {
         opfab.logout();
     });
 
-    it('Check display of acknowledgments footer for parameter "showAcknowledgmentFooter" set to "OnlyForUsersAllowedToEdit"', function () {
+    it('Check display of acknowledgments footer for parameter "showAcknowledgmentFooter" set to "OnlyForUsersAllowedToEdit"', function() {
         // Clean up existing cards
         script.deleteAllCards();
         opfab.loginWithUser('operator1_fr');
@@ -1024,7 +1024,7 @@ describe('Acknowledgment tests', function () {
         cy.get('#opfab-card-acknowledged-footer').should('not.exist');
     });
 
-    it('Check display of acknowledgments footer for parameter "showAcknowledgmentFooter" set to "ForAllUsers"', function () {
+    it('Check display of acknowledgments footer for parameter "showAcknowledgmentFooter" set to "ForAllUsers"', function() {
         // Clean up existing cards
         script.deleteAllCards();
         opfab.loginWithUser('operator1_fr');

--- a/src/test/cypress/cypress/integration/CardDetail.spec.js
+++ b/src/test/cypress/cypress/integration/CardDetail.spec.js
@@ -10,18 +10,18 @@
 /* This test file focuses on some state-type specific behaviour in card details header. As the Cypress test suite grows,
 it might make sense to merge it with other tests.
 * */
-import {OpfabGeneralCommands} from '../support/opfabGeneralCommands';
-import {FeedCommands} from '../support/feedCommands';
-import {ScriptCommands} from '../support/scriptCommands';
-import {CardCommands} from '../support/cardCommands';
+import { OpfabGeneralCommands } from '../support/opfabGeneralCommands';
+import { FeedCommands } from '../support/feedCommands';
+import { ScriptCommands } from '../support/scriptCommands';
+import { CardCommands } from '../support/cardCommands';
 
-describe('Card detail', function () {
+describe('Card detail', function() {
     const opfab = new OpfabGeneralCommands();
     const feed = new FeedCommands();
     const script = new ScriptCommands();
     const card = new CardCommands();
 
-    before('Set up configuration', function () {
+    before('Set up configuration', function() {
         // This can stay in a `before` block rather than `beforeEach` as long as the test does not change configuration
         script.resetUIConfigurationFiles();
         script.deleteAllSettings();
@@ -31,8 +31,8 @@ describe('Card detail', function () {
         script.sendCard('cypress/cardDetail/cardDetail.json');
     });
 
-    describe('Check card detail', function () {
-        it(`Check card detail`, function () {
+    describe('Check card detail', function() {
+        it(`Check card detail`, function() {
             opfab.loginWithUser('operator1_fr');
             feed.openFirstCard();
 
@@ -98,7 +98,7 @@ describe('Card detail', function () {
             cy.get('#severityColor').contains('#1074ad');
         });
 
-        it(`Check card footer for operator4_fr (member of several entities)`, function () {
+        it(`Check card footer for operator4_fr (member of several entities)`, function() {
             opfab.loginWithUser('operator4_fr');
             feed.openFirstCard();
 
@@ -110,7 +110,7 @@ describe('Card detail', function () {
             cy.get('#opfab-card-details-address-to').contains('Control Center FR South');
         });
 
-        it(`Check card detail spinner when simulating card processed `, function () {
+        it(`Check card detail spinner when simulating card processed `, function() {
             opfab.loginWithUser('operator1_fr');
             feed.openFirstCard();
             cy.get('#opfabAPI-display-spinner-button').click();
@@ -118,7 +118,7 @@ describe('Card detail', function () {
             opfab.checkLoadingSpinnerIsNotDisplayed();
         });
 
-        it(`Check card detail in archives`, function () {
+        it(`Check card detail in archives`, function() {
             opfab.loginWithUser('operator1_fr');
             opfab.navigateToArchives();
             // We click the search button
@@ -169,7 +169,7 @@ describe('Card detail', function () {
             cy.get('#opfab-card-details-address-to').should('not.exist');
         });
 
-        it(`Check card detail footer for archives for operator4_fr (member of several entities)`, function () {
+        it(`Check card detail footer for archives for operator4_fr (member of several entities)`, function() {
             opfab.loginWithUser('operator4_fr');
             opfab.navigateToArchives();
 
@@ -192,7 +192,7 @@ describe('Card detail', function () {
             cy.get('#opfab-card-details-address-to').should('not.exist');
         });
 
-        it(`Check opfab API when response not required `, function () {
+        it(`Check opfab API when response not required `, function() {
             script.sendCard('cypress/cardDetail/cardDetailResponseNotRequired.json');
             opfab.loginWithUser('operator1_fr');
             feed.openFirstCard();
@@ -200,7 +200,7 @@ describe('Card detail', function () {
             cy.get('#opfab-currentCard-isUserMemberOfAnEntityRequiredToRespond').contains('false');
         });
 
-        it(`Check opfab API when response is not possible `, function () {
+        it(`Check opfab API when response is not possible `, function() {
             script.sendCard('cypress/cardDetail/cardDetailResponseNotPossible.json');
             opfab.loginWithUser('operator1_fr');
             feed.openFirstCard();
@@ -208,7 +208,7 @@ describe('Card detail', function () {
             cy.get('#opfab-currentCard-isUserMemberOfAnEntityRequiredToRespond').contains('false');
         });
 
-        it(`Check that a spinner is displayed when the card takes time to load `, function () {
+        it(`Check that a spinner is displayed when the card takes time to load `, function() {
             script.sendCard('cypress/cardDetail/cardDetailResponseNotPossible.json');
             cy.delayRequestResponse('/cards-consultation/cards/**');
             opfab.loginWithUser('operator1_fr');
@@ -217,7 +217,7 @@ describe('Card detail', function () {
             opfab.checkLoadingSpinnerIsNotDisplayed();
         });
 
-        it(`Check deleted card detail footer in archives`, function () {
+        it(`Check deleted card detail footer in archives`, function() {
             script.sendCard('cypress/userCard/message.json');
             opfab.loginWithUser('operator1_fr');
             feed.openFirstCard();
@@ -242,29 +242,26 @@ describe('Card detail', function () {
             );
         });
 
-        it(`Check showCard link`, function () {
+        it(`Check showCard link`, function() {
             script.sendCard('cypress/userCard/message.json');
             script.sendCard('cypress/cardDetail/cardDetail.json');
 
             opfab.loginWithUser('operator1_fr');
 
             feed.openFirstCard();
-            cy.hash().should('eq', '#/feed/cards/cypress.kitchenSink');
 
             // We click on show card link
             cy.get('#showCardLink').click();
 
-            cy.hash().should('eq', '#/feed/cards/defaultProcess.process1');
             card.checkContainsText('Hello operator1_fr, you received the following message');
         });
 
-        it(`Check show alert message links`, function () {
+        it(`Check show alert message links`, function() {
             script.sendCard('cypress/cardDetail/cardDetail.json');
 
             opfab.loginWithUser('operator1_fr');
 
             feed.openFirstCard();
-            cy.hash().should('eq', '#/feed/cards/cypress.kitchenSink');
 
             cy.get('#showDebugMessage').click();
             cy.get('#opfab-alert-detail-msg').contains('Debug message');
@@ -287,26 +284,24 @@ describe('Card detail', function () {
             cy.get('.opfab-alert-close').click();
         });
 
-        it(`Check getCards API call`, function () {
+        it(`Check getCards API call`, function() {
             script.sendCard('cypress/userCard/message.json');
             script.sendCard('cypress/cardDetail/cardDetail.json');
 
             opfab.loginWithUser('operator1_fr');
 
             feed.openFirstCard();
-            cy.hash().should('eq', '#/feed/cards/cypress.kitchenSink');
 
             cy.get('#opfabGetCardsResult').contains('"numberOfElements":1');
             cy.get('#opfabGetCardsResult').contains('"_id":"defaultProcess.process1"');
             cy.get('#opfabGetCardsResult').contains('"titleTranslated":"Message"');
         });
 
-        it(`Check isUserAllowedToEdit and editCard API call`, function () {
+        it(`Check isUserAllowedToEdit and editCard API call`, function() {
             script.sendCard('defaultProcess/message.json');
             opfab.loginWithUser('operator1_fr');
 
             feed.openFirstCard();
-            cy.hash().should('eq', '#/feed/cards/defaultProcess.process1');
 
             // check allowed user can use the edit button to edit card
             cy.get('#opfab-div-card-template-processed').find('#editButton').eq(0).should('contain.text', 'Edit');
@@ -320,7 +315,6 @@ describe('Card detail', function () {
             opfab.loginWithUser('operator3_fr');
 
             feed.openFirstCard();
-            cy.hash().should('eq', '#/feed/cards/defaultProcess.process1');
 
             // check user not allowed to edit does not see the edit button
             cy.get('#opfab-div-card-template-processed').should('exist');

--- a/src/test/cypress/cypress/integration/FeedTests.spec.js
+++ b/src/test/cypress/cypress/integration/FeedTests.spec.js
@@ -7,13 +7,13 @@
  * This file is part of the OperatorFabric project.
  */
 
-import {OpfabGeneralCommands} from '../support/opfabGeneralCommands';
-import {FeedCommands} from '../support/feedCommands';
-import {CardCommands} from '../support/cardCommands';
-import {ScriptCommands} from '../support/scriptCommands';
-import {SettingsCommands} from '../support/settingsCommands';
+import { OpfabGeneralCommands } from '../support/opfabGeneralCommands';
+import { FeedCommands } from '../support/feedCommands';
+import { CardCommands } from '../support/cardCommands';
+import { ScriptCommands } from '../support/scriptCommands';
+import { SettingsCommands } from '../support/settingsCommands';
 
-describe('FeedScreen tests', function () {
+describe('FeedScreen tests', function() {
     const opfab = new OpfabGeneralCommands();
     const feed = new FeedCommands();
     const card = new CardCommands();
@@ -25,16 +25,16 @@ describe('FeedScreen tests', function () {
         cy.get('#opfab-feed-card-not-found').should('exist');
     }
 
-    before('Set up configuration', function () {
+    before('Set up configuration', function() {
         script.resetUIConfigurationFiles();
         script.loadTestConf();
     });
 
-    beforeEach('Delete all cards', function () {
+    beforeEach('Delete all cards', function() {
         script.deleteAllCards();
     });
 
-    it('Check card reception and read behaviour', function () {
+    it('Check card reception and read behaviour', function() {
         opfab.loginWithUser('operator1_fr');
         script.send6TestCards();
         // Set feed sort to "Date" so the cards don't move down the feed once they're read
@@ -73,7 +73,7 @@ describe('FeedScreen tests', function () {
             .invoke('attr', 'data-urlId')
             .as('firstCardUrlId')
             .then((urlId) => {
-                cy.hash().should('eq', '#/feed/cards/' + urlId);
+                cy.hash().should('eq', '#/feed/cards/' + opfab.base64urlEncode(urlId));
                 cy.get('of-card').find('of-card-body');
             });
         cy.get('#opfab-feed-card-not-found').should('not.exist');
@@ -97,7 +97,7 @@ describe('FeedScreen tests', function () {
                 .should('have.css', 'margin-left', '20px')
                 .invoke('attr', 'data-urlId')
                 .then((urlId) => {
-                    cy.hash().should('eq', '#/feed/cards/' + urlId);
+                    cy.hash().should('eq', '#/feed/cards/' + opfab.base64urlEncode(urlId));
                     cy.get('of-card').find('of-card-body');
                 });
         });
@@ -117,7 +117,7 @@ describe('FeedScreen tests', function () {
         });
     });
 
-    it('Check card delete ', function () {
+    it('Check card delete ', function() {
         opfab.loginWithUser('operator1_fr');
         script.send6TestCards();
         feed.checkNumberOfDisplayedCardsIs(6);
@@ -127,13 +127,13 @@ describe('FeedScreen tests', function () {
         cy.get('of-card').should('not.exist');
     });
 
-    it('Check card visibility by publish date when business period is after selected time range', function () {
+    it('Check card visibility by publish date when business period is after selected time range', function() {
         script.sendCard('cypress/feed/futureEvent.json');
         opfab.loginWithUser('operator1_fr');
         feed.checkNumberOfDisplayedCardsIs(1);
     });
 
-    it('Check sorting', function () {
+    it('Check sorting', function() {
         script.sendCard('defaultProcess/chartLine.json');
         script.sendCard('defaultProcess/question.json');
         script.sendCard('defaultProcess/process.json');
@@ -198,7 +198,7 @@ describe('FeedScreen tests', function () {
         feed.checkLightCardAtIndexHasTitle(3, 'Process state (calcul)');
     });
 
-    it('Check filter by priority', function () {
+    it('Check filter by priority', function() {
         opfab.loginWithUser('operator1_fr');
         script.send6TestCards();
 
@@ -226,7 +226,7 @@ describe('FeedScreen tests', function () {
         feed.checkNumberOfDisplayedCardsIs(6);
     });
 
-    it('Check filter by acknowledgement', function () {
+    it('Check filter by acknowledgement', function() {
         opfab.loginWithUser('operator1_fr');
         script.sendCard('defaultProcess/message.json');
         script.sendCard('defaultProcess/chart.json');
@@ -276,7 +276,7 @@ describe('FeedScreen tests', function () {
         feed.checkNumberOfDisplayedCardsIs(0);
     });
 
-    it('Check filter by response from user entity', function () {
+    it('Check filter by response from user entity', function() {
         opfab.loginWithUser('operator1_fr');
         script.sendCard('defaultProcess/message.json');
         script.sendCard('defaultProcess/question.json');
@@ -308,7 +308,7 @@ describe('FeedScreen tests', function () {
         cy.get('#opfab-feed-light-card-defaultProcess-process4').should('exist');
     });
 
-    it('Check filter by process', function () {
+    it('Check filter by process', function() {
         opfab.loginWithUser('operator1_fr');
         script.sendCard('defaultProcess/chart.json');
         script.sendCard('defaultProcess/question.json');
@@ -334,7 +334,7 @@ describe('FeedScreen tests', function () {
         feed.checkNumberOfDisplayedCardsIs(3);
     });
 
-    it('Check apply filters to timeline', function () {
+    it('Check apply filters to timeline', function() {
         opfab.loginWithUser('operator1_fr');
         script.sendCard('defaultProcess/chart.json');
 
@@ -359,7 +359,7 @@ describe('FeedScreen tests', function () {
         checkTimelineCircles(2);
     });
 
-    it('Check reset all filters', function () {
+    it('Check reset all filters', function() {
         opfab.loginWithUser('operator1_fr');
         script.send6TestCards();
 
@@ -412,7 +412,7 @@ describe('FeedScreen tests', function () {
         checkResetAllFiltersLinkDoesNotExists();
     });
 
-    it('Check reads and acks are kept when update card has KEEP_EXISTING_ACKS_AND_READS action', function () {
+    it('Check reads and acks are kept when update card has KEEP_EXISTING_ACKS_AND_READS action', function() {
         opfab.loginWithUser('operator1_fr');
         script.sendCard('defaultProcess/message.json');
 
@@ -467,7 +467,7 @@ describe('FeedScreen tests', function () {
         cy.get('#opfab-feed-light-card-defaultProcess-process1 .fa-check');
     });
 
-    it('Check Hallway mode', function () {
+    it('Check Hallway mode', function() {
         opfab.loginWithUser('operator1_fr');
         script.sendCard('defaultProcess/message.json');
         script.sendCard('defaultProcess/contingencies.json');
@@ -501,7 +501,7 @@ describe('FeedScreen tests', function () {
         cy.get('of-card').should('not.exist');
     });
 
-    it('Open next card after acknowledgment', function () {
+    it('Open next card after acknowledgment', function() {
         opfab.loginWithUser('operator1_fr');
         script.sendCard('defaultProcess/chart.json');
         script.sendCard('defaultProcess/message.json');

--- a/src/test/cypress/cypress/integration/GroupCards.spec.js
+++ b/src/test/cypress/cypress/integration/GroupCards.spec.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2021-2024, RTE (http://www.rte-france.com)
+/* Copyright (c) 2021-2025, RTE (http://www.rte-france.com)
  * See AUTHORS.txt
  * Ther Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with ther
@@ -6,15 +6,15 @@
  * SPDX-License-Identifier: MPL-2.0
  * Ther file is part of the OperatorFabric project.
  */
-import {OpfabGeneralCommands} from '../support/opfabGeneralCommands'
-import {ScriptCommands} from "../support/scriptCommands";
+import { OpfabGeneralCommands } from '../support/opfabGeneralCommands'
+import { ScriptCommands } from "../support/scriptCommands";
 
-describe('Group Cards tests', function () {
+describe('Group Cards tests', function() {
 
     const opfab = new OpfabGeneralCommands();
     const script = new ScriptCommands();
 
-    before('Set up configuration', function () {
+    before('Set up configuration', function() {
 
         // Ther can stay in a `before` block rather than `beforeEach` as long as the test does not change configuration
         script.resetUIConfigurationFiles();
@@ -25,26 +25,26 @@ describe('Group Cards tests', function () {
         script.deleteAllCards();
 
         // Send four cards with the same tag
-        script.sendCard('cypress/group/message1.json', {processInstanceId: 'message1_1'});
-        script.sendCard('cypress/group/message1.json', {processInstanceId: 'message1_2'});
-        script.sendCard('cypress/group/message1.json', {processInstanceId: 'message1_3'});
-        script.sendCard('cypress/group/message1.json', {processInstanceId: 'message1_4'});
+        script.sendCard('cypress/group/message1.json', { processInstanceId: 'message1_1' });
+        script.sendCard('cypress/group/message1.json', { processInstanceId: 'message1_2' });
+        script.sendCard('cypress/group/message1.json', { processInstanceId: 'message1_3' });
+        script.sendCard('cypress/group/message1.json', { processInstanceId: 'message1_4' });
 
         // Send three others cards, all having the same tag
-        script.sendCard('cypress/group/message2.json', {processInstanceId: 'message2_1'});
-        script.sendCard('cypress/group/message2.json', {processInstanceId: 'message2_2'});
-        script.sendCard('cypress/group/message2.json', {processInstanceId: 'message2_3'});
+        script.sendCard('cypress/group/message2.json', { processInstanceId: 'message2_1' });
+        script.sendCard('cypress/group/message2.json', { processInstanceId: 'message2_2' });
+        script.sendCard('cypress/group/message2.json', { processInstanceId: 'message2_3' });
 
         // Send three others cards (all having only the combined tags of the previous cards)
-        script.sendCard('cypress/group/message3.json', {processInstanceId: 'message3_1'});
-        script.sendCard('cypress/group/message3.json', {processInstanceId: 'message3_2'});
-        script.sendCard('cypress/group/message3.json', {processInstanceId: 'message3_3'});
+        script.sendCard('cypress/group/message3.json', { processInstanceId: 'message3_1' });
+        script.sendCard('cypress/group/message3.json', { processInstanceId: 'message3_2' });
+        script.sendCard('cypress/group/message3.json', { processInstanceId: 'message3_3' });
 
         // Send one card, having a different tag, not grouped
-        script.sendCard('cypress/group/message4.json', {processInstanceId: 'message4_1'});
+        script.sendCard('cypress/group/message4.json', { processInstanceId: 'message4_1' });
     });
 
-    it('Card grouping disabled -> all cards should be visible in the feed', function () {
+    it('Card grouping disabled -> all cards should be visible in the feed', function() {
         script.setPropertyInConf('feed.enableGroupedCards', false);
         opfab.loginWithUser('operator1_fr');
 
@@ -56,13 +56,13 @@ describe('Group Cards tests', function () {
         cy.get('[id^="opfab-feed-light-card-cypress-message2_"]').first().click();
 
         // Check if URL changes to display the card detail
-        cy.url().should('include', 'cypress.message2_')
+        cy.url().should('include', opfab.base64urlEncode('cypress.message2_'));
 
         // Operator1 should still see 11 cards in her feed
         cy.get('of-light-card').should('have.length', 11);
     });
 
-    it('Card grouping enabled -> only cards with unique tag strings should be visible in the feed', function () {
+    it('Card grouping enabled -> only cards with unique tag strings should be visible in the feed', function() {
         script.setPropertyInConf('feed.enableGroupedCards', true);
         opfab.loginWithUser('operator1_fr');
 
@@ -72,8 +72,8 @@ describe('Group Cards tests', function () {
         // // Click on a card
         cy.get('[id^="opfab-feed-light-card-cypress-message1_"]').first().click();
 
-         // Check if URL changes to display the card detail
-        cy.url().should('include', 'cypress.message1_');
+        // Check if URL changes to display the card detail
+        cy.url().should('include', opfab.base64urlEncode('cypress.message1_'));
 
         // Operator1 should see 4 + the 2 grouped cards + 1 not grouped card == 7 cards  in her feed
         cy.get('of-light-card').should('have.length', 7);
@@ -88,13 +88,13 @@ describe('Group Cards tests', function () {
         cy.get('[id^="opfab-feed-light-card-cypress-message3_"]').first().click();
 
         // Check if URL changes to display the card detail
-        cy.url().should('include', 'cypress.message3_');
+        cy.url().should('include', opfab.base64urlEncode('cypress.message3_'));
 
         // Operator1 should see 3 + the 2 grouped cards + 1 not grouped card == 6 cards  in her feed
         cy.get('of-light-card').should('have.length', 6);
     });
 
-    it('Card grouping enabled -> only cards with childrens should display the icon', function () {
+    it('Card grouping enabled -> only cards with childrens should display the icon', function() {
         opfab.loginWithUser('operator1_fr');
 
         cy.get('[id="opfab-feed-light-card-group-icon"]').should('have.length', 3);

--- a/src/test/cypress/cypress/support/opfabGeneralCommands.js
+++ b/src/test/cypress/cypress/support/opfabGeneralCommands.js
@@ -7,7 +7,7 @@
  * This file is part of the OperatorFabric project.
  */
 
-import {OpfabCommands} from './opfabCommands';
+import { OpfabCommands } from './opfabCommands';
 
 export class OpfabGeneralCommands extends OpfabCommands {
     constructor() {
@@ -15,19 +15,30 @@ export class OpfabGeneralCommands extends OpfabCommands {
         super.init('OPFAB');
     }
 
-    checkLoadingSpinnerIsDisplayed = function () {
+    base64urlEncode(str) {
+        const base64 = btoa(str);
+        // Replace '+' with '-', '/' with '_' and remove trailing '=' to convert base64 to base64url
+        let base64url = base64.replace(/\+/g, '-').replace(/\//g, '_');
+        while (base64url.endsWith('=')) {
+            base64url = base64url.slice(0, base64url.length - 1);
+        }
+        return base64url;
+    }
+
+    checkLoadingSpinnerIsDisplayed = function() {
         cy.get('#opfab-loading-spinner').should('exist');
     };
 
-    checkLoadingSpinnerIsNotDisplayed = function () {
+    checkLoadingSpinnerIsNotDisplayed = function() {
         cy.get('#opfab-loading-spinner').should('not.exist');
     };
 
-    hackUrlCurrentlyUsedMechanism = function () {
+    hackUrlCurrentlyUsedMechanism = function() {
         cy.hackUrlCurrentlyUsedMechanism();
     };
 
-    loginWithoutHackWithUser = function (user) {
+
+    loginWithoutHackWithUser = function(user) {
         //type login
         cy.get('#opfab-login').should('be.visible');
         cy.get('#opfab-login').type(user);
@@ -40,10 +51,10 @@ export class OpfabGeneralCommands extends OpfabCommands {
         cy.get('#opfab-login-btn-submit').click();
 
         //Wait for the app to finish initializing
-        cy.get('#opfab-cypress-loaded-check', {timeout: 20000}).should('have.text', 'true');
+        cy.get('#opfab-cypress-loaded-check', { timeout: 20000 }).should('have.text', 'true');
     };
 
-    loginWithUser = function (user) {
+    loginWithUser = function(user) {
         this.hackUrlCurrentlyUsedMechanism();
         //go to login page
         cy.visit('');
@@ -51,7 +62,7 @@ export class OpfabGeneralCommands extends OpfabCommands {
         this.loginWithoutHackWithUser(user);
     };
 
-    loginWithClock = function (dateToUse) {
+    loginWithClock = function(dateToUse) {
         // Do not use the generic login feature as we
         // need to launch cy.clock after cy.visit('')
         this.hackUrlCurrentlyUsedMechanism();
@@ -62,97 +73,97 @@ export class OpfabGeneralCommands extends OpfabCommands {
         cy.get('#opfab-login-btn-submit').click();
 
         //Wait for the app to finish initializing
-        cy.get('#opfab-cypress-loaded-check', {timeout: 15000}).should('have.text', 'true');
+        cy.get('#opfab-cypress-loaded-check', { timeout: 15000 }).should('have.text', 'true');
     };
 
-    logout = function () {
+    logout = function() {
         cy.get('#opfab-navbar-drop-user-menu').click();
         cy.get('#opfab-navbar-right-menu-logout').click();
     };
 
-    navigateToAdministration = function () {
+    navigateToAdministration = function() {
         cy.get('#opfab-navbar-drop-user-menu').click();
         cy.get('#opfab-navbar-right-menu-admin').click();
     };
 
-    navigateToFeed = function () {
+    navigateToFeed = function() {
         cy.get('#opfab-navbar-menu-feed').click();
         cy.get('of-card-list').should('exist');
     };
 
-    navigateToActivityArea = function () {
+    navigateToActivityArea = function() {
         cy.get('#opfab-navbar-drop-user-menu').click();
         cy.get('#opfab-navbar-right-menu-activityarea').click();
         cy.get('of-activityarea').should('exist');
     };
 
-    navigateToArchives = function () {
+    navigateToArchives = function() {
         cy.get('#opfab-navbar-menu-archives').click();
         cy.get('of-archives').should('exist');
     };
 
-    navigateToCalendar = function () {
+    navigateToCalendar = function() {
         cy.get('#opfab-calendar-menu').click();
         cy.get('of-calendar').should('exist');
     };
 
-    navigateToDashboard = function () {
+    navigateToDashboard = function() {
         cy.get('#opfab-navbar-menu-dashboard').click();
         cy.get('of-dashboard').should('exist');
     };
 
-    navigateToMonitoring = function () {
+    navigateToMonitoring = function() {
         cy.get('#opfab-navbar-menu-monitoring').click();
         cy.get('of-monitoring').should('exist');
     };
 
-    navigateToMonitoringProcessus = function () {
+    navigateToMonitoringProcessus = function() {
         cy.get('#opfab-navbar-menu-processmonitoring').click();
         cy.get('of-processmonitoring').should('exist');
     };
 
-    navigateToCustomScreen1 = function () {
+    navigateToCustomScreen1 = function() {
         cy.get('#opfab-navbar-menu-label-menu2').click();
         cy.get('#opfab-navbar-menu-dropdown-testId').click();
     };
 
-    navigateToCustomScreen2 = function () {
+    navigateToCustomScreen2 = function() {
         cy.get('#opfab-navbar-menu-label-menu2').click();
         cy.get('#opfab-navbar-menu-dropdown-testId2').click();
     };
 
-    navigateToCustomScreen3 = function () {
+    navigateToCustomScreen3 = function() {
         cy.get('#opfab-navbar-menu-label-menu2').click();
         cy.get('#opfab-navbar-menu-dropdown-testId3').click();
     };
 
-    navigateToRealTimeUsers = function () {
+    navigateToRealTimeUsers = function() {
         cy.get('#opfab-navbar-drop-user-menu').click();
         cy.get('#opfab-navbar-right-menu-realtimeusers').click();
     };
 
-    navigateToSettings = function () {
+    navigateToSettings = function() {
         cy.get('#opfab-navbar-drop-user-menu').click();
         cy.get('#opfab-navbar-right-menu-settings').click();
         cy.get('of-settings').should('exist');
     };
 
-    navigateToUserCard = function () {
+    navigateToUserCard = function() {
         cy.get('#opfab-newcard-menu').click();
         cy.get('of-usercard').should('exist');
     };
 
-    navigateToNotificationConfiguration = function () {
+    navigateToNotificationConfiguration = function() {
         cy.get('#opfab-navbar-drop-user-menu').click();
         cy.get('#opfab-navbar-right-menu-feedconfiguration').click();
     };
 
-    openExternalDevices = function () {
+    openExternalDevices = function() {
         cy.get('#opfab-navbar-drop-user-menu').click();
         cy.get('#opfab-navbar-right-menu-externaldevicesconfiguration').click();
     };
 
-    simulateTimeForOpfabCodeToExecute = function () {
+    simulateTimeForOpfabCodeToExecute = function() {
         cy.tick(100);
         cy.wait(10);
         cy.tick(100);
@@ -161,21 +172,21 @@ export class OpfabGeneralCommands extends OpfabCommands {
         cy.wait(10);
     };
 
-    navigateToUserActionLogs = function () {
+    navigateToUserActionLogs = function() {
         cy.get('#opfab-navbar-drop-user-menu').click();
         cy.get('#opfab-navbar-right-menu-useractionlogs').click();
     };
 
-    switchToDayMode = function () {
+    switchToDayMode = function() {
         cy.get('#opfab-navbar-drop-user-menu').click();
         cy.get('#opfab-navbar-right-menu-nightdaymode').click();
     };
 
-    checkUrlDisplayedIs = function (url) {
+    checkUrlDisplayedIs = function(url) {
         cy.get('iframe').invoke('attr', 'src').should('eq', url);
     };
 
-    selectOptionsFromMultiselect = function (multiselectId, option, hasTags = false, searchResultNumber = 0) {
+    selectOptionsFromMultiselect = function(multiselectId, option, hasTags = false, searchResultNumber = 0) {
         cy.get(multiselectId).click();
         cy.get(multiselectId).find('.vscomp-search-input').clear();
         cy.get(multiselectId).find('.vscomp-search-input').type(option);

--- a/src/test/resources/cards/cypress/cardDetail/cardDetail.json
+++ b/src/test/resources/cards/cypress/cardDetail/cardDetail.json
@@ -2,7 +2,7 @@
 	"publisher" : "publisher_test",
 	"processVersion" : "1",
 	"process"  :"cypress",
-	"processInstanceId" : "kitchenSink",
+	"processInstanceId" : "id with special characters #?\\%++",
 	"state": "kitchenSink",
 	"entityRecipients": ["ENTITY1_FR","ENTITY2_FR"],
 	"entitiesRequiredToRespond" : ["ENTITY1_FR"],

--- a/ui/main/src/app/services/cards/server/AngularCardsServer.ts
+++ b/ui/main/src/app/services/cards/server/AngularCardsServer.ts
@@ -43,7 +43,10 @@ export class AngularCardsServer extends AngularServer implements CardsServer {
     }
 
     loadCard(id: string): Observable<ServerResponse<any>> {
-        return this.processHttpResponse(this.httpClient.get<CardWithChildCards>(`${this.cardConsultationUrl}/${id}`));
+        // it is necessary to encode the id because it can contain special characters
+        return this.processHttpResponse(
+            this.httpClient.get<CardWithChildCards>(`${this.cardConsultationUrl}/${encodeURIComponent(id)}`)
+        );
     }
 
     loadArchivedCard(id: string): Observable<ServerResponse<any>> {
@@ -65,7 +68,10 @@ export class AngularCardsServer extends AngularServer implements CardsServer {
     }
 
     deleteCard(card: Card): Observable<ServerResponse<any>> {
-        return this.processHttpResponse(this.httpClient.delete<void>(`${this.userCardUrl}/${card.id}`));
+        // it is necessary to encode the id because it can contain special characters
+        return this.processHttpResponse(
+            this.httpClient.delete<void>(`${this.userCardUrl}/${encodeURIComponent(card.id)}`)
+        );
     }
 
     postUserCardRead(cardUid: string): Observable<ServerResponse<any>> {

--- a/ui/main/src/app/services/navigation/NavigationService.ts
+++ b/ui/main/src/app/services/navigation/NavigationService.ts
@@ -11,6 +11,7 @@ import {SelectedCardService} from '@ofServices/selectedCard/SelectedCardService'
 import {ApplicationRouter} from './router/ApplicationRouter';
 import {LogOption, LoggerService as logger} from 'app/services/logs/LoggerService';
 import {Observable, ReplaySubject} from 'rxjs';
+import {base64urlDecode, base64urlEncode} from 'app/utils/Encoding';
 export enum PageType {
     UNKNOWN,
     FEED,
@@ -59,7 +60,9 @@ export class NavigationService {
         NavigationService.router.listenForNavigationEnd((route: string) => {
             if (route.startsWith('/feed/cards/')) {
                 const cardId = route.split('cards/')[1];
-                SelectedCardService.setSelectedCardId(decodeURI(cardId));
+                // we need to decode the id as it is encoded in base64url to avoid the browser
+                // to interpret special characters that the id may contain
+                SelectedCardService.setSelectedCardId(base64urlDecode(cardId));
             }
         });
     }
@@ -91,7 +94,8 @@ export class NavigationService {
     }
 
     public static navigateToCard(cardId: string) {
-        NavigationService.navigateTo('/feed/cards/' + cardId);
+        // we encode the id in base64url to avoid the browser to interpret special characters that the id may contain
+        NavigationService.navigateTo('/feed/cards/' + base64urlEncode(cardId));
     }
 
     public static navigateToFeedWithProcessStateFilter(processFilter: string, stateFilter: string) {

--- a/ui/main/src/app/utils/Encoding.spec.ts
+++ b/ui/main/src/app/utils/Encoding.spec.ts
@@ -1,0 +1,48 @@
+/* Copyright (c) 2025, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
+ */
+
+import {base64urlDecode, base64urlEncode} from './Encoding';
+
+describe('Encoding Utility Functions', () => {
+    it('should correctly encode a string to base64url format', () => {
+        const input = 'test-string';
+        const expected = 'dGVzdC1zdHJpbmc';
+        const result = base64urlEncode(input);
+        expect(result).toEqual(expected);
+    });
+    it('should correctly encode a string with == in base 64 encoding  to base64url format', () => {
+        const input = 'testwithdoubleequals__';
+        // In base 64 it is converted to 'dGVzdHdpdGhkb3VibGVlcXVhbHNfXw=='
+        const expected = 'dGVzdHdpdGhkb3VibGVlcXVhbHNfXw';
+        const result = base64urlEncode(input);
+        expect(result).toEqual(expected);
+    });
+
+    it('should correctly decode a base64url string back to the original string', () => {
+        const input = 'dGVzdC1zdHJpbmc';
+        const expected = 'test-string';
+        const result = base64urlDecode(input);
+        expect(result).toEqual(expected);
+    });
+
+    it('should handle empty strings for encoding and decoding', () => {
+        const input = '';
+        const encoded = base64urlEncode(input);
+        const decoded = base64urlDecode(encoded);
+        expect(encoded).toEqual('');
+        expect(decoded).toEqual(input);
+    });
+
+    it('should handle special characters in strings', () => {
+        const input = 'special+chars/with=padding';
+        const encoded = base64urlEncode(input);
+        const decoded = base64urlDecode(encoded);
+        expect(decoded).toEqual(input);
+    });
+});

--- a/ui/main/src/app/utils/Encoding.ts
+++ b/ui/main/src/app/utils/Encoding.ts
@@ -1,0 +1,22 @@
+/* Copyright (c) 2025, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
+ */
+
+export function base64urlEncode(str: string) {
+    const base64 = btoa(str);
+    // Replace '+' with '-', '/' with '_' and remove trailing '=' to convert base64 to base64url
+    let base64url = base64.replace(/\+/g, '-').replace(/\//g, '_');
+    while (base64url.endsWith('=')) {
+        base64url = base64url.slice(0, base64url.length - 1);
+    }
+    return base64url;
+}
+export function base64urlDecode(str: string) {
+    const base64 = str.replace(/-/g, '+').replace(/_/g, '/');
+    return atob(base64);
+}


### PR DESCRIPTION
Add base64 encoding in id in urls on the angular side and configure spring to allowed special characters.

The only characters that is not allowed is the slash as it causes problem in spring when parsing the url path.

A cypress card has been updated with a processInstanceId containing special characters so to be able to detect potential future regressions

- In release notes :
  -  In chapter : Features
  -  Text : #8361 Authorize special characters in processInstanceId (except the slash) 