### PR TITLE
Custom card list screen : add an option to show only cards emitted by current user entities (#8440)

### DIFF
--- a/config/docker/externalJs/CustomScreenExample.js
+++ b/config/docker/externalJs/CustomScreenExample.js
@@ -38,6 +38,7 @@
             'INPROGRESS',
             'FINISHED'
         ],
+        includeOnlyCardsEmittedByCurrentUserEntities: false,
         results: {
             columns: [
                 {

--- a/src/docs/asciidoc/reference_doc/ui_customization.adoc
+++ b/src/docs/asciidoc/reference_doc/ui_customization.adoc
@@ -348,6 +348,7 @@ const customScreenExample = {
         'INPROGRESS',
         'FINISHED'
     ],
+    includeOnlyCardsEmittedByCurrentUserEntities: false,
     results: {
         columns: [
             {
@@ -417,6 +418,8 @@ opfab.businessconfig.registerCustomScreen(customScreenExample);
 In this example, the custom screen is accessible via the URL `#/customscreen/testId`.
 
 It is possible to exclude specific states from being display by adding them to the `statesToExclude` array. State ids are not unique and should be associated to their process id.
+
+It is possible to include only cards emitted by the entities of the current user by setting the `includeOnlyCardsEmittedByCurrentUserEntities` field to `true`. 
 
 You can define the filters to be displayed in the header of the screen by adding them to the `headerFilters` array. The following filters are available: `PROCESS`, `TYPE_OF_STATE`, `READ_ACK`, `RESPONSE_FROM_MY_ENTITIES` and `RESPONSE_FROM_ALL_ENTITIES`.
 

--- a/ui/main/src/app/services/customScreen/model/CustomScreenDefinition.ts
+++ b/ui/main/src/app/services/customScreen/model/CustomScreenDefinition.ts
@@ -24,6 +24,7 @@ export class CustomScreenDefinition {
     showAcknowledgmentButton?: boolean;
     responseSeverityColumnLabelsForExportFile?: {[key: string]: string};
     defaultSelectedTypeOfState?: string[];
+    includeOnlyCardsEmittedByCurrentUserEntities?: boolean;
 }
 
 export class Column {

--- a/ui/main/src/app/views/customCardList/CustomCardListView.ts
+++ b/ui/main/src/app/views/customCardList/CustomCardListView.ts
@@ -84,7 +84,6 @@ export class CustomCardListView {
         RealTimeDomainService.setStartAndEndPeriod(filterValues.startDate, filterValues.endDate);
         RealTimeDomainService.saveUserPreferenceAsNearestDomain();
         filterValues.processes = this.getProcessList(filterValues.processes);
-        filterValues.statesToExcludeFilter = this.customScreenDefinition?.statesToExclude;
         this.resultTable.setFilters(filterValues);
     }
 

--- a/ui/main/src/app/views/customCardList/FilterValues.ts
+++ b/ui/main/src/app/views/customCardList/FilterValues.ts
@@ -18,4 +18,5 @@ export class FilterValues {
     public readAndAckFilter: string[];
     public includeCardsWithResponseFromMyEntities: boolean;
     public includeCardsWithResponsesFromAllEntities: boolean;
+    public includeOnlyCardsEmittedByCurrentUserEntities: boolean;
 }

--- a/ui/main/src/app/views/customCardList/resultTable/CardFilter.ts
+++ b/ui/main/src/app/views/customCardList/resultTable/CardFilter.ts
@@ -12,6 +12,8 @@ import {ProcessesService} from '@ofServices/processes/ProcessesService';
 import {Card} from 'app/model/Card';
 import {FilterValues} from '../FilterValues';
 import {StateExclusion} from '@ofServices/customScreen/model/CustomScreenDefinition';
+import {UsersService} from '@ofServices/users/UsersService';
+import {PublisherType} from 'app/model/PublisherType';
 
 export class CardFilter {
     private startDate: number;
@@ -23,6 +25,7 @@ export class CardFilter {
     private includeCardsWithResponsesFromAllEntities = true;
     private readFilter: boolean = undefined;
     private ackFilter: boolean = undefined;
+    private includeOnlyCardsEmittedByCurrentUserEntities = false;
 
     public setFilters(filterValues: FilterValues) {
         this.startDate = filterValues.startDate;
@@ -33,6 +36,7 @@ export class CardFilter {
         this.setReadAndAckFilter(filterValues.readAndAckFilter);
         this.includeCardsWithResponsesFromAllEntities = filterValues.includeCardsWithResponsesFromAllEntities;
         this.includeCardsWithResponseFromMyEntities = filterValues.includeCardsWithResponseFromMyEntities;
+        this.includeOnlyCardsEmittedByCurrentUserEntities = filterValues.includeOnlyCardsEmittedByCurrentUserEntities;
     }
 
     private setReadAndAckFilter(readAndAck: string[]) {
@@ -63,6 +67,8 @@ export class CardFilter {
         if (this.isCardFilteredByAck(card)) return true;
         if (!this.includeCardsWithResponseFromMyEntities && card.hasChildCardFromCurrentUserEntity) return true;
         if (!this.includeCardsWithResponsesFromAllEntities && this.haveAllEntitiesResponded(card, childCards))
+            return true;
+        if (this.includeOnlyCardsEmittedByCurrentUserEntities && !this.isCardEmittedByCurrentUserEntity(card))
             return true;
         return false;
     }
@@ -121,5 +127,11 @@ export class CardFilter {
         if (entitiesToRespond.size === 0) return false;
         const respondedEntities = new Set(childCards.get(card.id)?.map((card) => card.publisher) ?? []);
         return Array.from(entitiesToRespond).every((entity) => respondedEntities.has(entity));
+    }
+
+    private isCardEmittedByCurrentUserEntity(card: Card): boolean {
+        if (card.publisherType === PublisherType.ENTITY)
+            return UsersService.getCurrentUserWithPerimeters().userData.entities.includes(card.publisher);
+        return false;
     }
 }

--- a/ui/main/src/app/views/customCardList/resultTable/ResultTable-Filter.spec.ts
+++ b/ui/main/src/app/views/customCardList/resultTable/ResultTable-Filter.spec.ts
@@ -7,20 +7,31 @@
  * This file is part of the OperatorFabric project.
  */
 
-import {CustomScreenDefinition, FieldType} from '@ofServices/customScreen/model/CustomScreenDefinition';
+import {CustomScreenDefinition, FieldType, StateExclusion} from '@ofServices/customScreen/model/CustomScreenDefinition';
 import {ResultTable} from './ResultTable';
-import {getOneLightCard, mockTranslation, setEntities, setProcessConfiguration} from '@tests/helpers';
+import {getOneLightCard, mockTranslation, setEntities, setProcessConfiguration, setUserPerimeter} from '@tests/helpers';
 import {Process, ReadAndAckEnum, State, TypeOfStateEnum} from '@ofServices/processes/model/Processes';
 import {Card} from 'app/model/Card';
 import {RoleEnum} from '@ofServices/entities/model/RoleEnum';
 import {Severity} from 'app/model/Severity';
 import {FilterValues} from '../FilterValues';
+import {PublisherType} from 'app/model/PublisherType';
 
 describe('CustomScreenView - ResultTable - Should Filter card', () => {
-    const getResultTable = () => {
+    const getResultTable = (options?: {
+        statesToExcludeFilter?: StateExclusion[];
+        includeOnlyCardsEmittedByCurrentUserEntities?: boolean;
+    }) => {
         const customScreenDefinition = new CustomScreenDefinition();
         customScreenDefinition.id = 'testId';
         customScreenDefinition.name = 'testName';
+        if (options?.statesToExcludeFilter) {
+            customScreenDefinition.statesToExclude = options.statesToExcludeFilter;
+        }
+        if (options?.includeOnlyCardsEmittedByCurrentUserEntities !== undefined) {
+            customScreenDefinition.includeOnlyCardsEmittedByCurrentUserEntities =
+                options.includeOnlyCardsEmittedByCurrentUserEntities;
+        }
         customScreenDefinition.results = {
             columns: [
                 {
@@ -325,7 +336,9 @@ describe('CustomScreenView - ResultTable - Should Filter card', () => {
         ]);
     });
     it('by excluded states', async () => {
-        const resultTable = getResultTable();
+        const resultTable = getResultTable({
+            statesToExcludeFilter: [{processId: 'processId0', stateIds: ['state1.0']}]
+        });
         const states = new Map<string, State>();
         states.set('state1.0', {});
         states.set('state1.1', {});
@@ -359,7 +372,6 @@ describe('CustomScreenView - ResultTable - Should Filter card', () => {
             })
         ];
         const filterValues = new FilterValues();
-        filterValues.statesToExcludeFilter = [{processId: 'processId0', stateIds: ['state1.0']}];
         resultTable.setFilters(filterValues);
 
         const dataArray = resultTable.getDataArrayFromCards(cards, emptyChildCardsList);
@@ -368,6 +380,42 @@ describe('CustomScreenView - ResultTable - Should Filter card', () => {
             {cardId: 'id2', testField: 'processId1'}
         ]);
     });
+    it('by current user entities if includeOnlyCardsEmittedByCurrentUserEntities is set to true', async () => {
+        const resultTable = getResultTable({includeOnlyCardsEmittedByCurrentUserEntities: true});
+        const cards = [
+            getOneLightCard({
+                publisher: 'entity1',
+                publisherType: PublisherType.ENTITY,
+                process: 'processId0',
+                state: 'state1.0',
+                id: 'id0'
+            }),
+            getOneLightCard({
+                publisher: 'entity2',
+                publisherType: PublisherType.ENTITY,
+                process: 'processId0',
+                state: 'state1.1',
+                startDate: 100,
+                id: 'id1'
+            })
+        ];
+
+        await setUserPerimeter({
+            computedPerimeters: [],
+            userData: {
+                login: 'test',
+                firstName: 'firstName',
+                lastName: 'lastName',
+                entities: ['entity1']
+            }
+        });
+
+        const filterValues = new FilterValues();
+        resultTable.setFilters(filterValues);
+        const dataArray = resultTable.getDataArrayFromCards(cards, emptyChildCardsList);
+        expect(dataArray).toEqual([{cardId: 'id0', testField: 'processId0'}]);
+    });
+
     it('that have responses from my entities if excludeCardsWithResponseFromMyEntities is called', () => {
         const resultTable = getResultTable();
         const cards = [

--- a/ui/main/src/app/views/customCardList/resultTable/ResultTable.ts
+++ b/ui/main/src/app/views/customCardList/resultTable/ResultTable.ts
@@ -100,6 +100,11 @@ export class ResultTable {
     }
 
     public setFilters(filtersValue: FilterValues) {
+        // statesToExcludeFilter and includeOnlyCardsEmittedByCurrentUserEntities are not set by the user
+        //  but by the custom screen definition
+        filtersValue.statesToExcludeFilter = this.customScreenDefinition?.statesToExclude;
+        filtersValue.includeOnlyCardsEmittedByCurrentUserEntities =
+            this.customScreenDefinition?.includeOnlyCardsEmittedByCurrentUserEntities;
         this.cardFilter.setFilters(filtersValue);
     }
 


### PR DESCRIPTION

- In release notes :
  -  In chapter : Features
  -  Text : #8440  Custom card list screen : add an option to show only cards emitted by current user entities