### PR TITLE
Solve issue : Custom screen menu shall be bold and underline if selected (#8462)

### DIFF
--- a/ui/main/src/app/views/navbar/NavbarMenuView.ts
+++ b/ui/main/src/app/views/navbar/NavbarMenuView.ts
@@ -161,10 +161,18 @@ export class NavbarMenuView {
             .pipe(takeUntil(this.destroy$))
             .subscribe((route) => {
                 const currentRouteWithoutParams = route.split('?')[0];
-                if (currentRouteWithoutParams.split('/')[1] === 'businessconfigparty')
+                if (
+                    currentRouteWithoutParams.split('/')[1] === 'businessconfigparty' ||
+                    currentRouteWithoutParams.split('/')[1] === 'customscreen'
+                ) {
                     func(currentRouteWithoutParams.split('/')[2]);
-                else if (currentRouteWithoutParams === '/') func('feed');
-                else func(currentRouteWithoutParams.split('/')[1]);
+                    return;
+                }
+                if (currentRouteWithoutParams === '/') {
+                    func('feed');
+                    return;
+                }
+                func(currentRouteWithoutParams.split('/')[1]);
             });
     }
 


### PR DESCRIPTION
Can be tested by for example adding in ui_menu.json 
```

 {                                                  
     "id": "menu2b",                                
     "label": "title.multi",                        
     "entries": [                                   
         {                                          
             "customMenuId": "uid_test_0",          
             "customScreenId": "testId",            
             "label": "entry.custom"                
         }]                                         
 },                                                 

```


- In release notes :
  -  In chapter :  Bugs 
  -  Text : #8462   Custom screen menu shall be bold and underline if selected 