### PR TITLE
Dashboard: show process even if only processCustomLinks visibles for user (#8485)

### DIFF
--- a/ui/main/src/app/views/dashboard/DashboardView.spec.ts
+++ b/ui/main/src/app/views/dashboard/DashboardView.spec.ts
@@ -55,6 +55,12 @@ describe('Dashboard', () => {
                     ['state3', {name: 'State 3'}],
                     ['childState', {name: 'child state', isOnlyAChildState: true}]
                 ])
+            },
+            {
+                id: 'processWithOnlyChildState',
+                version: 'v3',
+                name: 'process with only child state',
+                states: new Map<string, State>([['state1', {name: 'Child state', isOnlyAChildState: true}]])
             }
         ]);
     }
@@ -142,6 +148,73 @@ describe('Dashboard', () => {
         expect(result.processes[0].customScreenLinks[0].customScreenId).toEqual('testId');
         expect(result.processes[0].customScreenLinks[1].label).toEqual('My Link 2');
         expect(result.processes[0].customScreenLinks[1].customScreenId).toEqual('testId2');
+    });
+
+    // Special case: sometimes we want to show custom screen links even if there is no process state visible to the user.
+    // However, these links should still be displayed based on the user's permissions.
+    //
+    // To achieve this, we use a workaround: we add a process with a single child state that is not visible to the user.
+    // This process includes custom screen links in its configuration, and we control link visibility by defining access rights for the user to the child state.
+    //
+    // The two following tests verify that this behavior works as intended.
+
+    it('GIVEN a process with custom screen links in config and only a state with isOnlyAChildState = true  WHEN get dashboard THEN dashboard contains links', async () => {
+        await loadWebUIConf({
+            dashboard: {
+                processCustomLinks: [
+                    {
+                        processId: 'processWithOnlyChildState',
+                        customLinks: [
+                            {
+                                customScreenId: 'testId',
+                                label: 'My link'
+                            },
+                            {
+                                customScreenId: 'testId2',
+                                label: 'My Link 2'
+                            }
+                        ]
+                    }
+                ]
+            }
+        });
+
+        await initProcesses();
+
+        const computedPerimeters = [
+            new ComputedPerimeter('processWithOnlyChildState', 'state1', RightEnum.Receive, true)
+        ];
+
+        const userWithPerimeters = new UserWithPerimeters(null, computedPerimeters, null, new Map());
+        await setUserPerimeter(userWithPerimeters);
+
+        dashboard = new Dashboard();
+
+        const result = await firstValueFrom(dashboard.getDashboardPage());
+        expect(result.processes[0].id).toEqual('processWithOnlyChildState');
+        expect(result.processes[0].name).toEqual('process with only child state');
+        expect(result.processes[0].customScreenLinks[0].label).toEqual('My link');
+        expect(result.processes[0].customScreenLinks[0].customScreenId).toEqual('testId');
+        expect(result.processes[0].customScreenLinks[1].label).toEqual('My Link 2');
+        expect(result.processes[0].customScreenLinks[1].customScreenId).toEqual('testId2');
+    });
+
+    it('Given a process with no custom screen links and only a state with isOnlyAChildState = true  WHEN get dashboard THEN dashboard contains no process', async () => {
+        await loadWebUIConf({
+            dashboard: {
+                processCustomLinks: []
+            }
+        });
+        await initProcesses();
+        const computedPerimeters = [
+            new ComputedPerimeter('processWithOnlyChildState', 'state1', RightEnum.Receive, true)
+        ];
+
+        const userWithPerimeters = new UserWithPerimeters(null, computedPerimeters, null, new Map());
+        await setUserPerimeter(userWithPerimeters);
+        dashboard = new Dashboard();
+        const result = await firstValueFrom(dashboard.getDashboardPage());
+        expect(result.processes.length).toEqual(0);
     });
 
     it('GIVEN a process list and a restricted user perimeter WHEN get dashboard THEN dashboard contains restricted processes ', async () => {

--- a/ui/main/src/app/views/dashboard/DashboardView.ts
+++ b/ui/main/src/app/views/dashboard/DashboardView.ts
@@ -46,23 +46,27 @@ export class Dashboard {
         this.dashboardPage.processes = new Array();
         ProcessesService.getAllProcesses().forEach((process) => {
             const statesContent = new Array<StateContent>();
+            let hasChildstate = false;
             process.states.forEach((state, key) => {
                 if (
                     UsersService.isReceiveRightsForProcessAndState(process.id, key) &&
-                    this.isStateNotified(process.id, key) &&
-                    !state.isOnlyAChildState
+                    this.isStateNotified(process.id, key)
                 ) {
-                    const stateContent = new StateContent();
-                    stateContent.id = key;
-                    stateContent.circles = new Array();
-                    stateContent.name = state.name;
+                    if (state.isOnlyAChildState) {
+                        hasChildstate = true;
+                    } else {
+                        const stateContent = new StateContent();
+                        stateContent.id = key;
+                        stateContent.circles = new Array();
+                        stateContent.name = state.name;
 
-                    const circle = new DashboardCircle();
-                    circle.color = this.noSeverityColor;
-                    circle.numberOfCards = 0;
-                    circle.width = 10;
-                    stateContent.circles.push(circle);
-                    statesContent.push(stateContent);
+                        const circle = new DashboardCircle();
+                        circle.color = this.noSeverityColor;
+                        circle.numberOfCards = 0;
+                        circle.width = 10;
+                        stateContent.circles.push(circle);
+                        statesContent.push(stateContent);
+                    }
                 }
             });
             const processContent = new ProcessContent();
@@ -72,7 +76,10 @@ export class Dashboard {
             processContent.states = statesContent;
             this.addCustomScreenLinks(processContent);
 
-            if (processContent.states.length > 0) this.dashboardPage.processes.push(processContent);
+            // Show the process if it has visible states,
+            // or if it only has only child states but includes custom screen links (Special case: we want to show custom screen links even if there are no visible states)
+            if (processContent.states.length > 0 || (hasChildstate && processContent.customScreenLinks?.length > 0))
+                this.dashboardPage.processes.push(processContent);
         });
         this.dashboardPage.processes.sort((obj1, obj2) => Utilities.compareObj(obj1.name, obj2.name));
     }


### PR DESCRIPTION
To test : set all states to isOnlyChildState to true in config.json of defaultProcess

In release notes : 
  -  In chapter : Features
 -  #8485 : Dashboard: show process even if only processCustomLinks visibles for user 

