### PR TITLE
Move css property box-sizing from styles.scss to opfab-application.css (#8387)

### DIFF
--- a/ui/main/src/scss/styles.scss
+++ b/ui/main/src/scss/styles.scss
@@ -11,9 +11,6 @@
 /* You can add global styles to this file, and also import other style files */
 @use '../../node_modules/ag-grid-community/styles' as ag;
 
-*, ::after, ::before {
-  box-sizing: border-box;
-}
 
 p {
   margin-top: 0;

--- a/ui/main/src/shared/css/opfab-application.css
+++ b/ui/main/src/shared/css/opfab-application.css
@@ -174,6 +174,10 @@
     font-display: swap;
 }
 
+*, ::after, ::before {
+  box-sizing: border-box;
+}
+
 /* Global colors */
 
 .opfab-colors {


### PR DESCRIPTION

This is necessary for opfab input design in external applications

Nothing in release note