### PR TITLE
Solve issue  : Realtime screen - with option onlyDisplayUsersInGroups users with firstname and lastname are not visible

### DIFF
--- a/ui/main/src/app/views/realtimeusers/RealtimeUsersView.spec.ts
+++ b/ui/main/src/app/views/realtimeusers/RealtimeUsersView.spec.ts
@@ -37,7 +37,14 @@ describe('Realtimeusers', () => {
             {login: 'user1', entitiesConnected: ['ENTITY1_FR', 'ENTITY1_NL'], groups: ['group1']},
             {login: 'user2', entitiesConnected: ['ENTITY1_FR', 'ENTITY1_NL'], groups: ['group2']},
             {login: 'user3', entitiesConnected: ['ENTITY1_NL'], groups: ['group2', 'group3']},
-            {login: 'user4'}
+            {login: 'user4'},
+            {
+                login: 'userWithLastAndFirstName',
+                firstName: 'firstName',
+                lastName: 'lastName',
+                entitiesConnected: ['ENTITY1_IT'],
+                groups: ['group3']
+            }
         ];
         usersServerMock.setResponseForConnectedUsers(new ServerResponse(connectedUsers, ServerResponseStatus.OK, null));
 
@@ -155,19 +162,14 @@ describe('Realtimeusers', () => {
         expect(page.currentScreen.columns[1].entityPages[0].lines[0].connectedUsers).toEqual('user1, user2');
     });
 
-    it('If a user with first name and last name connects, they should be displayed instead of his login', () => {
-        expect(page.currentScreen.columns[1].entityPages[0].lines[0].connectedUsersCount).toEqual(1);
-        expect(page.currentScreen.columns[1].entityPages[0].lines[0].connectedUsers).toEqual('user1');
-
-        const connectedUsers = [
-            {login: 'user1', entitiesConnected: ['IT_SUPERVISOR_ENTITY']},
-            {login: 'user2', firstName: 'John', lastName: 'Smith', entitiesConnected: ['IT_SUPERVISOR_ENTITY']}
-        ];
-        usersServerMock.setResponseForConnectedUsers(new ServerResponse(connectedUsers, ServerResponseStatus.OK, null));
-
-        clock.tick(2500);
-        expect(page.currentScreen.columns[1].entityPages[0].lines[0].connectedUsersCount).toEqual(2);
-        expect(page.currentScreen.columns[1].entityPages[0].lines[0].connectedUsers).toEqual('user1, John Smith');
+    it('If a user with first name and last name connects, it should be displayed instead of his login', () => {
+        // userWithLastAndFirstName in ENTITY1_IT
+        expect(page.currentScreen.columns[0].entityPages[1].lines[0].connectedUsers).toEqual('firstName lastName');
+    });
+    it('If a user member of a group in onlyDisplayUsersInGroups with first name and last name connects, it should be displayed instead of his login', () => {
+        // userWithLastAndFirstName in ENTITY1_IT
+        view.setSelectedScreen('2');
+        expect(page.currentScreen.columns[0].entityPages[0].lines[0].connectedUsers).toEqual('firstName lastName');
     });
 
     const realtimeScreensTestConfig = {
@@ -196,6 +198,7 @@ describe('Realtimeusers', () => {
             },
             {
                 screenName: 'Italian Control Centers',
+                onlyDisplayUsersInGroups: ['group3'],
                 screenColumns: [
                     {
                         entitiesGroups: ['ENTITY_IT']

--- a/ui/main/src/app/views/realtimeusers/RealtimeUsersView.ts
+++ b/ui/main/src/app/views/realtimeusers/RealtimeUsersView.ts
@@ -30,6 +30,7 @@ export class RealtimeUsersView {
     private readonly connectedUsersGroups: Map<string, string[]> = new Map<string, string[]>();
     private readonly pageLoaded = new ReplaySubject<RealtimePage>(1);
     private updateInterval;
+    private readonly userNameToDisplay = new Map<string, string>();
 
     constructor(private readonly configServer: ConfigServer) {
         this.init();
@@ -87,25 +88,26 @@ export class RealtimeUsersView {
     }
 
     private updateConnectedUsers() {
-        let connectedUserName = '';
-
         UsersService.loadConnectedUsers().subscribe((connectedUsers) => {
             this.connectedUsersPerEntity.clear();
+            this.userNameToDisplay.clear();
 
             connectedUsers.forEach((connectedUser) => {
                 if (connectedUser.entitiesConnected) {
+                    if (connectedUser.firstName && connectedUser.lastName) {
+                        this.userNameToDisplay.set(
+                            connectedUser.login,
+                            connectedUser.firstName + ' ' + connectedUser.lastName
+                        );
+                    } else {
+                        this.userNameToDisplay.set(connectedUser.login, connectedUser.login);
+                    }
                     this.connectedUsersGroups.set(connectedUser.login, connectedUser.groups ?? []);
                     connectedUser.entitiesConnected.forEach((entityConnected) => {
                         const connectedUsersToEntity = this.connectedUsersPerEntity.get(entityConnected) ?? [];
 
-                        if (connectedUser.firstName && connectedUser.lastName) {
-                            connectedUserName = connectedUser.firstName + ' ' + connectedUser.lastName;
-                        } else {
-                            connectedUserName = connectedUser.login;
-                        }
-
-                        if (!connectedUsersToEntity.includes(connectedUserName)) {
-                            connectedUsersToEntity.push(connectedUserName);
+                        if (!connectedUsersToEntity.includes(connectedUser.login)) {
+                            connectedUsersToEntity.push(connectedUser.login);
                             this.connectedUsersPerEntity.set(entityConnected, connectedUsersToEntity);
                         }
                     });
@@ -124,8 +126,13 @@ export class RealtimeUsersView {
                             line.entityId,
                             screen.onlyDisplayUsersInGroups
                         );
+
                         line.connectedUsersCount = connectedUsers.length;
-                        line.connectedUsers = connectedUsers.join(', ');
+                        line.connectedUsers = connectedUsers
+                            .map((user) => {
+                                return this.userNameToDisplay.get(user) ?? user;
+                            })
+                            .join(', ');
                     });
                 });
             });


### PR DESCRIPTION

- In release notes :
  -  In chapter :  Bugs 
  -  Text : #8637 Realtime screen - with option onlyDisplayUsersInGroups users with firstname and lastname are not visible