### PR TITLE
Rename email field in object userWithPerimeter to emailForCardSending (#8643)

### DIFF
--- a/node-services/cards-external-diffusion/src/domain/application/realTimeCardsDiffusionControl.ts
+++ b/node-services/cards-external-diffusion/src/domain/application/realTimeCardsDiffusionControl.ts
@@ -114,13 +114,13 @@ export default class RealTimeCardsDiffusionControl extends CardsDiffusionControl
                     'Email setting enabled for ' +
                         userWithPerimeters.userData.login +
                         ' with mail ' +
-                        userWithPerimeters.email
+                        userWithPerimeters.emailForCardSending
                 );
                 const cardsForUser: Card[] = await this.getCardsForUser(cards, userWithPerimeters);
                 for (const cardForUser of cardsForUser) {
                     await this.sendCardIfAllowed(
                         cardForUser,
-                        userWithPerimeters.email,
+                        userWithPerimeters.emailForCardSending,
                         emailToPlainText,
                         timezoneForEmails
                     );
@@ -168,7 +168,7 @@ export default class RealTimeCardsDiffusionControl extends CardsDiffusionControl
     }
 
     isEmailSettingEnabled(userWithPerimeters: any): boolean {
-        return userWithPerimeters.sendCardsByEmail === true && userWithPerimeters.email;
+        return userWithPerimeters.sendCardsByEmail === true && userWithPerimeters.emailForCardSending;
     }
 
     async sendMail(card: Card, to: string, emailToPlainText: boolean, timezoneForEmails: string): Promise<void> {

--- a/node-services/cards-external-diffusion/src/domain/application/recapCardsDiffusionControl.ts
+++ b/node-services/cards-external-diffusion/src/domain/application/recapCardsDiffusionControl.ts
@@ -86,7 +86,7 @@ export default class RecapCardsDiffusionControl extends CardsDiffusionControl {
                         if (mode === 'daily' && userWithPerimeters.sendDailyEmail) {
                             await this.sendEmailRecap(
                                 visibleCards,
-                                userWithPerimeters.email,
+                                userWithPerimeters.emailForCardSending,
                                 emailToPlainText,
                                 this.dailyEmailTitle,
                                 this.dailyEmailBodyPrefix,
@@ -96,7 +96,7 @@ export default class RecapCardsDiffusionControl extends CardsDiffusionControl {
                         } else if (mode === 'weekly' && userWithPerimeters.sendWeeklyEmail) {
                             await this.sendEmailRecap(
                                 visibleCards,
-                                userWithPerimeters.email,
+                                userWithPerimeters.emailForCardSending,
                                 emailToPlainText,
                                 this.weeklyEmailTitle,
                                 this.weeklyEmailBodyPrefix,

--- a/node-services/cards-external-diffusion/src/domain/application/userWithPerimeter.ts
+++ b/node-services/cards-external-diffusion/src/domain/application/userWithPerimeter.ts
@@ -1,4 +1,4 @@
-/* Copyright (c) 2024, RTE (http://www.rte-france.com)
+/* Copyright (c) 2024-2025, RTE (http://www.rte-france.com)
  * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -10,7 +10,7 @@
 export class UserWithPerimeters {
     readonly sendDailyEmail?: true;
     readonly sendWeeklyEmail?: true;
-    readonly email?: string;
+    readonly emailForCardSending?: string;
     readonly timezoneForEmails?: string;
     readonly userData: UserData;
     readonly processesStatesNotNotified?: any;

--- a/node-services/cards-external-diffusion/src/tests/cardRoutingUtilities.test.ts
+++ b/node-services/cards-external-diffusion/src/tests/cardRoutingUtilities.test.ts
@@ -1,4 +1,4 @@
-/* Copyright (c) 2023-2024, RTE (http://www.rte-france.com)
+/* Copyright (c) 2023-2025, RTE (http://www.rte-france.com)
  * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -33,14 +33,14 @@ describe('Card routing', function () {
 
     const currentUserWithReceiveAndWriteRight = {
         userData: user,
-        email: 'test@opfab.com',
+        emailForCardSending: 'test@opfab.com',
         processesStatesNotifiedByEmail: {defaultProcess: ['processState']},
         computedPerimeters: perimetersWithReceiveAndWriteRight
     };
 
     const currentUserWithReceiveRight = {
         userData: user,
-        email: 'test@opfab.com',
+        emailForCardSending: 'test@opfab.com',
         processesStatesNotifiedByEmail: {defaultProcess: ['processState']},
         computedPerimeters: perimetersWithReceiveRight
     };
@@ -311,14 +311,14 @@ describe('Card routing', function () {
 
         const currentUserWithReceiveAndWriteRightNoMailForProcessState = {
             userData: user,
-            email: 'test@opfab.com',
+            emailForCardSending: 'test@opfab.com',
             processesStatesNotifiedByEmail: {defaultProcess: ['messageState']},
             computedPerimeters: perimetersWithReceiveAndWriteRight
         };
 
         const currentUserWithReceiveRightNoMailForProcessState = {
             userData: user,
-            email: 'test@opfab.com',
+            emailForCardSending: 'test@opfab.com',
             processesStatesNotifiedByEmail: {defaultProcess: ['messageState']},
             computedPerimeters: perimetersWithReceiveRight
         };
@@ -347,14 +347,14 @@ describe('Card routing', function () {
 
         const currentUserWithReceiveAndWriteRightWithFilteringNotification = {
             userData: user,
-            email: 'test@opfab.com',
+            emailForCardSending: 'test@opfab.com',
             processesStatesNotifiedByEmail: {defaultProcess: ['processState']},
             processesStatesNotNotified: {defaultProcess: ['processState']},
             computedPerimeters: perimetersWithReceiveAndWriteRight
         };
         const currentUserWithReceiveRightWithFilteringNotification = {
             userData: user,
-            email: 'test@opfab.com',
+            emailForCardSending: 'test@opfab.com',
             processesStatesNotifiedByEmail: {defaultProcess: ['processState']},
             processesStatesNotNotified: {defaultProcess: ['processState']},
             computedPerimeters: perimetersWithReceiveRight
@@ -362,14 +362,14 @@ describe('Card routing', function () {
 
         const currentUserWithReceiveAndWriteRightWithFilteringNotificationNotForProcessState = {
             userData: user,
-            email: 'test@opfab.com',
+            emailForCardSending: 'test@opfab.com',
             processesStatesNotifiedByEmail: {defaultProcess: ['processState']},
             processesStatesNotNotified: {defaultProcess: ['otherState']},
             computedPerimeters: perimetersWithReceiveAndWriteRight
         };
         const currentUserWithReceiveRightWithFilteringNotificationNotForProcessState = {
             userData: user,
-            email: 'test@opfab.com',
+            emailForCardSending: 'test@opfab.com',
             processesStatesNotifiedByEmail: {defaultProcess: ['processState']},
             processesStatesNotNotified: {defaultProcess: ['otherState']},
             computedPerimeters: perimetersWithReceiveRight

--- a/node-services/cards-external-diffusion/src/tests/realTimeCardsDiffusionControl.test.ts
+++ b/node-services/cards-external-diffusion/src/tests/realTimeCardsDiffusionControl.test.ts
@@ -76,7 +76,7 @@ describe('Cards external diffusion', function () {
             {
                 userData: {login: 'operator_2', entities: ['ENTITY1', 'ENTITY2']},
                 sendCardsByEmail: true,
-                email: 'operator_2@opfab.com',
+                emailForCardSending: 'operator_2@opfab.com',
                 processesStatesNotifiedByEmail: {defaultProcess: ['processState']},
                 computedPerimeters: perimeters
             }
@@ -120,7 +120,7 @@ describe('Cards external diffusion', function () {
             {
                 userData: {login: 'operator_1', entities: ['ENTITY1']},
                 sendCardsByEmail: true,
-                email: 'operator_1@opfab.com',
+                emailForCardSending: 'operator_1@opfab.com',
                 processesStatesNotifiedByEmail: {defaultProcess: ['processState']},
                 computedPerimeters: perimeters
             }
@@ -178,7 +178,7 @@ describe('Cards external diffusion', function () {
             {
                 userData: {login: 'operator_1', entities: ['ENTITY1']},
                 sendCardsByEmail: true,
-                email: 'operator_1@opfab.com',
+                emailForCardSending: 'operator_1@opfab.com',
                 processesStatesNotifiedByEmail: {defaultProcess: ['processState']},
                 computedPerimeters: perimeters
             }
@@ -237,7 +237,7 @@ describe('Cards external diffusion', function () {
             {
                 userData: {login: 'operator_1', entities: ['ENTITY1']},
                 sendCardsByEmail: true,
-                email: 'operator_1@opfab.com',
+                emailForCardSending: 'operator_1@opfab.com',
                 processesStatesNotifiedByEmail: {defaultProcess: ['processState']},
                 computedPerimeters: perimeters
             }
@@ -295,7 +295,7 @@ describe('Cards external diffusion', function () {
             {
                 userData: {login: 'operator_1', entities: ['ENTITY1']},
                 sendCardsByEmail: true,
-                email: 'operator_1@opfab.com',
+                emailForCardSending: 'operator_1@opfab.com',
                 processesStatesNotifiedByEmail: {defaultProcess: ['processState']},
                 computedPerimeters: perimeters
             }
@@ -352,7 +352,7 @@ describe('Cards external diffusion', function () {
             {
                 userData: {login: 'operator_1', entities: ['ENTITY1']},
                 sendCardsByEmail: true,
-                email: 'operator_1@opfab.com',
+                emailForCardSending: 'operator_1@opfab.com',
                 processesStatesNotifiedByEmail: {defaultProcess: ['processState']},
                 computedPerimeters: perimeters
             }
@@ -408,7 +408,7 @@ describe('Cards external diffusion', function () {
             {
                 userData: {login: 'operator_2', entities: ['ENTITY1', 'ENTITY2']},
                 sendCardsByEmail: true,
-                email: 'operator_2@opfab.com',
+                emailForCardSending: 'operator_2@opfab.com',
                 processesStatesNotifiedByEmail: {defaultProcess: ['processState']},
                 computedPerimeters: perimeters
             }
@@ -446,7 +446,7 @@ describe('Cards external diffusion', function () {
             {
                 userData: {login: 'operator_2', entities: ['ENTITY1', 'ENTITY2']},
                 sendCardsByEmail: false,
-                email: 'operator_2@opfab.com',
+                emailForCardSending: 'operator_2@opfab.com',
                 processesStatesNotifiedByEmail: {defaultProcess: ['processState']},
                 computedPerimeters: perimeters
             }
@@ -481,7 +481,7 @@ describe('Cards external diffusion', function () {
         opfabServicesInterfaceStub.usersWithPerimeters = [
             {
                 userData: {login: 'operator_2', entities: ['ENTITY1', 'ENTITY2']},
-                email: 'operator_2@opfab.com',
+                emailForCardSending: 'operator_2@opfab.com',
                 processesStatesNotifiedByEmail: {defaultProcess: ['processState']},
                 computedPerimeters: perimeters
             }
@@ -552,7 +552,7 @@ describe('Cards external diffusion', function () {
             {
                 userData: {login: 'operator_2', entities: ['ENTITY1', 'ENTITY2']},
                 sendCardsByEmail: true,
-                email: '',
+                emailForCardSending: '',
                 processesStatesNotifiedByEmail: {defaultProcess: ['processState']},
                 computedPerimeters: perimeters
             }
@@ -591,14 +591,14 @@ describe('Cards external diffusion', function () {
             {
                 userData: {login: 'operator_1', entities: ['ENTITY1']},
                 sendCardsByEmail: true,
-                email: 'operator_1@opfab.com',
+                emailForCardSending: 'operator_1@opfab.com',
                 processesStatesNotifiedByEmail: {defaultProcess: ['processState']},
                 computedPerimeters: perimeters
             },
             {
                 userData: {login: 'operator_2', entities: ['ENTITY1', 'ENTITY2']},
                 sendCardsByEmail: true,
-                email: 'operator_2@opfab.com',
+                emailForCardSending: 'operator_2@opfab.com',
                 processesStatesNotifiedByEmail: {defaultProcess: ['processState']},
                 computedPerimeters: perimeters
             }
@@ -639,7 +639,7 @@ describe('Cards external diffusion', function () {
             {
                 userData: {login: 'operator_1', entities: ['ENTITY1']},
                 sendCardsByEmail: true,
-                email: 'operator_1@opfab.com',
+                emailForCardSending: 'operator_1@opfab.com',
                 processesStatesNotifiedByEmail: {defaultProcess: ['processState']},
                 computedPerimeters: perimeters
             }
@@ -693,7 +693,7 @@ describe('Cards external diffusion', function () {
             {
                 userData: {login: 'operator_1', entities: ['ENTITY1']},
                 sendCardsByEmail: true,
-                email: 'operator_1@opfab.com',
+                emailForCardSending: 'operator_1@opfab.com',
                 processesStatesNotifiedByEmail: {defaultProcess: ['processState']},
                 computedPerimeters: perimeters
             }

--- a/node-services/cards-external-diffusion/src/tests/recapCardsDiffusionControl.test.ts
+++ b/node-services/cards-external-diffusion/src/tests/recapCardsDiffusionControl.test.ts
@@ -83,13 +83,13 @@ describe('Cards external diffusion', function () {
             {
                 userData: {login: 'operator_1', entities: ['ENTITY1']},
                 sendDailyEmail: true,
-                email: 'operator_1@opfab.com',
+                emailForCardSending: 'operator_1@opfab.com',
                 computedPerimeters: perimeters
             },
             {
                 userData: {login: 'operator_2', entities: ['ENTITY1', 'ENTITY2']},
                 sendDailyEmail: true,
-                email: 'operator_2@opfab.com',
+                emailForCardSending: 'operator_2@opfab.com',
                 processesStatesNotifiedByEmail: {defaultProcess: ['processState']},
                 computedPerimeters: perimeters
             }
@@ -124,13 +124,13 @@ describe('Cards external diffusion', function () {
             {
                 userData: {login: 'operator_1', entities: ['ENTITY1']},
                 sendWeeklyEmail: true,
-                email: 'operator_1@opfab.com',
+                emailForCardSending: 'operator_1@opfab.com',
                 computedPerimeters: perimeters
             },
             {
                 userData: {login: 'operator_2', entities: ['ENTITY1', 'ENTITY2']},
                 sendWeeklyEmail: true,
-                email: 'operator_2@opfab.com',
+                emailForCardSending: 'operator_2@opfab.com',
                 processesStatesNotifiedByEmail: {defaultProcess: ['processState']},
                 computedPerimeters: perimeters
             }
@@ -165,14 +165,14 @@ describe('Cards external diffusion', function () {
             {
                 userData: {login: 'operator_1', entities: ['ENTITY1']},
                 sendCardsByEmail: true,
-                email: 'operator_1@opfab.com',
+                emailForCardSending: 'operator_1@opfab.com',
                 computedPerimeters: perimeters
             },
             {
                 userData: {login: 'operator_2', entities: ['ENTITY1', 'ENTITY2']},
                 sendCardsByEmail: true,
                 sendDailyEmail: true,
-                email: 'operator_2@opfab.com',
+                emailForCardSending: 'operator_2@opfab.com',
                 processesStatesNotifiedByEmail: {defaultProcess: ['processState']},
                 computedPerimeters: perimeters
             }
@@ -232,14 +232,14 @@ describe('Cards external diffusion', function () {
             {
                 userData: {login: 'operator_1', entities: ['ENTITY1']},
                 sendCardsByEmail: true,
-                email: 'operator_1@opfab.com',
+                emailForCardSending: 'operator_1@opfab.com',
                 computedPerimeters: perimeters
             },
             {
                 userData: {login: 'operator_2', entities: ['ENTITY1', 'ENTITY2']},
                 sendCardsByEmail: true,
                 sendDailyEmail: true,
-                email: 'operator_2@opfab.com',
+                emailForCardSending: 'operator_2@opfab.com',
                 processesStatesNotifiedByEmail: {defaultProcess: ['processState']},
                 computedPerimeters: perimeters
             }
@@ -302,14 +302,14 @@ describe('Cards external diffusion', function () {
             {
                 userData: {login: 'operator_1', entities: ['ENTITY1']},
                 sendCardsByEmail: true,
-                email: 'operator_1@opfab.com',
+                emailForCardSending: 'operator_1@opfab.com',
                 computedPerimeters: perimeters
             },
             {
                 userData: {login: 'operator_2', entities: ['ENTITY1', 'ENTITY2']},
                 sendCardsByEmail: true,
                 sendDailyEmail: true,
-                email: 'operator_2@opfab.com',
+                emailForCardSending: 'operator_2@opfab.com',
                 processesStatesNotifiedByEmail: {defaultProcess: ['processState']},
                 computedPerimeters: perimeters
             }
@@ -365,14 +365,14 @@ describe('Cards external diffusion', function () {
             {
                 userData: {login: 'operator_1', entities: ['ENTITY1']},
                 sendCardsByEmail: true,
-                email: 'operator_1@opfab.com',
+                emailForCardSending: 'operator_1@opfab.com',
                 computedPerimeters: perimeters
             },
             {
                 userData: {login: 'operator_2', entities: ['ENTITY1', 'ENTITY2']},
                 sendCardsByEmail: true,
                 sendDailyEmail: false,
-                email: 'operator_2@opfab.com',
+                emailForCardSending: 'operator_2@opfab.com',
                 processesStatesNotifiedByEmail: {defaultProcess: ['processState']},
                 computedPerimeters: perimeters
             }
@@ -409,13 +409,13 @@ describe('Cards external diffusion', function () {
             {
                 userData: {login: 'operator_1', entities: ['ENTITY1']},
                 sendCardsByEmail: true,
-                email: 'operator_1@opfab.com',
+                emailForCardSending: 'operator_1@opfab.com',
                 computedPerimeters: perimeters
             },
             {
                 userData: {login: 'operator_2', entities: ['ENTITY1', 'ENTITY2']},
                 sendCardsByEmail: true,
-                email: 'operator_2@opfab.com',
+                emailForCardSending: 'operator_2@opfab.com',
                 processesStatesNotifiedByEmail: {defaultProcess: ['processState']},
                 computedPerimeters: perimeters
             }
@@ -453,7 +453,7 @@ describe('Cards external diffusion', function () {
                 userData: {login: 'operator_1', entities: ['ENTITY1']},
                 sendCardsByEmail: true,
                 sendDailyEmail: true,
-                email: 'operator_1@opfab.com',
+                emailForCardSending: 'operator_1@opfab.com',
                 processesStatesNotifiedByEmail: {defaultProcess: ['processState']},
                 computedPerimeters: perimeters
             },
@@ -461,7 +461,7 @@ describe('Cards external diffusion', function () {
                 userData: {login: 'operator_2', entities: ['ENTITY1', 'ENTITY2']},
                 sendCardsByEmail: true,
                 sendDailyEmail: true,
-                email: 'operator_2@opfab.com',
+                emailForCardSending: 'operator_2@opfab.com',
                 processesStatesNotifiedByEmail: {defaultProcess: ['processState']},
                 computedPerimeters: perimeters
             }
@@ -500,13 +500,13 @@ describe('Cards external diffusion', function () {
             {
                 userData: {login: 'operator_1', entities: ['ENTITY1']},
                 sendCardsByEmail: true,
-                email: 'operator_1@opfab.com',
+                emailForCardSending: 'operator_1@opfab.com',
                 computedPerimeters: perimeters
             },
             {
                 userData: {login: 'operator_2', entities: ['ENTITY1', 'ENTITY2']},
                 sendCardsByEmail: true,
-                email: 'operator_2@opfab.com',
+                emailForCardSending: 'operator_2@opfab.com',
                 processesStatesNotifiedByEmail: {defaultProcess: ['processState']},
                 computedPerimeters: perimeters
             }
@@ -544,7 +544,7 @@ describe('Cards external diffusion', function () {
                 userData: {login: 'operator_1', entities: ['ENTITY1']},
                 sendCardsByEmail: true,
                 sendWeeklyEmail: true,
-                email: 'operator_1@opfab.com',
+                emailForCardSending: 'operator_1@opfab.com',
                 processesStatesNotifiedByEmail: {defaultProcess: ['processState']},
                 computedPerimeters: perimeters
             },
@@ -552,7 +552,7 @@ describe('Cards external diffusion', function () {
                 userData: {login: 'operator_2', entities: ['ENTITY1', 'ENTITY2']},
                 sendCardsByEmail: true,
                 sendWeeklyEmail: true,
-                email: 'operator_2@opfab.com',
+                emailForCardSending: 'operator_2@opfab.com',
                 processesStatesNotifiedByEmail: {defaultProcess: ['processState']},
                 computedPerimeters: perimeters
             }

--- a/services/users/src/main/java/org/opfab/users/model/CurrentUserWithPerimeters.java
+++ b/services/users/src/main/java/org/opfab/users/model/CurrentUserWithPerimeters.java
@@ -33,7 +33,7 @@ public class CurrentUserWithPerimeters {
     private Boolean emailToPlainText;
     private Boolean sendDailyEmail;
     private Boolean sendWeeklyEmail;
-    private String email;
+    private String emailForCardSending;
     private String timezoneForEmails;
 
     @Valid
@@ -87,12 +87,12 @@ public class CurrentUserWithPerimeters {
         this.sendWeeklyEmail = sendWeeklyEmail;
     }
 
-    public String getEmail() {
-        return email;
+    public String getEmailForCardSending() {
+        return emailForCardSending;
     }
 
-    public void setEmail(String email) {
-        this.email = email;
+    public void setEmailForCardSending(String emailForCardSending) {
+        this.emailForCardSending = emailForCardSending;
     }
 
     public String getTimezoneForEmails() {

--- a/services/users/src/main/java/org/opfab/users/services/CurrentUserWithPerimetersService.java
+++ b/services/users/src/main/java/org/opfab/users/services/CurrentUserWithPerimetersService.java
@@ -90,9 +90,9 @@ public class CurrentUserWithPerimetersService {
             userWithPerimeterData.setSendDailyEmail(operationResult.getResult().getSendDailyEmail());
             userWithPerimeterData.setSendWeeklyEmail(operationResult.getResult().getSendWeeklyEmail());
             if (this.getEmailFromUserInsteadOfSettings) {
-                userWithPerimeterData.setEmail(userData.getEmail() == null ? "" : userData.getEmail());
+                userWithPerimeterData.setEmailForCardSending(userData.getEmail() == null ? "" : userData.getEmail());
             } else {
-                userWithPerimeterData.setEmail(operationResult.getResult().getEmail());
+                userWithPerimeterData.setEmailForCardSending(operationResult.getResult().getEmail());
             }
             userWithPerimeterData.setTimezoneForEmails(operationResult.getResult().getTimezoneForEmails());
         }

--- a/services/users/src/main/modeling/swagger.yaml
+++ b/services/users/src/main/modeling/swagger.yaml
@@ -355,7 +355,7 @@ definitions:
         type: boolean
         description: |-
             If this is set to true, an email will be sent weekly with all the cards received during the week
-      email:
+      emailForCardSending:
         type: string
         description: Email address to use as recipient for email notifications
       timezoneForEmails:

--- a/ui/main/src/app/services/users/model/UserWithPerimeters.ts
+++ b/ui/main/src/app/services/users/model/UserWithPerimeters.ts
@@ -22,7 +22,7 @@ export class UserWithPerimeters {
         readonly emailToPlainText?: boolean,
         readonly sendDailyEmail?: boolean,
         readonly sendWeeklyEmail?: boolean,
-        readonly email?: string
+        readonly emailForCardSending?: string
     ) {}
 }
 

--- a/ui/main/src/app/views/notificationConfiguration/NotificationConfigurationView.ts
+++ b/ui/main/src/app/views/notificationConfiguration/NotificationConfigurationView.ts
@@ -67,7 +67,7 @@ export class NotificationConfigurationView {
     private isEmailFromUserInsteadOfSettingsAndFieldIsNotEmpty(): boolean {
         return (
             ConfigService.getConfigValue('settings.getEmailFromUserInsteadOfSettings', false) &&
-            UsersService.getCurrentUserWithPerimeters().email?.length > 0
+            UsersService.getCurrentUserWithPerimeters().emailForCardSending?.length > 0
         );
     }
 

--- a/ui/main/src/app/views/settings/SettingsView.ts
+++ b/ui/main/src/app/views/settings/SettingsView.ts
@@ -38,7 +38,7 @@ export class SettingsView {
 
             case 'email':
                 if (this.isEmailFromUserInsteadOfSettings()) {
-                    return UsersService.getCurrentUserWithPerimeters().email;
+                    return UsersService.getCurrentUserWithPerimeters().emailForCardSending;
                 } else {
                     return ConfigService.getConfigValue('settings.' + setting);
                 }


### PR DESCRIPTION
- In release notes :
  -  In chapter : Tasks
  -  Text : #8643 : Rename email field in object userWithPerimeter to emailForCardSending