### PR TITLE
Remove deprecated way of responding to opfab.currentCard.registerFunctionToGetUserResponse (#8002)

### DIFF
--- a/src/docs/asciidoc/resources/migration_guide_to_4.10.adoc
+++ b/src/docs/asciidoc/resources/migration_guide_to_4.10.adoc
@@ -1,0 +1,49 @@
+// Copyright (c) 2025 RTE (http://www.rte-france.com)
+// See AUTHORS.txt
+// This document is subject to the terms of the Creative Commons Attribution 4.0 International license.
+// If a copy of the license was not distributed with this
+// file, You can obtain one at https://creativecommons.org/licenses/by/4.0/.
+// SPDX-License-Identifier: CC-BY-4.0
+
+= Migration Guide from release 4.9.X to release 4.10.0
+
+== Response card in handlebars templates
+
+If this has not been done in a previous migration, the object that should be returned by
+the method registered via `opfab.currentCard.registerFunctionToGetUserResponse` is to be
+changed.
+
+Previously, the object was structured as follows:
+
+----
+{
+    valid: true/false,
+    errorMsg: string,
+    responseCardData: {},
+    responseState: string,
+    publisher: string,
+    actions: [string]
+}
+----
+
+Now, all elements related to the response card are encapsulated within a `responseCard` object:
+
+----
+{
+    valid: true/false,
+    errorMsg: string,
+    responseCard: {
+        data: {},
+        state: string,
+        publisher: string,
+        actions: [string]
+    }
+}
+----
+
+Note that the `responseState` field has been renamed to `state`.
+
+The old structure has been supported as a fallback for a limited time, now it is removed, so you have to update your
+code to use the new structure.
+
+

--- a/src/test/api/karate/businessconfig/resources/bundle_test_action/template/long-card.handlebars
+++ b/src/test/api/karate/businessconfig/resources/bundle_test_action/template/long-card.handlebars
@@ -1,4 +1,4 @@
-<!-- Copyright (c) 2021-2023, RTE (http://www.rte-france.com)              -->
+<!-- Copyright (c) 2021-2025, RTE (http://www.rte-france.com)              -->
 <!-- See AUTHORS.txt                                                       -->
 <!-- This Source Code Form is subject to the terms of the Mozilla Public   -->
 <!-- License, v. 2.0. If a copy of the MPL was not distributed with this   -->
@@ -71,7 +71,9 @@
     if (validateResponse(responseCardData.opfabOpinion[0])) {
       return {
         valid: true,
-        responseCardData: responseCardData
+        responseCard: {
+          data: responseCardData
+        }
       };
     } else {
       return {

--- a/src/test/api/karate/businessconfig/resources/bundle_test_action/template/template1.handlebars
+++ b/src/test/api/karate/businessconfig/resources/bundle_test_action/template/template1.handlebars
@@ -1,4 +1,4 @@
-<!-- Copyright (c) 2021-2023, RTE (http://www.rte-france.com)              -->
+<!-- Copyright (c) 2021-2025, RTE (http://www.rte-france.com)              -->
 <!-- See AUTHORS.txt                                                       -->
 <!-- This Source Code Form is subject to the terms of the Mozilla Public   -->
 <!-- License, v. 2.0. If a copy of the MPL was not distributed with this   -->
@@ -56,7 +56,9 @@
     if (validateResponse(responseCardData.opfabOpinion[0])) {
       return {
         valid: true,
-        responseCardData: responseCardData
+        responseCard: {
+          data: responseCardData
+        }
       };
     } else {
       return {

--- a/src/test/resources/bundles/conferenceAndITIncidentExample/template/incidentInProgress.handlebars
+++ b/src/test/resources/bundles/conferenceAndITIncidentExample/template/incidentInProgress.handlebars
@@ -148,7 +148,9 @@
 
                 return {
                     valid: true,
-                    responseCardData: responseCardData // keep the deprecated way for testing only
+                    responseCard: {
+                      data: responseCardData
+                    }
                 };
             });
         }

--- a/src/test/resources/bundles/messageOrQuestionExample/template/confirmation.handlebars
+++ b/src/test/resources/bundles/messageOrQuestionExample/template/confirmation.handlebars
@@ -89,12 +89,13 @@
                         confirm: confirm,
                         message: message
                     };
-                return { //keep deprecated format for testing only
+                return {
                     valid: true,
-                    publisher : publisher,
-                    responseCardData: responseCardData,
-                    actions: ['PROPAGATE_READ_ACK_TO_PARENT_CARD']
-
+                    responseCard: {
+                      data: responseCardData,
+                      actions: ['PROPAGATE_READ_ACK_TO_PARENT_CARD'],
+                      publisher : publisher
+                    }
                 };
 
             });

--- a/ui/main/src/app/services/templateGateway/CardTemplateGateway.ts
+++ b/ui/main/src/app/services/templateGateway/CardTemplateGateway.ts
@@ -102,34 +102,7 @@ export class CardTemplateGateway {
     }
 
     public static getUserResponseFromTemplate(emitter: string) {
-        const response = Utilities.cloneObj(CardTemplateGateway._functionToGetUserResponseFromTemplate(emitter));
-        return CardTemplateGateway.convertDeprecatedUserResponseDataIfNeeded(response);
-    }
-
-    private static convertDeprecatedUserResponseDataIfNeeded(response: any): any {
-        if (response.responseCard) return response;
-        response.responseCard = {};
-        if (response.responseCardData) {
-            logger.warn('card response : responseCardData is deprecated, please use responseCard.data instead');
-            response.responseCard.data = response.responseCardData;
-            response.responseCardData = undefined;
-        }
-        if (response.publisher) {
-            logger.warn('card response : publisher is deprecated, please use responseCard.publisher instead');
-            response.responseCard.publisher = response.publisher;
-            response.publisher = undefined;
-        }
-        if (response.responseState) {
-            logger.warn('card response : responseState is deprecated, please use responseCard.state instead');
-            response.responseCard.state = response.responseState;
-            response.responseState = undefined;
-        }
-        if (response.actions) {
-            logger.warn('card response : actions is deprecated, please use responseCard.actions instead');
-            response.responseCard.actions = response.actions;
-            response.actions = undefined;
-        }
-        return response;
+        return Utilities.cloneObj(CardTemplateGateway._functionToGetUserResponseFromTemplate(emitter));
     }
 
     public static hideLoadingSpinner() {


### PR DESCRIPTION
- In release notes :
  -  In chapter : Tasks
  -  Text : #8002 : Remove deprecated way of responding to opfab.currentCard.registerFunctionToGetUserResponse