### PR TITLE
Replace bitnami images with confluentinc for kafka and zookeeper (#8802)

### DIFF
--- a/config/docker-compose.yml
+++ b/config/docker-compose.yml
@@ -67,7 +67,13 @@ services:
     ports:
       - "2181:2181"
     environment:
-      ALLOW_ANONYMOUS_LOGIN: "yes"
+      ZOOKEEPER_CLIENT_PORT: "2181"
+      ZOOKEEPER_TICK_TIME: "2000"
+    healthcheck:
+      test: ["CMD-SHELL", "echo ruok | nc -w 1 localhost 2181 | grep imok"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
   kafka:
     image: confluentinc/cp-kafka:7.2.15
     ports:

--- a/config/docker-compose.yml
+++ b/config/docker-compose.yml
@@ -63,13 +63,13 @@ services:
       - 1025:1025
       - 8025:8025
   zookeeper:
-    image: bitnamilegacy/zookeeper:3
+    image: confluentinc/cp-zookeeper:7.2.15
     ports:
       - "2181:2181"
     environment:
       ALLOW_ANONYMOUS_LOGIN: "yes"
   kafka:
-    image: bitnamilegacy/kafka:3
+    image: confluentinc/cp-kafka:7.2.15
     ports:
       - "9092:9092"
     environment:


### PR DESCRIPTION
# PR Description

## Summary
Replaced legacy Bitnami Kafka/Zookeeper Docker images with Confluent’s actively maintained images.
This resolves issue #8802 

## Background

- Bitnami images used in our test setup are no longer maintained.
- Continuing to use them poses risks for security, compatibility, and future updates.

## Changes

- Updated `config/docker-compose.yml` to use:
     - `confluentinc/cp-kafka`
     - `confluentinc/cp-zookeeper`
- Verified compatibility with existing test scenarios.

## Impact

- No functional changes in application logic.
- Test infrastructure now uses supported images.
- Safer long-term maintenance and upgrades.

# Release Notes

## Features / Bugs / Tasks

- Task: Replace bitnami images with confluentinc for kafka and zookeeper (#8802)