### PR TITLE
Built in template task : should not be possibe to set empty time (#8712)

### DIFF
--- a/ui/main/src/app/builtInTemplates/task/usercard/TaskUserCardTemplate.ts
+++ b/ui/main/src/app/builtInTemplates/task/usercard/TaskUserCardTemplate.ts
@@ -559,6 +559,18 @@ export class TaskUserCardTemplate extends BaseUserCardTemplate {
         const bymonthday: number[] = [];
         let bysetpos: number[] = [];
 
+        if (
+            (<HTMLInputElement>document.getElementById('radioButtonMonthlyFreq')).checked === true ||
+            (<HTMLInputElement>document.getElementById('radioButtonDailyFreq')).checked === true
+        ) {
+            if (!time) {
+                return {
+                    valid: false,
+                    errorMsg: opfab.utils.getTranslation('builtInTemplate.taskUserCard.youMustProvideATime')
+                };
+            }
+        }
+
         if ((<HTMLInputElement>document.getElementById('radioButtonMonthlyFreq')).checked === true) {
             freq = 'MONTHLY';
             bymonth = this.fetchMonths();

--- a/ui/main/src/assets/i18n/en.json
+++ b/ui/main/src/assets/i18n/en.json
@@ -824,6 +824,7 @@
             "youMustProvideAtLeastOneNthDay": "You must provide at least one nth day.",
             "youMustProvideAtLeastOneWeekday": "You must provide at least one weekday.",
             "youMustProvideAtLeastOneMonth": "You must provide at least one month.",
+            "youMustProvideATime": "You must provide a time.",
             "the": "The"
         },
         "message-or-question-listCard": {

--- a/ui/main/src/assets/i18n/fr.json
+++ b/ui/main/src/assets/i18n/fr.json
@@ -825,6 +825,7 @@
             "youMustProvideAtLeastOneNthDay": "Vous devez fournir au moins un numéro de jour.",
             "youMustProvideAtLeastOneWeekday": "Vous devez fournir au moins un jour de la semaine.",
             "youMustProvideAtLeastOneMonth": "Vous devez fournir au moins un mois.",
+            "youMustProvideATime": "Vous devez fournir une heure.",
             "the": "Le"
         },
         "message-or-question-listCard": {

--- a/ui/main/src/assets/i18n/nl.json
+++ b/ui/main/src/assets/i18n/nl.json
@@ -824,6 +824,7 @@
             "youMustProvideAtLeastOneNthDay": "U dient minimaal één dagnummer op te geven.",
             "youMustProvideAtLeastOneWeekday": "U dient minimaal één dag van de week op te geven.",
             "youMustProvideAtLeastOneMonth": "U dient minimaal één maand op te geven.",
+            "youMustProvideATime": "U moet een tijd opgeven.",
             "the": "De"
         },
         "message-or-question-listCard": {


### PR DESCRIPTION
- In release notes :
  -  In chapter : Bugs
  -  Text : #8712 : Built in template task : should not be possibe to set empty time