### PR TITLE
Remove default rabbit password from services (#8899)

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -1,5 +1,7 @@
 This directory contains all the configuration files needed to start Opfab.
 
+This configuration is intended for testing and demonstration purposes only. It is not suitable for production environments, but can serve as a starting point to be adapted for production requirements.
+
 # Directory Structure
 
 ## services

--- a/config/docker-compose.yml
+++ b/config/docker-compose.yml
@@ -6,14 +6,15 @@ services:
       - "27017:27017"
     environment:
       MONGO_INITDB_ROOT_USERNAME: root
-      MONGO_INITDB_ROOT_PASSWORD: password
+      MONGO_INITDB_ROOT_PASSWORD: password   # !!! TO BE CHANGED THIS IS ONLY FOR TEST AND DEMONSTRATION !!! 
     volumes:
       - "./mongodump:/dump"
   rabbitmq:
     container_name: rabbit
     image: "lfeoperatorfabric/of-rabbitmq:SNAPSHOT"
     hostname: rabbit
-
+    environment: 
+      RABBITMQ_DEFAULT_PASS: for_test_only    # !!! TO BE CHANGED THIS IS ONLY FOR TEST AND DEMONSTRATION !!! 
 
 #  If you want to persist queue after rabbit docker container removal mount 
 #  a volume to store persistance data 
@@ -31,11 +32,6 @@ services:
        - "5672:5672"
 #      - "15672:15672"
 
-#    If you open the port, you must change default user and password as follow
-#    environment: 
-#    - RABBITMQ_DEFAULT_USER=default_user
-#    - RABBITMQ_DEFAULT_PASS=password
-
   keycloak:
     container_name: keycloak
     image: keycloak/keycloak:26.3
@@ -44,7 +40,7 @@ services:
       - KC_HTTP_PORT=89
       - KC_HEALTH_ENABLED=true
       - KC_METRICS_ENABLED=true
-      - KEYCLOAK_ADMIN=admin
+      - KEYCLOAK_ADMIN=admin # !!! TO BE CHANGED THIS IS ONLY FOR TEST AND DEMONSTRATION !!! 
       - KEYCLOAK_ADMIN_PASSWORD=admin
       - KC_HTTP_RELATIVE_PATH=/auth
     volumes:

--- a/config/services/cards-external-diffusion.yml
+++ b/config/services/cards-external-diffusion.yml
@@ -4,7 +4,7 @@ operatorfabric:
     port: 1025
     auth:
       user: guest
-      pass: guest
+      pass: guest # !!! TO BE CHANGED THIS IS ONLY FOR TEST AND DEMONSTRATION !!!
   cardsExternalDiffusion:
     defaultConfig:
       mailFrom: opfab@localhost.it

--- a/config/services/common-java.yml
+++ b/config/services/common-java.yml
@@ -4,8 +4,9 @@ operatorfabric:
     dataFields: ["keywords", "nested.field","comment","reason"]
   rabbitmq:
     host: localhost
+    password: for_test_only # !!! TO BE CHANGED THIS IS ONLY FOR TEST AND DEMONSTRATION !!!
   mongodb:
-    uri: mongodb://root:password@localhost:27017/operator-fabric?authSource=admin
+    uri: mongodb://root:password@localhost:27017/operator-fabric?authSource=admin # !!! TO BE CHANGED THIS IS ONLY FOR TEST AND DEMONSTRATION !!!
   servicesUrls:
     users: "http://localhost:2103"
     businessconfig: "http://localhost:2100"

--- a/config/services/common.yml
+++ b/config/services/common.yml
@@ -6,18 +6,17 @@ management:
         include: '*'
 
 operatorfabric:
-  # rabbitmq:
-    # host: rabbitmq
-    # SECURITY WARNING : To set and change in production if rabbit port is open outside of docker network
-    # username: guest
-    # password: guest
+  rabbitmq:
+    host: rabbitmq
+    username: guest
+    password: for_test_only # !!! TO BE CHANGED THIS IS ONLY FOR TEST AND DEMONSTRATION !!!
   customscreen:
     dataFields: ["keywords", "nested.field","comment","reason"]
   mongodb:
-    uri: mongodb://root:password@mongodb:27017/operator-fabric?authSource=admin
+    uri: mongodb://root:password@mongodb:27017/operator-fabric?authSource=admin # !!! TO BE CHANGED THIS IS ONLY FOR TEST AND DEMONSTRATION !!!
   internalAccount:
     login: opfab
-    password: test
+    password: test # !!! TO BE CHANGED THIS IS ONLY FOR TEST AND DEMONSTRATION !!!
   security:
     oauth2:
       resourceserver:

--- a/config/web-ui/nginx-dev.conf.template
+++ b/config/web-ui/nginx-dev.conf.template
@@ -16,7 +16,7 @@ server {
   # Realm associated to OperatorFabric within the Authentication provider
   set $OperatorFabricRealm "dev";
   # base64 encoded pair of authentication in the form of 'client-id:secret-id'
-  set $ClientPairOFAuthentication "b3BmYWItY2xpZW50Om9wZmFiLWtleWNsb2FrLXNlY3JldA==" ;
+  set $ClientPairOFAuthentication "b3BmYWItY2xpZW50Om9wZmFiLWtleWNsb2FrLXNlY3JldA==" ; # !!! TO BE CHANGED THIS IS ONLY FOR TEST AND DEMONSTRATION !!!
   ### CUSTOMIZATION - END
   set $BasicValue "Basic $ClientPairOFAuthentication";
   set $KeycloakOpenIdConnect $KeycloakBaseUrl/auth/realms/$OperatorFabricRealm/protocol/openid-connect;

--- a/config/web-ui/nginx-prod.conf
+++ b/config/web-ui/nginx-prod.conf
@@ -17,7 +17,7 @@ server {
   # Realm associated to OperatorFabric within the Authentication provider
   set $OperatorFabricRealm "dev";
   # base64 encoded pair of authentication in the form of 'client-id:secret-id'
-  set $ClientPairOFAuthentication "b3BmYWItY2xpZW50Om9wZmFiLWtleWNsb2FrLXNlY3JldA==" ;
+  set $ClientPairOFAuthentication "b3BmYWItY2xpZW50Om9wZmFiLWtleWNsb2FrLXNlY3JldA==" ; # !!! TO BE CHANGED THIS IS ONLY FOR TEST AND DEMONSTRATION !!!
  
   ### CUSTOMIZATION - END
 

--- a/node-services/cards-external-diffusion/config/default-docker.yml
+++ b/node-services/cards-external-diffusion/config/default-docker.yml
@@ -4,7 +4,6 @@ operatorfabric:
     host: rabbitmq
     port: 5672
     username: guest
-    password: guest
   mongodb:
     database: "operator-fabric"
   servicesUrls:

--- a/node-services/cards-external-diffusion/config/default.yml
+++ b/node-services/cards-external-diffusion/config/default.yml
@@ -10,10 +10,10 @@ operatorfabric:
     host: localhost
     port: 5672
     username: guest
-    password: guest
+    password: for_test_only #use for test environment only
   mongodb:
     database: "operator-fabric"
-    uri: "mongodb://root:password@localhost:27017/operator-fabric?authSource=admin"
+    uri: "mongodb://root:password@localhost:27017/operator-fabric?authSource=admin" #use for test environment only
   servicesUrls:
     authToken: "http://127.0.0.1:2002/auth/token"
     users: "http://127.0.0.1:2103"
@@ -21,7 +21,7 @@ operatorfabric:
     businessconfig: "http://127.0.0.1:2100"
   internalAccount:
     login: opfab
-    password: test
+    password: test # use for test environment only
   logConfig:
     logFolder: logs/
     logFile: "%DATE%.log"
@@ -31,7 +31,7 @@ operatorfabric:
     port: 1025
     auth:
       user: guest
-      pass: guest
+      pass: guest # use for test environment only
   cardsExternalDiffusion:
     adminPort: 2106
     activeOnStartup: true

--- a/node-services/cards-reminder/config/default-docker.yml
+++ b/node-services/cards-reminder/config/default-docker.yml
@@ -4,7 +4,6 @@ operatorfabric:
     host: "rabbitmq"
     port: 5672
     username: "guest"
-    password: "guest"
   mongodb:
     database: "operator-fabric"
   servicesUrls:

--- a/node-services/cards-reminder/config/default.yml
+++ b/node-services/cards-reminder/config/default.yml
@@ -11,17 +11,17 @@ operatorfabric:
     host: "localhost"
     port: 5672
     username: "guest"
-    password: "guest"
+    password: "for_test_only" #use for test environment only
   mongodb:
     database: "operator-fabric"
-    uri: "mongodb://root:password@localhost:27017/operator-fabric?authSource=admin"
+    uri: "mongodb://root:password@localhost:27017/operator-fabric?authSource=admin" #use for test environment only
   servicesUrls:
     authToken: "http://127.0.0.1:2002/auth/token"
     users: "http://127.0.0.1:2103"
     cardsPublication: "http://127.0.0.1:2102"
   internalAccount:
     login: opfab
-    password: test
+    password: test # use for test environment only
   logConfig:
     logFolder: "logs/"
     logFile: "%DATE%.log"

--- a/node-services/supervisor/config/default.yml
+++ b/node-services/supervisor/config/default.yml
@@ -8,7 +8,7 @@ operatorfabric:
       login-claim: preferred_username
   mongodb:
     database: "operator-fabric"
-    uri: "mongodb://root:password@localhost:27017/operator-fabric?authSource=admin"
+    uri: "mongodb://root:password@localhost:27017/operator-fabric?authSource=admin" #use for test environment only
   servicesUrls:
     authToken: "http://127.0.0.1:2002/auth/token"
     users: "http://127.0.0.1:2103"
@@ -16,7 +16,7 @@ operatorfabric:
     cardsConsultation: "http://127.0.0.1:2104"
   internalAccount:
     login: opfab
-    password: test
+    password: test # use for test environment only
   logConfig:
     logFolder: logs/
     logFile: "%DATE%.log"

--- a/services/businessconfig/src/main/resources/application.yml
+++ b/services/businessconfig/src/main/resources/application.yml
@@ -29,8 +29,6 @@ operatorfabric:
     host: rabbitmq
     port: 5672
     username: guest
-    password: guest   
-
   businessconfig:
     storage:
       path: "/businessconfig-storage"

--- a/services/businessconfig/src/test/resources/application.yml
+++ b/services/businessconfig/src/test/resources/application.yml
@@ -4,5 +4,5 @@ operatorfabric.businessconfig:
 spring:
   data:
     mongodb:
-      uri: mongodb://root:password@localhost:27017/?authSource=admin
+      uri: mongodb://root:password@localhost:27017/?authSource=admin #use for test environment only
       database: operator-fabric-test

--- a/services/cards-consultation/src/main/resources/application.yml
+++ b/services/cards-consultation/src/main/resources/application.yml
@@ -30,4 +30,3 @@ operatorfabric:
     host: rabbitmq
     port: 5672
     username: guest
-    password: guest

--- a/services/cards-consultation/src/test/resources/application.yml
+++ b/services/cards-consultation/src/test/resources/application.yml
@@ -1,5 +1,5 @@
 spring:
   data:
     mongodb:
-      uri: mongodb://root:password@localhost:27017/?authSource=admin
+      uri: mongodb://root:password@localhost:27017/?authSource=admin #use for test environment only
       database: operator-fabric-test

--- a/services/cards-publication/src/main/resources/application.yml
+++ b/services/cards-publication/src/main/resources/application.yml
@@ -38,7 +38,6 @@ operatorfabric:
     host: rabbitmq
     port: 5672
     username: guest
-    password: guest
   servicesUrls:
     users: "http://users:2103"
     businessconfig: "http://businessconfig:2100"

--- a/services/external-devices/src/main/resources/application.yml
+++ b/services/external-devices/src/main/resources/application.yml
@@ -26,7 +26,6 @@ operatorfabric:
     host: rabbitmq
     port: 5672
     username: guest
-    password: guest
   servicesUrls:
     businessconfig: "businessconfig:2100"
     users: "http://users:2103"

--- a/services/users/src/main/resources/application.yml
+++ b/services/users/src/main/resources/application.yml
@@ -25,5 +25,4 @@ operatorfabric:
     host: rabbitmq
     port: 5672
     username: guest
-    password: guest
 

--- a/src/docs/asciidoc/resources/index.adoc
+++ b/src/docs/asciidoc/resources/index.adoc
@@ -55,3 +55,5 @@ include::migration_guide_to_4.6.adoc[leveloffset=+1]
 include::migration_guide_to_4.7.adoc[leveloffset=+1]
 
 include::migration_guide_to_4.9.adoc[leveloffset=+1]
+
+include::migration_guide_to_4.10.adoc[leveloffset=+1]

--- a/src/docs/asciidoc/resources/migration_guide_to_4.10.adoc
+++ b/src/docs/asciidoc/resources/migration_guide_to_4.10.adoc
@@ -52,6 +52,7 @@ code to use the new structure.
 To be consistent, the timeline domain J has been renamed D (Day).
 So if necessary, you have to update your config file `web-ui.json`, replacing value `J` with `D` in the field
 `feed.timeline.domains`, for example :
+
 ----
  "timeline": {
    "domains": [
@@ -64,5 +65,22 @@ So if necessary, you have to update your config file `web-ui.json`, replacing va
    ]
  }
 ----
+
+
+== RabbitMQ configuration
+
+
+In previous version, a default password was set for RabbitMQ connection if no password was provided in configuration. Using the default password was considered as acceptable as the rabbit server was not suppose to be accessible from outside the docker network and a security advice was present in the docker compose file. 
+
+Starting from this version, no default password is set anymore in the services configuration to mitigate security risk by forcing user to set a password. 
+
+So you must provide a password :
+
+- in your docker compose configuration file via the env variable RABBITMQ_DEFAULT_PASS. 
+- in your yaml common configuration file via the property `operatorfabric.rabbitmq.password`
+
+If you do not provide any password, the application will not start and an error message will be logged.
+
+
 
 

--- a/src/main/docker/test-environment/docker-compose.yml
+++ b/src/main/docker/test-environment/docker-compose.yml
@@ -5,4 +5,4 @@ services:
       - "27017:27017"
     environment:
       MONGO_INITDB_ROOT_USERNAME: root
-      MONGO_INITDB_ROOT_PASSWORD: password
+      MONGO_INITDB_ROOT_PASSWORD: password #use for test environment only

--- a/src/main/docker/test-quality-environment/docker-compose.yml
+++ b/src/main/docker/test-quality-environment/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       - "27017:27017"
     environment:
       MONGO_INITDB_ROOT_USERNAME: root
-      MONGO_INITDB_ROOT_PASSWORD: password
+      MONGO_INITDB_ROOT_PASSWORD: password #use for test environment only
   sonarqube:
     image: sonarqube:latest
     ports:

--- a/src/test/resources/deleteAllUserActionLogs.sh
+++ b/src/test/resources/deleteAllUserActionLogs.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (c) 2022-2024, RTE (http://www.rte-france.com)
+# Copyright (c) 2022-2025, RTE (http://www.rte-france.com)
 # See AUTHORS.txt
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -18,5 +18,5 @@ then
 	url="http://localhost"
 fi
 (
-	docker exec "$(docker ps --format "{{.Names}}" | grep "mongodb")" bash -c "mongosh mongodb://root:password@localhost:27017/?authSource=admin --eval \"db=db.getSiblingDB('operator-fabric'); db['userActionLogs'].drop();\""
+	docker exec "$(docker ps --format "{{.Names}}" | grep "mongodb")" bash -c "mongosh mongodb://root:password@localhost:27017/?authSource=admin --eval \"db=db.getSiblingDB('operator-fabric'); db['userActionLogs'].drop();\"" #use for test environment only
 )

--- a/src/test/resources/mongodump.sh
+++ b/src/test/resources/mongodump.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (c) 2023, RTE (http://www.rte-france.com)
+# Copyright (c) 2023-2025, RTE (http://www.rte-france.com)
 # See AUTHORS.txt
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -11,4 +11,4 @@
 # This starts by moving to the directory where the script is located so the paths below still work even if the script
 # is called from another folder
 
-docker exec -i mongodb mongodump --username=root --password=password
+docker exec -i mongodb mongodump --username=root --password=password #use for test environment only

--- a/src/test/resources/mongorestore.sh
+++ b/src/test/resources/mongorestore.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (c) 2023, RTE (http://www.rte-france.com)
+# Copyright (c) 2023-2025, RTE (http://www.rte-france.com)
 # See AUTHORS.txt
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -12,4 +12,4 @@
 # This starts by moving to the directory where the script is located so the paths below still work even if the script
 # is called from another folder
 
-docker exec -it mongodb mongorestore --drop -u root -p password 
+docker exec -it mongodb mongorestore --drop -u root -p password #use for test environment only


### PR DESCRIPTION
and add comment warnings for default passwords in configuration files

- In release notes :
  -  In chapter :   Tasks
  -  Text : #8899 Remove default rabbit password from services 