### PR TITLE
Typo errors : set "lue ou acquittée" instead of "lu ou acquitté" (#8981)

### DIFF
--- a/ui/main/src/assets/i18n/fr.json
+++ b/ui/main/src/assets/i18n/fr.json
@@ -34,7 +34,7 @@
             "selectStateText": "Sélectionner un État",
             "selectTagText": "Sélectionner une Étiquette",
             "selectEntityText": "Sélectionner une Entité",
-            "selectReadAndAckText": "Sélectionner si lu ou acquitté",
+            "selectReadAndAckText": "Sélectionner si lue ou acquittée",
             "selectTypeOfStateText": "Sélectionner un État de processus",
             "toDateBeforeFromDate": "La date 'Jusqu'à' doit être postérieure à la date 'À partir de'.",
             "businessDateRange": "PÉRIODE MÉTIER",


### PR DESCRIPTION
I propose to add nothing in release notes.