### PR TITLE
Admin screen : id of group exceeds the width of its column sometimes (#8909)

### DIFF
--- a/frontend/src/app/components/admin/components/table/AdminTableDirective.ts
+++ b/frontend/src/app/components/admin/components/table/AdminTableDirective.ts
@@ -196,7 +196,11 @@ export abstract class AdminTableDirective implements OnDestroy {
             const columnDef = {
                 type: field.type,
                 headerName: i18nPrefixForHeader + field.name,
-                field: field.name
+                field: field.name,
+                cellStyle: {
+                    whiteSpace: 'normal',
+                    wordBreak: 'break-word'
+                }
             };
             if (field.flex) columnDef['flex'] = field.flex;
             if (field.cellRendererName) columnDef['cellRenderer'] = field.cellRendererName;


### PR DESCRIPTION
- In release notes :
  -  In chapter :  Bugs 
  -  Text : #8909 : Admin screen : id of group exceeds the width of its column sometimes