### PR TITLE
Fix sonarcloud issue : Node.js built-in modules should be imported using the "node:" protocol javascript:S7772

### DIFF
--- a/cli/src/configCommands.js
+++ b/cli/src/configCommands.js
@@ -9,7 +9,7 @@
 
 const os = require('node:os');
 const fs = require('node:fs');
-const path = require('path');
+const path = require('node:path');
 const JSON5 = require('json5');
 
 const config = {

--- a/frontend/src/karma.conf.js
+++ b/frontend/src/karma.conf.js
@@ -27,7 +27,7 @@ module.exports = function (config) {
             clearContext: false // leave Jasmine Spec Runner output visible in browser
         },
         coverageIstanbulReporter: {
-            dir: require('path').join(__dirname, '../reports/coverage'),
+            dir: require('node:path').join(__dirname, '../reports/coverage'),
             reports: ['html', 'lcovonly'],
             fixWebpackSourcePaths: true
         },


### PR DESCRIPTION
Nothing in release note
