### PR TITLE
Fix sonarcloud issue : "tabIndex" should only be declared on interactive elements.

### DIFF
--- a/frontend/src/app/components/admin/components/editmodal/entities/EditEntityModalComponent.html
+++ b/frontend/src/app/components/admin/components/editmodal/entities/EditEntityModalComponent.html
@@ -93,7 +93,7 @@
                             @for (label of labels.value; track label; let i = $index) {
                             <div class="label-chip">
                                 {{ label }}
-                                <span tabindex="0" (click)="removeLabel(i)" (keydown.enter)="removeLabel(i)"> x </span>
+                                <span (click)="removeLabel(i)" (keydown.enter)="removeLabel(i)"> x </span>
                             </div>
                             }
                             <input


### PR DESCRIPTION
Nothing in release note