### PR TITLE
Notification configuration: add thicker red line to the “mail not activated” icon (#9565)

### DIFF
--- a/frontend/src/app/components/notificationconfiguration/NotificationConfigurationComponent.scss
+++ b/frontend/src/app/components/notificationconfiguration/NotificationConfigurationComponent.scss
@@ -1,4 +1,4 @@
-/* Copyright (c) 2018-2025, RTE (http://www.rte-france.com)
+/* Copyright (c) 2018-2026, RTE (http://www.rte-france.com)
  * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -52,7 +52,7 @@
 }
 
 .opfab-notificationconfiguration-slash {
-    height: 1px;
+    height: 3px;
     transform: rotate(-35deg) translateY(3px) translateX(2px);
     display: inline-block;
     background: red;


### PR DESCRIPTION
nothing in release notes.