### PR TITLE
Move configuration parameters operatorfabric.emailGateway.defaultConfig.* to operatorfabric.emailGateway.defaultConfig.outgoingEmails (#9592)

### DIFF
--- a/backend/email-gateway/config/default-docker.yml
+++ b/backend/email-gateway/config/default-docker.yml
@@ -21,24 +21,25 @@ operatorfabric:
     adminPort: 2106
     activeOnStartup: true
     defaultConfig:
-      subjectPrefix: 'Opfab card received '
-      bodyPrefix: 'You received a card in opfab : '
-      bodyPostfix: 'This email has been sent by Opfab, there is no need to reply.'
-      publisherEntityPrefix: 'The card has been sent by '
-      dailyEmailTitle: 'Cards received during the day'
-      weeklyEmailTitle: 'Cards received during the week'
-      dailyEmailBodyPrefix: 'You received the following cards during the past 24 hours : '
-      weeklyEmailBodyPrefix: 'You received the following cards during the past 7 days : '
-      dayOfWeekToSendWeeklyRecapEmail: 1
-      hourToSendRecapEmail: 7
-      minuteToSendRecapEmail: 30
-      opfabUrlInMailContent: http://localhost:2002
-      windowInSecondsForCardSearch: 360
-      checkPeriodInSeconds: 10
-      activateCardsDiffusionRateLimiter: true
-      sendRateLimit: 100
-      sendRateLimitPeriodInSec : 3600
-      defaultTimeZone: 'Europe/Paris'
-      showCardUrls: true
-      forceEmailsInPlainText: false
-      showCardTitleInBody: true
+      outgoingEmails:
+        subjectPrefix: 'Opfab card received '
+        bodyPrefix: 'You received a card in opfab : '
+        bodyPostfix: 'This email has been sent by Opfab, there is no need to reply.'
+        publisherEntityPrefix: 'The card has been sent by '
+        dailyEmailTitle: 'Cards received during the day'
+        weeklyEmailTitle: 'Cards received during the week'
+        dailyEmailBodyPrefix: 'You received the following cards during the past 24 hours : '
+        weeklyEmailBodyPrefix: 'You received the following cards during the past 7 days : '
+        dayOfWeekToSendWeeklyRecapEmail: 1
+        hourToSendRecapEmail: 7
+        minuteToSendRecapEmail: 30
+        opfabUrlInMailContent: http://localhost:2002
+        windowInSecondsForCardSearch: 360
+        checkPeriodInSeconds: 10
+        activateCardsDiffusionRateLimiter: true
+        sendRateLimit: 100
+        sendRateLimitPeriodInSec : 3600
+        defaultTimeZone: 'Europe/Paris'
+        showCardUrls: true
+        forceEmailsInPlainText: false
+        showCardTitleInBody: true

--- a/backend/email-gateway/config/default.yml
+++ b/backend/email-gateway/config/default.yml
@@ -37,28 +37,29 @@ operatorfabric:
     activeOnStartup: true
     customHandlebarsHelpersFile: config/customHandlebarsHelpersExample.js
     defaultConfig:
-      mailFrom: opfab@localhost.it
-      subjectPrefix: 'Opfab card received '
-      bodyPrefix: 'You received a card in opfab : '
-      bodyPostfix: 'This email has been sent by Opfab, there is no need to reply.'
-      publisherEntityPrefix: 'The card has been sent by '
-      dailyEmailTitle: 'Cards received during the day'
-      weeklyEmailTitle: 'Cards received during the week'
-      dailyEmailBodyPrefix: 'You received the following cards during the past 24 hours'
-      weeklyEmailBodyPrefix: 'You received the following cards during the past 7 days'
-      dayOfWeekToSendWeeklyRecapEmail: 1
-      hourToSendRecapEmail: 7
-      minuteToSendRecapEmail: 30
-      opfabUrlInMailContent: http://localhost:2002
-      windowInSecondsForCardSearch: 360
-      checkPeriodInSeconds: 10
-      activateCardsDiffusionRateLimiter: true
-      sendRateLimit: 100
-      sendRateLimitPeriodInSec : 3600
-      defaultTimeZone: 'Europe/Paris'
-      showCardUrls: true
-      forceEmailsInPlainText: false
-      showCardTitleInBody: true
-      customConfig: 
-        customParam1 : 'myValue1'
-        customParam2 : 'myValue2'
+      outgoingEmails:
+        mailFrom: opfab@localhost.it
+        subjectPrefix: 'Opfab card received '
+        bodyPrefix: 'You received a card in opfab : '
+        bodyPostfix: 'This email has been sent by Opfab, there is no need to reply.'
+        publisherEntityPrefix: 'The card has been sent by '
+        dailyEmailTitle: 'Cards received during the day'
+        weeklyEmailTitle: 'Cards received during the week'
+        dailyEmailBodyPrefix: 'You received the following cards during the past 24 hours'
+        weeklyEmailBodyPrefix: 'You received the following cards during the past 7 days'
+        dayOfWeekToSendWeeklyRecapEmail: 1
+        hourToSendRecapEmail: 7
+        minuteToSendRecapEmail: 30
+        opfabUrlInMailContent: http://localhost:2002
+        windowInSecondsForCardSearch: 360
+        checkPeriodInSeconds: 10
+        activateCardsDiffusionRateLimiter: true
+        sendRateLimit: 100
+        sendRateLimitPeriodInSec : 3600
+        defaultTimeZone: 'Europe/Paris'
+        showCardUrls: true
+        forceEmailsInPlainText: false
+        showCardTitleInBody: true
+        customConfig: 
+          customParam1 : 'myValue1'
+          customParam2 : 'myValue2'

--- a/backend/email-gateway/src/domain/application/realTimeCardsDiffusionControl.ts
+++ b/backend/email-gateway/src/domain/application/realTimeCardsDiffusionControl.ts
@@ -8,7 +8,7 @@
  */
 
 import CardsRoutingUtilities from './cardRoutingUtilities';
-import ConfigDTO from '../client-side/configDTO';
+import OutgoingEmailsConfigDTO from '../client-side/outgoingEmailsConfigDTO';
 import CardsDiffusionRateLimiter from './cardsDiffusionRateLimiter';
 import CardsDiffusionControl from './cardsDiffusionControl';
 import {UserWithPerimeters} from './userWithPerimeter';
@@ -67,7 +67,7 @@ export default class RealTimeCardsDiffusionControl extends CardsDiffusionControl
         return this;
     }
 
-    public setConfiguration(updated: ConfigDTO): void {
+    public setConfiguration(updated: OutgoingEmailsConfigDTO): void {
         this.from = updated.mailFrom;
         this.subjectPrefix = updated.subjectPrefix;
         this.bodyPrefix = updated.bodyPrefix;

--- a/backend/email-gateway/src/domain/application/recapCardsDiffusionControl.ts
+++ b/backend/email-gateway/src/domain/application/recapCardsDiffusionControl.ts
@@ -8,7 +8,7 @@
  */
 
 import CardsRoutingUtilities from './cardRoutingUtilities';
-import ConfigDTO from '../client-side/configDTO';
+import OutgoingEmailsConfigDTO from '../client-side/outgoingEmailsConfigDTO';
 import CardsDiffusionControl from './cardsDiffusionControl';
 import {UserWithPerimeters} from './userWithPerimeter';
 import {Card} from './card';
@@ -51,7 +51,7 @@ export default class RecapCardsDiffusionControl extends CardsDiffusionControl {
         return this;
     }
 
-    public setConfiguration(updated: ConfigDTO): void {
+    public setConfiguration(updated: OutgoingEmailsConfigDTO): void {
         this.from = updated.mailFrom;
         this.dailyEmailTitle = updated.dailyEmailTitle;
         this.weeklyEmailTitle = updated.weeklyEmailTitle;

--- a/backend/email-gateway/src/domain/client-side/configDTO.ts
+++ b/backend/email-gateway/src/domain/client-side/configDTO.ts
@@ -7,28 +7,8 @@
  * This file is part of the OperatorFabric project.
  */
 
+import OutgoingEmailsConfigDTO from './outgoingEmailsConfigDTO';
+
 export default class ConfigDTO {
-    public mailFrom: string;
-    public subjectPrefix: string;
-    public bodyPrefix: string;
-    public bodyPostfix: string;
-    public publisherEntityPrefix: string;
-    public dailyEmailTitle: string;
-    public weeklyEmailTitle: string;
-    public dailyEmailBodyPrefix: string;
-    public weeklyEmailBodyPrefix: string;
-    public dayOfWeekToSendWeeklyRecapEmail: 0;
-    public hourToSendRecapEmail: 0;
-    public minuteToSendRecapEmail: 0;
-    public opfabUrlInMailContent: string;
-    public windowInSecondsForCardSearch = 0;
-    public checkPeriodInSeconds = 0;
-    public activateCardsDiffusionRateLimiter: boolean;
-    public sendRateLimit = 100;
-    public sendRateLimitPeriodInSec = 3600;
-    public defaultTimeZone: string;
-    public customConfig: any;
-    public showCardUrls: boolean;
-    public forceEmailsInPlainText: boolean;
-    public showCardTitleInBody: boolean;
+    public outgoingEmails: OutgoingEmailsConfigDTO;
 }

--- a/backend/email-gateway/src/domain/client-side/configService.ts
+++ b/backend/email-gateway/src/domain/client-side/configService.ts
@@ -8,6 +8,7 @@
  */
 
 import ConfigDTO from './configDTO';
+import OutgoingEmailsConfigDTO from './outgoingEmailsConfigDTO';
 
 import fs from 'node:fs';
 
@@ -25,29 +26,33 @@ export default class ConfigService {
                 this.loadFromFile();
             } else {
                 this.config = new ConfigDTO();
+                this.config.outgoingEmails = new OutgoingEmailsConfigDTO();
 
-                this.config.mailFrom = defaultConfig.mailFrom;
-                this.config.hourToSendRecapEmail = defaultConfig.hourToSendRecapEmail;
-                this.config.minuteToSendRecapEmail = defaultConfig.minuteToSendRecapEmail;
-                this.config.dayOfWeekToSendWeeklyRecapEmail = defaultConfig.dayOfWeekToSendWeeklyRecapEmail;
-                this.config.dailyEmailTitle = defaultConfig.dailyEmailTitle;
-                this.config.weeklyEmailTitle = defaultConfig.weeklyEmailTitle;
-                this.config.dailyEmailBodyPrefix = defaultConfig.dailyEmailBodyPrefix;
-                this.config.weeklyEmailBodyPrefix = defaultConfig.weeklyEmailBodyPrefix;
-                this.config.subjectPrefix = defaultConfig.subjectPrefix;
-                this.config.bodyPrefix = defaultConfig.bodyPrefix;
-                this.config.bodyPostfix = defaultConfig.bodyPostfix;
-                this.config.publisherEntityPrefix = defaultConfig.publisherEntityPrefix;
-                this.config.opfabUrlInMailContent = defaultConfig.opfabUrlInMailContent;
-                this.config.windowInSecondsForCardSearch = defaultConfig.windowInSecondsForCardSearch;
-                this.config.checkPeriodInSeconds = defaultConfig.checkPeriodInSeconds;
-                this.config.activateCardsDiffusionRateLimiter = defaultConfig.activateCardsDiffusionRateLimiter;
-                this.config.sendRateLimit = defaultConfig.sendRateLimit;
-                this.config.sendRateLimitPeriodInSec = defaultConfig.sendRateLimitPeriodInSec;
-                this.config.customConfig = defaultConfig.customConfig;
-                this.config.showCardUrls = defaultConfig.showCardUrls;
-                this.config.forceEmailsInPlainText = defaultConfig.forceEmailsInPlainText;
-                this.config.showCardTitleInBody = defaultConfig.showCardTitleInBody;
+                this.config.outgoingEmails.mailFrom = defaultConfig?.mailFrom;
+                this.config.outgoingEmails.hourToSendRecapEmail = defaultConfig?.hourToSendRecapEmail;
+                this.config.outgoingEmails.minuteToSendRecapEmail = defaultConfig?.minuteToSendRecapEmail;
+                this.config.outgoingEmails.dayOfWeekToSendWeeklyRecapEmail =
+                    defaultConfig?.dayOfWeekToSendWeeklyRecapEmail;
+                this.config.outgoingEmails.dailyEmailTitle = defaultConfig?.dailyEmailTitle;
+                this.config.outgoingEmails.weeklyEmailTitle = defaultConfig?.weeklyEmailTitle;
+                this.config.outgoingEmails.dailyEmailBodyPrefix = defaultConfig?.dailyEmailBodyPrefix;
+                this.config.outgoingEmails.weeklyEmailBodyPrefix = defaultConfig?.weeklyEmailBodyPrefix;
+                this.config.outgoingEmails.subjectPrefix = defaultConfig?.subjectPrefix;
+                this.config.outgoingEmails.bodyPrefix = defaultConfig?.bodyPrefix;
+                this.config.outgoingEmails.bodyPostfix = defaultConfig?.bodyPostfix;
+                this.config.outgoingEmails.publisherEntityPrefix = defaultConfig?.publisherEntityPrefix;
+                this.config.outgoingEmails.opfabUrlInMailContent = defaultConfig?.opfabUrlInMailContent;
+                this.config.outgoingEmails.windowInSecondsForCardSearch = defaultConfig?.windowInSecondsForCardSearch;
+                this.config.outgoingEmails.checkPeriodInSeconds = defaultConfig?.checkPeriodInSeconds;
+                this.config.outgoingEmails.activateCardsDiffusionRateLimiter =
+                    defaultConfig?.activateCardsDiffusionRateLimiter;
+                this.config.outgoingEmails.sendRateLimit = defaultConfig?.sendRateLimit;
+                this.config.outgoingEmails.sendRateLimitPeriodInSec = defaultConfig?.sendRateLimitPeriodInSec;
+                this.config.outgoingEmails.customConfig = defaultConfig?.customConfig;
+                this.config.outgoingEmails.showCardUrls = defaultConfig?.showCardUrls;
+                this.config.outgoingEmails.forceEmailsInPlainText = defaultConfig?.forceEmailsInPlainText;
+                this.config.outgoingEmails.showCardTitleInBody = defaultConfig?.showCardTitleInBody;
+                this.config.outgoingEmails.defaultTimeZone = defaultConfig?.defaultTimeZone;
                 this.save();
             }
         } catch (err) {
@@ -76,8 +81,8 @@ export default class ConfigService {
     public patch(update: object): ConfigDTO {
         try {
             for (const [key, value] of Object.entries(update)) {
-                if (Object.hasOwn(this.config, key) && value != null) {
-                    (this.config as any)[key] = value;
+                if (Object.hasOwn(this.config.outgoingEmails, key) && value != null) {
+                    (this.config.outgoingEmails as any)[key] = value;
                 }
             }
             this.save();

--- a/backend/email-gateway/src/domain/client-side/emailGatewayService.ts
+++ b/backend/email-gateway/src/domain/client-side/emailGatewayService.ts
@@ -38,58 +38,58 @@ export default class EmailGatewayService {
         logger: any
     ) {
         this.logger = logger;
-        this.checkPeriodInSeconds = serviceConfig.checkPeriodInSeconds;
-        this.hourToSendRecapEmail = serviceConfig.hourToSendRecapEmail;
-        this.minuteToSendRecapEmail = serviceConfig.minuteToSendRecapEmail;
-        this.dayOfWeekToSendWeeklyRecapEmail = serviceConfig.dayOfWeekToSendWeeklyRecapEmail;
+        this.checkPeriodInSeconds = serviceConfig.outgoingEmails.checkPeriodInSeconds;
+        this.hourToSendRecapEmail = serviceConfig.outgoingEmails.hourToSendRecapEmail;
+        this.minuteToSendRecapEmail = serviceConfig.outgoingEmails.minuteToSendRecapEmail;
+        this.dayOfWeekToSendWeeklyRecapEmail = serviceConfig.outgoingEmails.dayOfWeekToSendWeeklyRecapEmail;
 
         this.recapCardsDiffusionControl = new RecapCardsDiffusionControl()
             .setLogger(logger)
-            .setOpfabUrlInMailContent(serviceConfig.opfabUrlInMailContent)
+            .setOpfabUrlInMailContent(serviceConfig.outgoingEmails.opfabUrlInMailContent)
             .setOpfabServicesInterface(opfabServicesInterface)
             .setOpfabBusinessConfigServicesInterface(opfabBusinessConfigServicesInterface)
             .setEmailGatewayDatabaseService(emailGatewayDatabaseService)
             .setMailService(mailService)
-            .setDailyEmailTitle(serviceConfig.dailyEmailTitle as string)
-            .setWeeklyEmailTitle(serviceConfig.weeklyEmailTitle as string)
-            .setDailyEmailBodyPrefix(serviceConfig.dailyEmailBodyPrefix as string)
-            .setWeeklyEmailBodyPrefix(serviceConfig.weeklyEmailBodyPrefix as string)
-            .setBodyPostfix(serviceConfig.bodyPostfix as string)
-            .setFrom(serviceConfig.mailFrom as string)
-            .setDefaultTimeZone((serviceConfig.defaultTimeZone as string) ?? 'Europe/Paris')
-            .setShowCardUrls(serviceConfig.showCardUrls ?? true)
-            .setForceEmailsInPlainText(serviceConfig.forceEmailsInPlainText ?? false);
+            .setDailyEmailTitle(serviceConfig.outgoingEmails.dailyEmailTitle as string)
+            .setWeeklyEmailTitle(serviceConfig.outgoingEmails.weeklyEmailTitle as string)
+            .setDailyEmailBodyPrefix(serviceConfig.outgoingEmails.dailyEmailBodyPrefix as string)
+            .setWeeklyEmailBodyPrefix(serviceConfig.outgoingEmails.weeklyEmailBodyPrefix as string)
+            .setBodyPostfix(serviceConfig.outgoingEmails.bodyPostfix as string)
+            .setFrom(serviceConfig.outgoingEmails.mailFrom as string)
+            .setDefaultTimeZone((serviceConfig.outgoingEmails.defaultTimeZone as string) ?? 'Europe/Paris')
+            .setShowCardUrls(serviceConfig.outgoingEmails.showCardUrls ?? true)
+            .setForceEmailsInPlainText(serviceConfig.outgoingEmails.forceEmailsInPlainText ?? false);
 
         this.realTimeCardsDiffusionControl = new RealTimeCardsDiffusionControl()
             .setLogger(logger)
-            .setOpfabUrlInMailContent(serviceConfig.opfabUrlInMailContent)
+            .setOpfabUrlInMailContent(serviceConfig.outgoingEmails.opfabUrlInMailContent)
             .setOpfabServicesInterface(opfabServicesInterface)
             .setOpfabBusinessConfigServicesInterface(opfabBusinessConfigServicesInterface)
             .setEmailGatewayDatabaseService(emailGatewayDatabaseService)
             .setMailService(mailService)
-            .setFrom(serviceConfig.mailFrom as string)
-            .setSubjectPrefix(serviceConfig.subjectPrefix as string)
-            .setBodyPrefix(serviceConfig.bodyPrefix as string)
-            .setBodyPostfix(serviceConfig.bodyPostfix as string)
-            .setPublisherEntityPrefix(serviceConfig.publisherEntityPrefix as string)
-            .setWindowInSecondsForCardSearch(serviceConfig.windowInSecondsForCardSearch as number)
-            .setDefaultTimeZone((serviceConfig.defaultTimeZone as string) ?? 'Europe/Paris')
-            .setCustomConfig(serviceConfig.customConfig)
-            .setShowCardUrls(serviceConfig.showCardUrls ?? true)
-            .setForceEmailsInPlainText(serviceConfig.forceEmailsInPlainText ?? false)
-            .setShowCardTitleInBody(serviceConfig.showCardTitleInBody ?? true);
+            .setFrom(serviceConfig.outgoingEmails.mailFrom as string)
+            .setSubjectPrefix(serviceConfig.outgoingEmails.subjectPrefix as string)
+            .setBodyPrefix(serviceConfig.outgoingEmails.bodyPrefix as string)
+            .setBodyPostfix(serviceConfig.outgoingEmails.bodyPostfix as string)
+            .setPublisherEntityPrefix(serviceConfig.outgoingEmails.publisherEntityPrefix as string)
+            .setWindowInSecondsForCardSearch(serviceConfig.outgoingEmails.windowInSecondsForCardSearch as number)
+            .setDefaultTimeZone((serviceConfig.outgoingEmails.defaultTimeZone as string) ?? 'Europe/Paris')
+            .setCustomConfig(serviceConfig.outgoingEmails.customConfig)
+            .setShowCardUrls(serviceConfig.outgoingEmails.showCardUrls ?? true)
+            .setForceEmailsInPlainText(serviceConfig.outgoingEmails.forceEmailsInPlainText ?? false)
+            .setShowCardTitleInBody(serviceConfig.outgoingEmails.showCardTitleInBody ?? true);
 
-        if (serviceConfig.activateCardsDiffusionRateLimiter) {
+        if (serviceConfig.outgoingEmails.activateCardsDiffusionRateLimiter) {
             this.logger.info(
                 'Activating cards diffusion rate limiter with send rate limit of ' +
-                    serviceConfig.sendRateLimit +
+                    serviceConfig.outgoingEmails.sendRateLimit +
                     ' mails per recipients per ' +
-                    serviceConfig.sendRateLimitPeriodInSec +
+                    serviceConfig.outgoingEmails.sendRateLimitPeriodInSec +
                     ' seconds'
             );
             const cardsDiffusionRateLimiter = new CardsDiffusionRateLimiter()
-                .setLimitPeriodInSec(serviceConfig.sendRateLimitPeriodInSec as number)
-                .setSendRateLimit(serviceConfig.sendRateLimit as number);
+                .setLimitPeriodInSec(serviceConfig.outgoingEmails.sendRateLimitPeriodInSec as number)
+                .setSendRateLimit(serviceConfig.outgoingEmails.sendRateLimit as number);
             this.realTimeCardsDiffusionControl.setCardsDiffusionRateLimiter(cardsDiffusionRateLimiter);
             this.realTimeCardsDiffusionControl.setActivateCardsDiffusionRateLimiter(true);
         }
@@ -100,10 +100,11 @@ export default class EmailGatewayService {
     }
 
     setConfiguration(serviceConfig: ConfigDTO): this {
-        if (serviceConfig.checkPeriodInSeconds != null) this.checkPeriodInSeconds = serviceConfig.checkPeriodInSeconds;
+        if (serviceConfig.outgoingEmails.checkPeriodInSeconds != null)
+            this.checkPeriodInSeconds = serviceConfig.outgoingEmails.checkPeriodInSeconds;
 
-        this.realTimeCardsDiffusionControl.setConfiguration(serviceConfig);
-        this.recapCardsDiffusionControl.setConfiguration(serviceConfig);
+        this.realTimeCardsDiffusionControl.setConfiguration(serviceConfig.outgoingEmails);
+        this.recapCardsDiffusionControl.setConfiguration(serviceConfig.outgoingEmails);
         return this;
     }
 

--- a/backend/email-gateway/src/domain/client-side/outgoingEmailsConfigDTO.ts
+++ b/backend/email-gateway/src/domain/client-side/outgoingEmailsConfigDTO.ts
@@ -1,0 +1,34 @@
+/* Copyright (c) 2023-2026, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
+ */
+
+export default class OutgoingEmailsConfigDTO {
+    public mailFrom: string;
+    public subjectPrefix: string;
+    public bodyPrefix: string;
+    public bodyPostfix: string;
+    public publisherEntityPrefix: string;
+    public dailyEmailTitle: string;
+    public weeklyEmailTitle: string;
+    public dailyEmailBodyPrefix: string;
+    public weeklyEmailBodyPrefix: string;
+    public dayOfWeekToSendWeeklyRecapEmail: 0;
+    public hourToSendRecapEmail: 0;
+    public minuteToSendRecapEmail: 0;
+    public opfabUrlInMailContent: string;
+    public windowInSecondsForCardSearch = 0;
+    public checkPeriodInSeconds = 0;
+    public activateCardsDiffusionRateLimiter: boolean;
+    public sendRateLimit = 100;
+    public sendRateLimitPeriodInSec = 3600;
+    public defaultTimeZone: string;
+    public customConfig: any;
+    public showCardUrls: boolean;
+    public forceEmailsInPlainText: boolean;
+    public showCardTitleInBody: boolean;
+}

--- a/backend/email-gateway/src/emailGateway.ts
+++ b/backend/email-gateway/src/emailGateway.ts
@@ -51,7 +51,7 @@ const logger = getLogger();
 const activeOnStartUp = config.get('operatorfabric.emailGateway.activeOnStartup');
 
 const configService = new ConfigService(
-    config.get('operatorfabric.emailGateway.defaultConfig'),
+    config.get('operatorfabric.emailGateway.defaultConfig.outgoingEmails'),
     'config/serviceConfig.json',
     logger
 );

--- a/backend/email-gateway/src/tests/configService.test.ts
+++ b/backend/email-gateway/src/tests/configService.test.ts
@@ -10,12 +10,12 @@
 import 'jest';
 import {getLogger} from '../common/server-side/logger';
 import ConfigService from '../domain/client-side/configService';
-import ConfigDTO from '../domain/client-side/configDTO';
+import OutgoingEmailsConfigDTO from '../domain/client-side/outgoingEmailsConfigDTO';
 
 const logger = getLogger();
 
-function getDefaultConfig(): ConfigDTO {
-    const defaultConfig = new ConfigDTO();
+function getDefaultConfig(): OutgoingEmailsConfigDTO {
+    const defaultConfig = new OutgoingEmailsConfigDTO();
     defaultConfig.checkPeriodInSeconds = 30;
     defaultConfig.subjectPrefix = 'Mail subject prefix';
 
@@ -26,19 +26,19 @@ describe('config service', function () {
     it('Update config params ', async function () {
         const defaultConfig = getDefaultConfig();
         const configService = new ConfigService(defaultConfig, null, logger);
-        expect(configService.getConfig().checkPeriodInSeconds).toEqual(30);
-        expect(configService.getConfig().subjectPrefix).toEqual('Mail subject prefix');
+        expect(configService.getConfig().outgoingEmails.checkPeriodInSeconds).toEqual(30);
+        expect(configService.getConfig().outgoingEmails.subjectPrefix).toEqual('Mail subject prefix');
 
         const confUpdate = {checkPeriodInSeconds: 60};
 
         configService.patch(confUpdate);
-        expect(configService.getConfig().checkPeriodInSeconds).toEqual(60);
-        expect(configService.getConfig().subjectPrefix).toEqual('Mail subject prefix');
+        expect(configService.getConfig().outgoingEmails.checkPeriodInSeconds).toEqual(60);
+        expect(configService.getConfig().outgoingEmails.subjectPrefix).toEqual('Mail subject prefix');
 
         const updateSubjexctPrefix = {subjectPrefix: 'NEW Mail subject prefix'};
         configService.patch(updateSubjexctPrefix);
-        expect(configService.getConfig().checkPeriodInSeconds).toEqual(60);
-        expect(configService.getConfig().subjectPrefix).toEqual('NEW Mail subject prefix');
+        expect(configService.getConfig().outgoingEmails.checkPeriodInSeconds).toEqual(60);
+        expect(configService.getConfig().outgoingEmails.subjectPrefix).toEqual('NEW Mail subject prefix');
     });
 
     it('Wrong config params are ignored', async function () {
@@ -48,7 +48,7 @@ describe('config service', function () {
         const confUpdate = {checkPeriodInSeconds: 10, wrongParam: 5};
 
         configService.patch(confUpdate);
-        expect(configService.getConfig().checkPeriodInSeconds).toEqual(10);
-        expect(configService.getConfig().subjectPrefix).toEqual('Mail subject prefix');
+        expect(configService.getConfig().outgoingEmails.checkPeriodInSeconds).toEqual(10);
+        expect(configService.getConfig().outgoingEmails.subjectPrefix).toEqual('Mail subject prefix');
     });
 });

--- a/config/services/email-gateway.yml
+++ b/config/services/email-gateway.yml
@@ -8,14 +8,15 @@ operatorfabric:
         pass: guest # !!! TO BE CHANGED THIS IS ONLY FOR TEST AND DEMONSTRATION !!!
     customHandlebarsHelpersFile: config/customHandlebarsHelpersExample.js
     defaultConfig:
-      mailFrom: opfab@localhost.it
-      subjectPrefix: 'Opfab card received '
-      bodyPrefix: 'You received a card in opfab : '
-      bodyPostfix: 'This email has been sent by Opfab, there is no need to reply.'
-      publisherEntityPrefix: 'The card has been sent by '
-      opfabUrlInMailContent: http://localhost:2002
-      showCardUrls: true
-      forceEmailsInPlainText: false
-      showCardTitleInBody: true
+      outgoingEmails:
+        mailFrom: opfab@localhost.it
+        subjectPrefix: 'Opfab card received '
+        bodyPrefix: 'You received a card in opfab : '
+        bodyPostfix: 'This email has been sent by Opfab, there is no need to reply.'
+        publisherEntityPrefix: 'The card has been sent by '
+        opfabUrlInMailContent: http://localhost:2002
+        showCardUrls: true
+        forceEmailsInPlainText: false
+        showCardTitleInBody: true
 #  logConfig:
 #    logLevel: debug

--- a/docs/asciidoc/deployment/configuration/configuration.adoc
+++ b/docs/asciidoc/deployment/configuration/configuration.adoc
@@ -57,7 +57,6 @@ A rabbitMQ component (docker image) is provided in opfab, it has a default confi
 
 ==== Internal account 
 
-
 The backend services cards-reminder, email-gateway, and supervision need an internal account to communicate between opfab back services. Therefore, if you intend to utilize any of these services, it is necessary to create an Opfab technical account with ADMIN permissions and configure it
 |===
 |Name|Default|Mandatory|Description
@@ -394,28 +393,28 @@ The email gateway service can be configured with the following properties:
 |operatorfabric.emailGateway.adminPort|2106|no|Listen port
 |operatorfabric.emailGateway.activeOnStartup|true|no|Flag to start the notification service on startup
 |operatorfabric.emailGateway.customHandlebarsHelpersFile||no|Path to a javascript file containing custom Handlebars helpers to be used in email templates
-|operatorfabric.emailGateway.defaultConfig.mailFrom||yes|Mail from address
-|operatorfabric.emailGateway.defaultConfig.dailyEmailTitle|'Cards received during the day'|no|Daily mail subject title
-|operatorfabric.emailGateway.defaultConfig.weeklyEmailTitle|'Cards received during the week'|no|Weekly mail subject title
-|operatorfabric.emailGateway.defaultConfig.dailyEmailBodyPrefix|'You received the following cards during the past 24 hours : '|no|Daily email body prefix
-|operatorfabric.emailGateway.defaultConfig.weeklyEmailBodyPrefix|'You received the following cards during the past 7 days : '|no|Weekly email body prefix
-|operatorfabric.emailGateway.defaultConfig.dayOfWeekToSendWeeklyRecapEmail|1|no|Day of the week to send the weekly recap emails (0 is Sunday, 6 is Saturday)
-|operatorfabric.emailGateway.defaultConfig.hourToSendRecapEmail|7|no|Hour at which to send the recap emails
-|operatorfabric.emailGateway.defaultConfig.minuteToSendRecapEmail|30|no|Minute at which to send the recap emails
-|operatorfabric.emailGateway.defaultConfig.subjectPrefix|'Opfab card received'|no|Mail subject prefix
-|operatorfabric.emailGateway.defaultConfig.bodyPrefix|'You received a card in opfab : '|no|Mail body prefix
-|operatorfabric.emailGateway.defaultConfig.bodyPostfix|'This email has been sent by Opfab, there is no need to reply.'|no|Mail body postfix
-|operatorfabric.emailGateway.defaultConfig.publisherEntityPrefix|'The card has been sent by '|no|Publisher entity text prefix
-|operatorfabric.emailGateway.defaultConfig.opfabUrlInMailContent||yes|Url to write in mail to access the opfab server (example : https://opfab_url/)
-|operatorfabric.emailGateway.defaultConfig.windowInSecondsForCardSearch|360|no|Max time interval used to query new cards (in seconds)
-|operatorfabric.emailGateway.defaultConfig.checkPeriodInSeconds|10|no|Time interval between consecutive checks
-|operatorfabric.emailGateway.defaultConfig.activateCardsDiffusionRateLimiter|true|no|Flag to activate mail sending rate limiting
-|operatorfabric.emailGateway.defaultConfig.sendRateLimit|100|no|Max number of mail sent allowed for a single destination in the configured period
-|operatorfabric.emailGateway.defaultConfig.sendRateLimitPeriodInSec|3600|no|Time period for rate limiting control
-|operatorfabric.emailGateway.defaultConfig.defaultTimeZone|Europe/Paris|no|Default timezone used to display dates and times for email notifications if user has not set the timezone for mail in his settings
-|operatorfabric.emailGateway.defaultConfig.showCardUrls|true|no|Flag to set whether the URL of the card should be displayed in email notifications
-|operatorfabric.emailGateway.defaultConfig.forceEmailsInPlainText|false|no|Flag to set whether the emails must be sent in plain text (regardless of user configuration in settings)
-|operatorfabric.emailGateway.defaultConfig.showCardTitleInBody|true|no|Flag to set whether the body of the emails must include the card title or not. This only concerns real time email sending and not the recapitulatory emails
+|operatorfabric.emailGateway.defaultConfig.outgoingEmails.mailFrom||yes|Mail from address
+|operatorfabric.emailGateway.defaultConfig.outgoingEmails.dailyEmailTitle|'Cards received during the day'|no|Daily mail subject title
+|operatorfabric.emailGateway.defaultConfig.outgoingEmails.weeklyEmailTitle|'Cards received during the week'|no|Weekly mail subject title
+|operatorfabric.emailGateway.defaultConfig.outgoingEmails.dailyEmailBodyPrefix|'You received the following cards during the past 24 hours : '|no|Daily email body prefix
+|operatorfabric.emailGateway.defaultConfig.outgoingEmails.weeklyEmailBodyPrefix|'You received the following cards during the past 7 days : '|no|Weekly email body prefix
+|operatorfabric.emailGateway.defaultConfig.outgoingEmails.dayOfWeekToSendWeeklyRecapEmail|1|no|Day of the week to send the weekly recap emails (0 is Sunday, 6 is Saturday)
+|operatorfabric.emailGateway.defaultConfig.outgoingEmails.hourToSendRecapEmail|7|no|Hour at which to send the recap emails
+|operatorfabric.emailGateway.defaultConfig.outgoingEmails.minuteToSendRecapEmail|30|no|Minute at which to send the recap emails
+|operatorfabric.emailGateway.defaultConfig.outgoingEmails.subjectPrefix|'Opfab card received'|no|Mail subject prefix
+|operatorfabric.emailGateway.defaultConfig.outgoingEmails.bodyPrefix|'You received a card in opfab : '|no|Mail body prefix
+|operatorfabric.emailGateway.defaultConfig.outgoingEmails.bodyPostfix|'This email has been sent by Opfab, there is no need to reply.'|no|Mail body postfix
+|operatorfabric.emailGateway.defaultConfig.outgoingEmails.publisherEntityPrefix|'The card has been sent by '|no|Publisher entity text prefix
+|operatorfabric.emailGateway.defaultConfig.outgoingEmails.opfabUrlInMailContent||yes|Url to write in mail to access the opfab server (example : https://opfab_url/)
+|operatorfabric.emailGateway.defaultConfig.outgoingEmails.windowInSecondsForCardSearch|360|no|Max time interval used to query new cards (in seconds)
+|operatorfabric.emailGateway.defaultConfig.outgoingEmails.checkPeriodInSeconds|10|no|Time interval between consecutive checks
+|operatorfabric.emailGateway.defaultConfig.outgoingEmails.activateCardsDiffusionRateLimiter|true|no|Flag to activate mail sending rate limiting
+|operatorfabric.emailGateway.defaultConfig.outgoingEmails.sendRateLimit|100|no|Max number of mail sent allowed for a single destination in the configured period
+|operatorfabric.emailGateway.defaultConfig.outgoingEmails.sendRateLimitPeriodInSec|3600|no|Time period for rate limiting control
+|operatorfabric.emailGateway.defaultConfig.outgoingEmails.defaultTimeZone|Europe/Paris|no|Default timezone used to display dates and times for email notifications if user has not set the timezone for mail in his settings
+|operatorfabric.emailGateway.defaultConfig.outgoingEmails.showCardUrls|true|no|Flag to set whether the URL of the card should be displayed in email notifications
+|operatorfabric.emailGateway.defaultConfig.outgoingEmails.forceEmailsInPlainText|false|no|Flag to set whether the emails must be sent in plain text (regardless of user configuration in settings)
+|operatorfabric.emailGateway.defaultConfig.outgoingEmails.showCardTitleInBody|true|no|Flag to set whether the body of the emails must include the card title or not. This only concerns real time email sending and not the recapitulatory emails
 |===
 
 The parameters in "operatorfabric.emailGateway.defaultConfig" section can be modified at runtime by sending an http POST request to the `/config` API of email gateway service with a JSON payload containing the config parameters to be changed.

--- a/docs/asciidoc/resources/migration_guide_to_4.12.adoc
+++ b/docs/asciidoc/resources/migration_guide_to_4.12.adoc
@@ -96,6 +96,32 @@ operatorfabric:
         pass: guest
 ----
 
+Furthermore, email configuration parameters under `defaultConfig` have been reorganized under an `outgoingEmails` section:
+
+Replace
+----
+operatorfabric:
+  emailGateway:
+    defaultConfig:
+      mailFrom: opfab@localhost.it
+      subjectPrefix: 'Opfab card received '
+      bodyPrefix: 'You received a card in opfab : '
+      # ... other email config
+----
+
+With
+
+----
+operatorfabric:
+  emailGateway:
+    defaultConfig:
+      outgoingEmails:
+        mailFrom: opfab@localhost.it
+        subjectPrefix: 'Opfab card received '
+        bodyPrefix: 'You received a card in opfab : '
+        # ... other email config
+----
+
 === MongoDB collection name
 
 The MongoDB collection name has changed:


### PR DESCRIPTION
- In release notes :
  -  In chapter : Tasks
  -  Text : `#9592  Move configuration parameters operatorfabric.emailGateway.defaultConfig.* to operatorfabric.emailGateway.defaultConfig.outgoingEmails 
` 
