### PR TITLE
Load dashboard conf via registerCustomScreen instead of web-ui.json (#9765)

### DIFF
--- a/config/web-ui/externalJs/DashboardExample.js
+++ b/config/web-ui/externalJs/DashboardExample.js
@@ -1,0 +1,48 @@
+/* Copyright (c) 2026, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
+ */
+
+{
+    console.log(new Date().toISOString(), 'INFO Dashboard example loaded');
+    const dashboardExample = {
+        "id": "dashboard",
+        "name": "Dashboard",
+        "type": "DASHBOARD",
+        "processCustomLinks": [
+            {
+                "processId": "defaultProcess",
+                "customLinks": [
+                    {
+                        "label": "Custom screen",
+                        "customScreenId": "testId"
+                    },
+                    {
+                        "label": "Custom screen 2",
+                        "customScreenId": "testId2"
+                    }
+                ]
+            }
+        ],
+        "processStateRedirects": [
+            {
+                "processId": "defaultProcess",
+                "stateId": "chartLineState",
+                "menuId": "uid_test_0",
+                "urlExtension": "?search=chart&fulltext=1"
+            },
+            {
+                "processId": "defaultProcess",
+                "stateId": "questionState",
+                "screenId": "testId"
+            }
+        ]
+    };
+
+    opfab.businessconfig.registerCustomScreen(dashboardExample);
+
+}

--- a/config/web-ui/ui-config/web-ui-base.json
+++ b/config/web-ui/ui-config/web-ui-base.json
@@ -181,35 +181,6 @@
   "customCssToLoad": ["http://localhost:2002/externalCss/externalStyle.css"],
   "customJsToLoad": ["http://localhost:2002/externalJs/handlebarsExample.js",
         "http://localhost:2002/externalJs/loadTags.js",
-        "http://localhost:2002/externalJs/CustomScreenExample.js"],
-  "dashboard": {
-        "processCustomLinks": [
-            {
-            "processId": "defaultProcess",
-            "customLinks": [
-                    {
-                        "label": "Custom screen",
-                        "customScreenId": "testId"
-                    },
-                    {
-                        "label": "Custom screen 2",
-                        "customScreenId": "testId2"
-                    }
-                ]
-            }
-        ],
-        "processStateRedirects": [
-            {
-            "processId": "defaultProcess",
-            "stateId": "chartLineState",
-            "menuId": "uid_test_0",
-            "urlExtension": "?search=chart&fulltext=1"
-            },
-            {
-            "processId": "defaultProcess",
-            "stateId": "questionState",
-            "screenId": "testId"
-            }
-        ]
-  }
+        "http://localhost:2002/externalJs/CustomScreenExample.js",
+        "http://localhost:2002/externalJs/DashboardExample.js"]
 }

--- a/docs/asciidoc/deployment/configuration/web-ui_configuration.adoc
+++ b/docs/asciidoc/deployment/configuration/web-ui_configuration.adoc
@@ -72,47 +72,6 @@ For example adding `Keycloak` application, with `'Keycloak'` as `name`, `1` as `
 
 |customJsToLoad||no|List of URLs of javascript files to be loaded at startup
 
-|dashboard.processStateRedirects||no| Declares if a state when clicked in the dashboard should redirect to a custom menu or custom screen. If nothing is specified the redirection is pointing to the card feed. Here is a declaration with one redirection to a custom menu and one to a custom screen. The ids declared should match the ones in the ui-menu config.
-[source, json]
-----
-"dashboard": {
-    "processStateRedirects": [
-      {
-        "processId": "defaultProcess",
-        "stateId": "chartLineState",
-        "menuId": "uid_test_0",
-        "urlExtension": "?search=chart&fulltext=1"
-      },
-      {
-        "processId": "defaultProcess",
-        "stateId": "questionState",
-        "screenId": "testId"
-      }
-    ]
-  }
-----
-
-|dashboard.processCustomLinks||no| Declares a list of link to show under the states of processes.Here is a declaration with two links  to custom screens.
-[source, json]
-----
-  "dashboard": {
-        "processCustomLinks": [
-            { 
-            "processId": "defaultProcess",
-            "customLinks": [
-                    {
-                        "label": "Custom screen",
-                        "customScreenId": "testId"
-                    },
-                    {
-                        "label": "Custom screen 2",
-                        "customScreenId": "testId2"
-                    }
-                ]
-            }
-        ]
-  }
-----
 |dateRangePickerConfig|default|no|Specifies the mode for the date range picker configuration. The default mode can be changed to "ahead", which displays three predefined periods: W-1 (Week ahead), M-1 (Month ahead), and Y-1 (Year ahead) for the date range picker across all screens.
 |defaultEntryPage|feed|no|This configuration determines the default page that will be displayed after a user logs in. The possible values include all core menus, with the exception of 'usercard' and 'about'. Additionally, you can set a custom application as the entry page by using 'businessconfigparty/menuId' as the value.
 |environmentColor|blue|no| Color of the background of the environment name. The format of color is css, for example : `red` , `#4052FF`

--- a/docs/asciidoc/reference_doc/ui_customization.adoc
+++ b/docs/asciidoc/reference_doc/ui_customization.adoc
@@ -718,6 +718,136 @@ results: {
 For each configured severity, a column will be exported (but not shown in the UI) with the entities that responded with that severity.These columns are only present in the export, not in the UI.
 
 
+== Dashboard screen
+
+The dashboard screen presents the number of cards per process and state. To the right of each state, bubbles display the number of visible cards by severity.
+
+An optional configuration can be loaded via a call to the `opfab.businessconfig.registerCustomScreen` method, to be defined in a JavaScript file loaded at startup.
+
+Two types of configuration are available for the dashboard:
+
+=== processStateRedirects
+
+This configuration allows you to define custom redirections when clicking on a state in the dashboard. If not specified, clicking on a state redirects to the card feed filtered by the selected process and state.
+
+You can redirect to:
+
+* A custom menu (URL-based link) using `menuId` and optionally `urlExtension`
+* A custom screen using `screenId`
+
+The IDs declared must match those defined in the UI menu configuration.
+
+.Example with redirections to a custom menu and a custom screen
+[source, json]
+----
+"processStateRedirects": [
+  {
+    "processId": "defaultProcess",
+    "stateId": "chartLineState",
+    "menuId": "uid_test_0",
+    "urlExtension": "?search=chart&fulltext=1"
+  },
+  {
+    "processId": "defaultProcess",
+    "stateId": "questionState",
+    "screenId": "testId"
+  }
+]
+----
+
+=== processCustomLinks
+
+This configuration allows you to define custom links that appear below the states for each process in the dashboard. These links typically point to custom screens.
+
+Each link requires:
+
+* `label`: The text displayed for the link
+* `customScreenId`: The ID of the custom screen to open
+
+.Example with two custom screen links
+[source, json]
+----
+"processCustomLinks": [
+  {
+    "processId": "defaultProcess",
+    "customLinks": [
+      {
+        "label": "Custom screen",
+        "customScreenId": "testId"
+      },
+      {
+        "label": "Custom screen 2",
+        "customScreenId": "testId2"
+      }
+    ]
+  }
+]
+----
+
+=== Loading the configuration
+
+To apply the dashboard configuration, you need to:
+
+1. Create a JavaScript file containing your dashboard definition
+2. Register it using the `opfab.businessconfig.registerCustomScreen` method
+3. Load this file at application startup
+
+.Complete example combining both processCustomLinks and processStateRedirects
+[source, javascript]
+----
+{
+    const dashboardExample = {
+        id: "dashboard",
+        name: "Dashboard",
+        type: "DASHBOARD",
+        processCustomLinks: [
+            {
+                processId: "defaultProcess",
+                customLinks: [
+                    {
+                        label: "Custom screen",
+                        customScreenId: "testId"
+                    },
+                    {
+                        label: "Custom screen 2",
+                        customScreenId: "testId2"
+                    }
+                ]
+            }
+        ],
+        processStateRedirects: [
+            {
+                processId: "defaultProcess",
+                stateId: "chartLineState",
+                menuId: "uid_test_0",
+                urlExtension: "?search=chart&fulltext=1"
+            },
+            {
+                processId: "defaultProcess",
+                stateId: "questionState",
+                screenId: "testId"
+            }
+        ]
+    };
+
+    opfab.businessconfig.registerCustomScreen(dashboardExample);
+}
+----
+
+Then, declare this file in `web-ui.json` to load it at startup:
+
+[source, json]
+----
+{
+  "customJsToLoad": [
+    "/externalJs/DashboardExample.js"
+  ]
+}
+----
+
+NOTE: The custom screen IDs referenced in `processCustomLinks` and `processStateRedirects` must match the IDs of custom screens registered via `opfab.businessconfig.registerCustomScreen` or custom menu IDs defined in the UI menu configuration.
+
+
 == Customizing browser notification sounds
 
 The sounds used by default by the browser to signal a card of a given severity

--- a/docs/asciidoc/resources/migration_guide_to_4.12.adoc
+++ b/docs/asciidoc/resources/migration_guide_to_4.12.adoc
@@ -250,3 +250,95 @@ These endpoints are used internally by the OperatorFabric web UI and are not typ
 === Impact on custom integrations
 
 If you have custom code or scripts calling these endpoints directly, you must update them to use the new request format. The OperatorFabric web UI, CLI, and internal services have all been updated to use the new format.
+
+
+== Dashboard configuration 
+
+In previous versions, dashboard configuration was managed via the `web-ui.json` config file. Starting from version 4.12, it is now handled programmatically using the `opfab.businessconfig.registerCustomScreen` method.
+
+For example, instead of the following configuration in `web-ui.json`:
+
+```
+  "dashboard": {
+        "processCustomLinks": [
+            {
+            "processId": "defaultProcess",
+            "customLinks": [
+                    {
+                        "label": "Custom screen",
+                        "customScreenId": "testId"
+                    },
+                    {
+                        "label": "Custom screen 2",
+                        "customScreenId": "testId2"
+                    }
+                ]
+            }
+        ],
+        "processStateRedirects": [
+            {
+            "processId": "defaultProcess",
+            "stateId": "chartLineState",
+            "menuId": "uid_test_0",
+            "urlExtension": "?search=chart&fulltext=1"
+            },
+            {
+            "processId": "defaultProcess",
+            "stateId": "questionState",
+            "screenId": "testId"
+            }
+        ]
+  }
+```
+
+You now need to create a JavaScript file like this:
+
+```
+{
+    const dashboardExample = {
+        "id": "dashboard",
+        "name": "Dashboard",
+        "type": "DASHBOARD",
+        "processCustomLinks": [
+            {
+                "processId": "defaultProcess",
+                "customLinks": [
+                    {
+                        "label": "Custom screen",
+                        "customScreenId": "testId"
+                    },
+                    {
+                        "label": "Custom screen 2",
+                        "customScreenId": "testId2"
+                    }
+                ]
+            }
+        ],
+        "processStateRedirects": [
+            {
+                "processId": "defaultProcess",
+                "stateId": "chartLineState",
+                "menuId": "uid_test_0",
+                "urlExtension": "?search=chart&fulltext=1"
+            },
+            {
+                "processId": "defaultProcess",
+                "stateId": "questionState",
+                "screenId": "testId"
+            }
+        ]
+    };
+
+    opfab.businessconfig.registerCustomScreen(dashboardExample);
+
+}
+```  
+
+Then, load this file at startup by declaring it in `web-ui.json`, for example:
+
+```
+  "customJsToLoad": [
+        "/externalJs/DashboardExample.js",
+        ....]
+```
+

--- a/frontend/src/app/components/dashboard/DashboardComponent.ts
+++ b/frontend/src/app/components/dashboard/DashboardComponent.ts
@@ -1,4 +1,4 @@
-/* Copyright (c) 2023-2025, RTE (http://www.rte-france.com)
+/* Copyright (c) 2023-2026, RTE (http://www.rte-france.com)
  * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -18,6 +18,8 @@ import {TranslateModule} from '@ngx-translate/core';
 import {NgClass} from '@angular/common';
 import {CardComponent} from '../card/CardComponent';
 import {NavigationService} from '@ofServices/navigation/NavigationService';
+import {CustomScreenService} from '@ofServices/customScreen/CustomScreenService';
+import {DashboardScreenDefinition} from '@ofServices/customScreen/model/DashboardScreenDefinition';
 
 declare const opfab: any;
 
@@ -50,7 +52,10 @@ export class DashboardComponent implements OnInit, OnDestroy {
         this.dashboard.getDashboardPage().subscribe((dashboardPage) => (this.dashboardPage = dashboardPage));
         this.hideProcessFilter = ConfigService.getConfigValue('feed.card.hideProcessFilter', false);
         this.hideStateFilter = ConfigService.getConfigValue('feed.card.hideStateFilter', false);
-        this.processStateRedirects = ConfigService.getConfigValue('dashboard.processStateRedirects', []);
+        const dashboardScreenDefinition = CustomScreenService.getCustomScreenDefinition(
+            'dashboard'
+        ) as DashboardScreenDefinition;
+        this.processStateRedirects = dashboardScreenDefinition?.processStateRedirects ?? [];
     }
 
     ngOnDestroy() {

--- a/frontend/src/app/components/dashboard/view/DashboardView.spec.ts
+++ b/frontend/src/app/components/dashboard/view/DashboardView.spec.ts
@@ -13,13 +13,16 @@ import {ComputedPerimeter, UserWithPerimeters} from '@ofServices/users/model/Use
 import {RightEnum} from '@ofServices/perimeters/model/Perimeter';
 import {OpfabEventStreamServerMock} from '@tests/mocks/opfab-event-stream.server.mock';
 import {OpfabEventStreamService} from '@ofServices/events/OpfabEventStreamService';
-import {getOneLightCard, loadWebUIConf, resetServices, setProcessConfiguration, setUserPerimeter} from '@tests/helpers';
+import {getOneLightCard, resetServices, setProcessConfiguration, setUserPerimeter} from '@tests/helpers';
 import {firstValueFrom, skip} from 'rxjs';
 import {Severity} from 'app/model/Severity';
 import {Utilities} from '../../../utils/Utilities';
 import {FilterType} from '@ofStore/lightcards/model/Filter';
 import {FilteredLightCardsStore} from '../../../store/lightcards/FilteredLightcardsStore';
 import {OpfabStore} from '../../../store/OpfabStore';
+import {CustomScreenService} from '@ofServices/customScreen/CustomScreenService';
+import {DashboardScreenDefinition} from '@ofServices/customScreen/model/DashboardScreenDefinition';
+import {ScreenType} from '@ofServices/customScreen/model/ScreenDefinition';
 
 async function initProcesses() {
     await setProcessConfiguration([
@@ -60,6 +63,7 @@ describe('Dashboard', () => {
         OpfabEventStreamService.setEventStreamServer(opfabEventStreamServerMock);
         OpfabStore.reset();
         filteredLightCardStore = OpfabStore.getFilteredLightCardStore();
+        CustomScreenService.clearCustomScreenDefinitions();
     });
 
     afterEach(() => {
@@ -113,25 +117,27 @@ describe('Dashboard', () => {
     });
 
     it('GIVEN a process with custom screen links in config WHEN get dashboard THEN dashboard contains links', async () => {
-        await loadWebUIConf({
-            dashboard: {
-                processCustomLinks: [
+        const dashboardScreenDefinition = new DashboardScreenDefinition();
+        dashboardScreenDefinition.id = 'dashboard';
+        dashboardScreenDefinition.name = 'Dashboard';
+        dashboardScreenDefinition.type = ScreenType.DASHBOARD;
+        dashboardScreenDefinition.processCustomLinks = [
+            {
+                processId: 'process1',
+                customLinks: [
                     {
-                        processId: 'process1',
-                        customLinks: [
-                            {
-                                customScreenId: 'testId',
-                                label: 'My link'
-                            },
-                            {
-                                customScreenId: 'testId2',
-                                label: 'My Link 2'
-                            }
-                        ]
+                        customScreenId: 'testId',
+                        label: 'My link'
+                    },
+                    {
+                        customScreenId: 'testId2',
+                        label: 'My Link 2'
                     }
                 ]
             }
-        });
+        ];
+        dashboardScreenDefinition.processStateRedirects = [];
+        CustomScreenService.addCustomScreenDefinition(dashboardScreenDefinition);
 
         await initProcesses();
 
@@ -160,25 +166,27 @@ describe('Dashboard', () => {
     // The two following tests verify that this behavior works as intended.
 
     it('GIVEN a process with custom screen links in config and only a state with isOnlyAChildState = true  WHEN get dashboard THEN dashboard contains links', async () => {
-        await loadWebUIConf({
-            dashboard: {
-                processCustomLinks: [
+        const dashboardScreenDefinition = new DashboardScreenDefinition();
+        dashboardScreenDefinition.id = 'dashboard';
+        dashboardScreenDefinition.name = 'Dashboard';
+        dashboardScreenDefinition.type = ScreenType.DASHBOARD;
+        dashboardScreenDefinition.processCustomLinks = [
+            {
+                processId: 'processWithOnlyChildState',
+                customLinks: [
                     {
-                        processId: 'processWithOnlyChildState',
-                        customLinks: [
-                            {
-                                customScreenId: 'testId',
-                                label: 'My link'
-                            },
-                            {
-                                customScreenId: 'testId2',
-                                label: 'My Link 2'
-                            }
-                        ]
+                        customScreenId: 'testId',
+                        label: 'My link'
+                    },
+                    {
+                        customScreenId: 'testId2',
+                        label: 'My Link 2'
                     }
                 ]
             }
-        });
+        ];
+        dashboardScreenDefinition.processStateRedirects = [];
+        CustomScreenService.addCustomScreenDefinition(dashboardScreenDefinition);
 
         await initProcesses();
 
@@ -201,11 +209,14 @@ describe('Dashboard', () => {
     });
 
     it('Given a process with no custom screen links and only a state with isOnlyAChildState = true  WHEN get dashboard THEN dashboard contains no process', async () => {
-        await loadWebUIConf({
-            dashboard: {
-                processCustomLinks: []
-            }
-        });
+        const dashboardScreenDefinition = new DashboardScreenDefinition();
+        dashboardScreenDefinition.id = 'dashboard';
+        dashboardScreenDefinition.name = 'Dashboard';
+        dashboardScreenDefinition.type = ScreenType.DASHBOARD;
+        dashboardScreenDefinition.processCustomLinks = [];
+        dashboardScreenDefinition.processStateRedirects = [];
+        CustomScreenService.addCustomScreenDefinition(dashboardScreenDefinition);
+
         await initProcesses();
         const computedPerimeters = [
             new ComputedPerimeter('processWithOnlyChildState', 'state1', RightEnum.Receive, true)

--- a/frontend/src/app/components/dashboard/view/DashboardView.ts
+++ b/frontend/src/app/components/dashboard/view/DashboardView.ts
@@ -23,7 +23,8 @@ import {
 import {FilteredLightCardsStore} from '../../../store/lightcards/FilteredLightcardsStore';
 import {OpfabStore} from '../../../store/OpfabStore';
 import {format} from 'date-fns';
-import {ConfigService} from '@ofServices/config/ConfigService';
+import {CustomScreenService} from '@ofServices/customScreen/CustomScreenService';
+import {DashboardScreenDefinition} from '@ofServices/customScreen/model/DashboardScreenDefinition';
 import {Card} from 'app/model/Card';
 
 export class Dashboard {
@@ -35,7 +36,10 @@ export class Dashboard {
     private readonly processesCustomScreenLinks: any;
 
     constructor() {
-        this.processesCustomScreenLinks = ConfigService.getConfigValue('dashboard.processCustomLinks', []);
+        const dashboardScreenDefinition = CustomScreenService.getCustomScreenDefinition(
+            'dashboard'
+        ) as DashboardScreenDefinition;
+        this.processesCustomScreenLinks = dashboardScreenDefinition?.processCustomLinks ?? [];
         this.filteredLightCardStore = OpfabStore.getFilteredLightCardStore();
         this.loadProcesses();
         this.processLightCards();

--- a/frontend/src/app/services/customScreen/model/DashboardScreenDefinition.ts
+++ b/frontend/src/app/services/customScreen/model/DashboardScreenDefinition.ts
@@ -1,0 +1,33 @@
+/* Copyright (c) 2026, RTE (http://www.rte-france.com)
+ * See AUTHORS.txt
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ * This file is part of the OperatorFabric project.
+ */
+
+import {ScreenDefinition} from './ScreenDefinition';
+
+export class DashboardScreenDefinition extends ScreenDefinition {
+    processCustomLinks: ProcessCustomLink[];
+    processStateRedirects: ProcessStateRedirect[];
+}
+
+export interface ProcessCustomLink {
+    processId: string;
+    customLinks: CustomLink[];
+}
+
+export interface CustomLink {
+    label: string;
+    customScreenId: string;
+}
+
+export interface ProcessStateRedirect {
+    processId: string;
+    stateId: string;
+    menuId?: string;
+    urlExtension?: string;
+    screenId?: string;
+}

--- a/frontend/src/app/services/customScreen/model/ScreenDefinition.ts
+++ b/frontend/src/app/services/customScreen/model/ScreenDefinition.ts
@@ -1,4 +1,4 @@
-/* Copyright (c) 2025-2026, RTE (http://www.rte-france.com)
+/* Copyright (c) 2026, RTE (http://www.rte-france.com)
  * See AUTHORS.txt
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -14,5 +14,6 @@ export class ScreenDefinition {
 }
 
 export enum ScreenType {
-    CARD_LIST = 'CARD_LIST'
+    CARD_LIST = 'CARD_LIST',
+    DASHBOARD = 'DASHBOARD'
 }


### PR DESCRIPTION


- In release notes :
  -  In chapter :  Tasks
  -  Text : `#9765  Load dashboard conf via registerCustomScreen instead of web-ui.json` 
