### PR TITLE
Email gateway : add an option to set mail as plain text for a specific process state (#9743)

### DIFF
--- a/backend/businessconfig/src/main/java/org/opfab/businessconfig/model/Email.java
+++ b/backend/businessconfig/src/main/java/org/opfab/businessconfig/model/Email.java
@@ -12,7 +12,10 @@ package org.opfab.businessconfig.model;
 import org.springframework.validation.annotation.Validated;
 
 @Validated
-public record Email(String bodyTemplate, Boolean hideDefaultBodyPrefixAndPostfix, String sender,
-                    String cardFieldUsedForSubject) {
+public record Email(String bodyTemplate,
+                    Boolean hideDefaultBodyPrefixAndPostfix,
+                    String sender,
+                    String cardFieldUsedForSubject,
+                    Boolean bodyInPlainText) {
 
 }

--- a/backend/email-gateway/src/domain/application/outgoing-emails/realTimeCardsDiffusionControl.ts
+++ b/backend/email-gateway/src/domain/application/outgoing-emails/realTimeCardsDiffusionControl.ts
@@ -210,14 +210,17 @@ export default class RealTimeCardsDiffusionControl extends CardsDiffusionControl
                 ) as string;
             }
 
-            if (emailToPlainText) {
+            const stateEmailPlainText = cardConfig?.states?.[stateName]?.email?.bodyInPlainText === true;
+            const sendAsPlainText = emailToPlainText || stateEmailPlainText;
+
+            if (sendAsPlainText) {
                 body = htmlToText(body, {wordwrap: false, selectors: [{selector: 'table', format: 'dataTable'}]});
             }
 
             try {
                 const from = cardConfig?.states?.[stateName]?.email?.sender ?? this.from;
 
-                await this.mailService.sendMail(subject, body, attachment, from, to, emailToPlainText);
+                await this.mailService.sendMail(subject, body, attachment, from, to, sendAsPlainText);
                 this.registerNewSending(to);
                 await this.emailGatewayDatabaseService.persistSentMail(card.uid, to);
             } catch (e) {

--- a/backend/email-gateway/src/tests/realTimeCardsDiffusionControl.test.ts
+++ b/backend/email-gateway/src/tests/realTimeCardsDiffusionControl.test.ts
@@ -228,6 +228,127 @@ describe('Cards external diffusion', function () {
         );
     });
 
+    it('Should send email with body as plain text if email.bodyInPlainText is set to true in state config', async function () {
+        const publishDate = Date.now();
+        setup();
+        opfabServicesInterfaceStub.allUsers = [{login: 'operator_1', entities: ['ENTITY1']}];
+
+        opfabServicesInterfaceStub.usersWithPerimeters = [
+            {
+                userData: {login: 'operator_1', entities: ['ENTITY1']},
+                sendCardsByEmail: true,
+                emailForCardSending: 'operator_1@opfab.com',
+                processesStatesNotifiedByEmail: {defaultProcess: ['processState']},
+                computedPerimeters: perimeters
+            }
+        ];
+
+        opfabBusinessConfigServicesInterfaceStub.config = {
+            id: 'defaultProcess',
+            name: 'Process example',
+            version: '1',
+            states: {
+                processState: {
+                    email: {
+                        bodyTemplate: 'testTemplateMail',
+                        bodyInPlainText: true
+                    }
+                }
+            }
+        };
+
+        databaseServiceStub.cards = [
+            {
+                uid: '1001',
+                id: 'defaultProcess.process1',
+                publisher: 'publisher1',
+                publishDate,
+                startDate: publishDate,
+                titleTranslated: 'Title1',
+                summaryTranslated: 'Summary1',
+                process: 'defaultProcess',
+                state: 'processState',
+                entityRecipients: ['ENTITY1'],
+                processVersion: '1'
+            }
+        ];
+
+        opfabBusinessConfigServicesInterfaceStub.template = '{{card.titleTranslated}} {{config.customParam1}}';
+
+        realTimeCardsDiffusionControl.setForceEmailsInPlainText(false);
+
+        await realTimeCardsDiffusionControl.checkCardsNeedToBeSent();
+        await new Promise((resolve) => setTimeout(resolve, 1));
+
+        expect(mailService.numberOfMailsSent).toEqual(1);
+        expect(mailService.sent[0].fromAddress).toEqual('test@opfab.com');
+        expect(mailService.sent[0].toAddress).toEqual('operator_1@opfab.com');
+
+        expect(mailService.sent[0].body).toEqual(
+            `Prefix Title1 ` +
+                `[ http://localhost/#/feed/cards/${BASE64URL_ENCODED_CARDID} ]` +
+                '\nTitle1 Param1\n\nPostfix'
+        );
+    });
+
+    it('Should send email as HTML when email.bodyInPlainText is not set', async function () {
+        const publishDate = Date.now();
+        setup();
+
+        opfabServicesInterfaceStub.allUsers = [{login: 'operator_1', entities: ['ENTITY1']}];
+
+        opfabServicesInterfaceStub.usersWithPerimeters = [
+            {
+                userData: {login: 'operator_1', entities: ['ENTITY1']},
+                sendCardsByEmail: true,
+                emailForCardSending: 'operator_1@opfab.com',
+                processesStatesNotifiedByEmail: {defaultProcess: ['processState']},
+                computedPerimeters: perimeters
+            }
+        ];
+
+        opfabBusinessConfigServicesInterfaceStub.config = {
+            id: 'defaultProcess',
+            name: 'Process example',
+            version: '1',
+            states: {
+                processState: {
+                    email: {
+                        bodyTemplate: 'testTemplateMail'
+                    }
+                }
+            }
+        };
+
+        databaseServiceStub.cards = [
+            {
+                uid: '1001',
+                id: 'defaultProcess.process1',
+                publisher: 'publisher1',
+                publishDate,
+                startDate: publishDate,
+                titleTranslated: 'Title1',
+                summaryTranslated: 'Summary1',
+                process: 'defaultProcess',
+                state: 'processState',
+                entityRecipients: ['ENTITY1'],
+                processVersion: '1'
+            }
+        ];
+
+        opfabBusinessConfigServicesInterfaceStub.template = '{{card.titleTranslated}} {{config.customParam1}}';
+
+        realTimeCardsDiffusionControl.setForceEmailsInPlainText(false);
+
+        await realTimeCardsDiffusionControl.checkCardsNeedToBeSent();
+        await new Promise((resolve) => setTimeout(resolve, 1));
+
+        expect(mailService.numberOfMailsSent).toEqual(1);
+        expect(mailService.sent[0].body).toEqual(
+            `Prefix <a href=" http://localhost/#/feed/cards/ZGVmYXVsdFByb2Nlc3MucHJvY2VzczE ">Title1</a> <br> Title1 Param1 <br><br>Postfix`
+        );
+    });
+
     it('Body of email should contain publisherEntityPrefix when publisher is an entity', async function () {
         const publishDate = Date.now();
         setup();

--- a/backend/java-common/src/main/java/org/opfab/common/businessconfig/Email.java
+++ b/backend/java-common/src/main/java/org/opfab/common/businessconfig/Email.java
@@ -12,7 +12,10 @@ package org.opfab.common.businessconfig;
 import org.springframework.validation.annotation.Validated;
 
 @Validated
-public record Email(String bodyTemplate, Boolean hideDefaultBodyPrefixAndPostfix, String sender,
-                    String cardFieldUsedForSubject) {
+public record Email(String bodyTemplate,
+                    Boolean hideDefaultBodyPrefixAndPostfix,
+                    String sender,
+                    String cardFieldUsedForSubject,
+                    Boolean bodyInPlainText) {
 
 }

--- a/docs/api/openapi.yml
+++ b/docs/api/openapi.yml
@@ -5631,6 +5631,7 @@
                   "hideDefaultBodyPrefixAndPostfix": { "type": "boolean" },
                   "sender": { "type": "string" },
                   "cardFieldUsedForSubject": { "type": "string" },
+                  "bodyInPlainText": { "type": "boolean" }
                 },
             },
         },

--- a/docs/asciidoc/reference_doc/mail_notification.adoc
+++ b/docs/asciidoc/reference_doc/mail_notification.adoc
@@ -32,7 +32,9 @@ This template can use handlebars helpers for formatting but can't run javascript
 is sent with just the link to the card in the body. +
 In the state definition, you can also set `email.hideDefaultBodyPrefixAndPostfix` to true if you don't want to display the
 default body prefix and postfix. +
+
 You can override the default mail sender using `email.sender` in the state definition. +
+
 You can override the mail subject using `email.cardFieldUsedForSubject`, which references a field in the card, for example:
 ....
 email : {
@@ -45,6 +47,20 @@ email : {
     cardFieldUsedForSubject:"titleTranslated"
 }
 ....
+
+You can force the email body to be sent as plain text instead of HTML by using the `email.bodyInPlainText` parameter in the state definition.
+
+When this parameter is set to `true`, the email body is converted to plain text for this specific state.
+If the parameter is absent or set to `false`, the email is sent using the default HTML format.
+
+Example:
+....
+email: {
+    bodyTemplate: "myTemplate",
+    bodyInPlainText: true
+}
+....
+
 === Email templates
 In email handlebars templates it is possible to refer card fields by prefixing with "card" prefix. For example:
 

--- a/tests/api/karate/businessconfig/getABusinessconfig.feature
+++ b/tests/api/karate/businessconfig/getABusinessconfig.feature
@@ -34,6 +34,7 @@ Feature: Bundle
     And match response.states.messageState.email.hideDefaultBodyPrefixAndPostfix == true
     And match response.states.messageState.email.sender == 'senderOfMail@opfab.com'
     And match response.states.messageState.email.cardFieldUsedForSubject == 'data.mailTitle'
+    And match response.states.messageState.email.bodyInPlainText == true
     And match response.states.messageState.editCardEnabledOnUserInterface == false
     And match response.states.messageState.copyCardEnabledOnUserInterface == false
     And match response.states.messageState.showAcknowledgmentFooter == 'OnlyForEmittingEntity'

--- a/tests/api/karate/businessconfig/resources/bundle_api_test_v2/config.json
+++ b/tests/api/karate/businessconfig/resources/bundle_api_test_v2/config.json
@@ -14,7 +14,8 @@
 				"bodyTemplate" : "email_template",
 				"hideDefaultBodyPrefixAndPostfix" : true,
 				"sender" : "senderOfMail@opfab.com",
-				"cardFieldUsedForSubject" : "data.mailTitle"
+				"cardFieldUsedForSubject" : "data.mailTitle",
+				"bodyInPlainText" : true
 			},
 			"editCardEnabledOnUserInterface": false,
 			"copyCardEnabledOnUserInterface": false,


### PR DESCRIPTION
- In release notes :
  -  In chapter : Features
  -  Text : `#9743 : Email gateway : add an option to set mail as plain text for a specific process state` 
