### PR TITLE
Email gateway : replace hideDefaultBodyPrefixAndPostfix config param …

### DIFF
--- a/backend/businessconfig/src/main/java/org/opfab/businessconfig/model/Email.java
+++ b/backend/businessconfig/src/main/java/org/opfab/businessconfig/model/Email.java
@@ -13,7 +13,7 @@ import org.springframework.validation.annotation.Validated;
 
 @Validated
 public record Email(String bodyTemplate,
-                    Boolean hideDefaultBodyPrefixAndPostfix,
+                    Boolean useOnlyTemplateForBodyRendering,
                     String sender,
                     String cardFieldUsedForSubject,
                     Boolean bodyInPlainText) {

--- a/backend/email-gateway/src/domain/application/outgoing-emails/realTimeCardsDiffusionControl.ts
+++ b/backend/email-gateway/src/domain/application/outgoing-emails/realTimeCardsDiffusionControl.ts
@@ -200,7 +200,7 @@ export default class RealTimeCardsDiffusionControl extends CardsDiffusionControl
                 card.process,
                 card.processVersion
             );
-            body = await this.processEmailTemplate(card, cardConfig, timezone);
+            body = await this.processEmailBodyRendering(card, cardConfig, timezone);
             const attachment = await this.processAttachmentTemplate(card, cardConfig);
 
             if (cardConfig?.states?.[stateName]?.email?.cardFieldUsedForSubject) {
@@ -249,14 +249,34 @@ export default class RealTimeCardsDiffusionControl extends CardsDiffusionControl
     }
 
     async processEmailTemplate(cardContent: Card, cardConfig: any, timezone: string): Promise<string> {
-        const urlOfCard =
-            '<a href=" ' + this.opfabUrlInMailContent + '/#/feed/cards/' + this.base64urlEncode(cardContent.id) + ' ">';
-
         const stateName = cardContent.state;
 
-        let cardBodyHtml = cardConfig?.states?.[stateName]?.email?.hideDefaultBodyPrefixAndPostfix
-            ? ''
-            : this.bodyPrefix + ' ';
+        if (cardConfig?.states?.[stateName]?.email?.bodyTemplate != null) {
+            const templateCompiler = await this.businessConfigOpfabServicesInterface.fetchTemplate(
+                cardContent.process,
+                cardConfig.states[stateName].email.bodyTemplate as string,
+                cardContent.processVersion
+            );
+
+            HandlebarsHelper.timezone = timezone;
+
+            return templateCompiler({card: cardContent, config: this.customConfig});
+        }
+        return '';
+    }
+
+    async processEmailBodyRendering(cardContent: Card, cardConfig: any, timezone: string): Promise<string> {
+        const stateName = cardContent.state;
+        const useOnlyTemplate = cardConfig?.states?.[stateName]?.email?.useOnlyTemplateForBodyRendering === true;
+
+        if (useOnlyTemplate) {
+            return this.processEmailTemplate(cardContent, cardConfig, timezone);
+        }
+
+        const urlOfCard =
+            '<a href="' + this.opfabUrlInMailContent + '/#/feed/cards/' + this.base64urlEncode(cardContent.id) + '">';
+
+        let cardBodyHtml = this.bodyPrefix + ' ';
         cardBodyHtml +=
             (this.showCardUrls ? urlOfCard : '') +
             (this.showCardTitleInBody ? this.escapeHtml(cardContent.titleTranslated) : '') +
@@ -282,7 +302,7 @@ export default class RealTimeCardsDiffusionControl extends CardsDiffusionControl
             const entity = await this.emailGatewayOpfabServicesInterface.getEntityById(cardContent.publisher);
             cardBodyHtml = cardBodyHtml + ' <br><br>' + this.publisherEntityPrefix + entity.name + '.';
         }
-        if (this.bodyPostfix != null && !cardConfig?.states?.[stateName]?.email?.hideDefaultBodyPrefixAndPostfix) {
+        if (this.bodyPostfix != null) {
             cardBodyHtml = cardBodyHtml + ' <br><br>' + this.bodyPostfix;
         }
         return cardBodyHtml;

--- a/backend/email-gateway/src/tests/realTimeCardsDiffusionControl.test.ts
+++ b/backend/email-gateway/src/tests/realTimeCardsDiffusionControl.test.ts
@@ -105,8 +105,7 @@ describe('Cards external diffusion', function () {
         expect(mailService.sent[0].toAddress).toEqual('operator_2@opfab.com');
         expect(mailService.sent[0].subject).toEqual('Subject - Title1');
         expect(mailService.sent[0].body).toEqual(
-            `Prefix <a href=" http://localhost/#/feed/cards/${BASE64URL_ENCODED_CARDID} ">Title1` +
-                '</a> <br><br>Postfix'
+            `Prefix <a href="http://localhost/#/feed/cards/${BASE64URL_ENCODED_CARDID}">Title1` + '</a> <br><br>Postfix'
         );
     });
 
@@ -163,7 +162,7 @@ describe('Cards external diffusion', function () {
         expect(mailService.sent[0].fromAddress).toEqual('test@opfab.com');
         expect(mailService.sent[0].toAddress).toEqual('operator_1@opfab.com');
         expect(mailService.sent[0].body).toEqual(
-            `Prefix <a href=" http://localhost/#/feed/cards/${BASE64URL_ENCODED_CARDID} ">Title1` +
+            `Prefix <a href="http://localhost/#/feed/cards/${BASE64URL_ENCODED_CARDID}">Title1` +
                 '</a> <br> Title1 Param1 <br><br>Postfix'
         );
     });
@@ -223,7 +222,7 @@ describe('Cards external diffusion', function () {
         expect(mailService.sent[0].toAddress).toEqual('operator_1@opfab.com');
         expect(mailService.sent[0].body).toEqual(
             `Prefix Title1 ` +
-                `[ http://localhost/#/feed/cards/${BASE64URL_ENCODED_CARDID} ]` +
+                `[http://localhost/#/feed/cards/${BASE64URL_ENCODED_CARDID}]` +
                 '\nTitle1 Param1\n\nPostfix'
         );
     });
@@ -286,7 +285,7 @@ describe('Cards external diffusion', function () {
 
         expect(mailService.sent[0].body).toEqual(
             `Prefix Title1 ` +
-                `[ http://localhost/#/feed/cards/${BASE64URL_ENCODED_CARDID} ]` +
+                `[http://localhost/#/feed/cards/${BASE64URL_ENCODED_CARDID}]` +
                 '\nTitle1 Param1\n\nPostfix'
         );
     });
@@ -345,7 +344,7 @@ describe('Cards external diffusion', function () {
 
         expect(mailService.numberOfMailsSent).toEqual(1);
         expect(mailService.sent[0].body).toEqual(
-            `Prefix <a href=" http://localhost/#/feed/cards/ZGVmYXVsdFByb2Nlc3MucHJvY2VzczE ">Title1</a> <br> Title1 Param1 <br><br>Postfix`
+            `Prefix <a href="http://localhost/#/feed/cards/ZGVmYXVsdFByb2Nlc3MucHJvY2VzczE">Title1</a> <br> Title1 Param1 <br><br>Postfix`
         );
     });
 
@@ -401,7 +400,7 @@ describe('Cards external diffusion', function () {
 
         expect(mailService.numberOfMailsSent).toEqual(1);
         expect(mailService.sent[0].body).toEqual(
-            `Prefix <a href=" http://localhost/#/feed/cards/${BASE64URL_ENCODED_CARDID} ">Title1 &amp; &lt;br&gt;` +
+            `Prefix <a href="http://localhost/#/feed/cards/${BASE64URL_ENCODED_CARDID}">Title1 &amp; &lt;br&gt;` +
                 '</a> <br> Title1 &amp; &lt;br&gt; <br><br>Sent by ENTITY2 name. <br><br>Postfix'
         );
     });
@@ -457,7 +456,7 @@ describe('Cards external diffusion', function () {
 
         expect(mailService.numberOfMailsSent).toEqual(1);
         expect(mailService.sent[0].body).toEqual(
-            `Prefix <a href=" http://localhost/#/feed/cards/${BASE64URL_ENCODED_CARDID} ">Title1 &amp; &lt;br&gt;` +
+            `Prefix <a href="http://localhost/#/feed/cards/${BASE64URL_ENCODED_CARDID}">Title1 &amp; &lt;br&gt;` +
                 '</a> <br> Title1 &amp; &lt;br&gt; <br><br>Postfix'
         );
     });
@@ -628,12 +627,12 @@ describe('Cards external diffusion', function () {
 
         expect(mailService.numberOfMailsSent).toEqual(1);
         expect(mailService.sent[0].body).toEqual(
-            `Prefix <a href=" http://localhost/#/feed/cards/ZGVmYXVsdFByb2Nlc3MucHJvY2VzczE "></a> ` +
+            `Prefix <a href="http://localhost/#/feed/cards/ZGVmYXVsdFByb2Nlc3MucHJvY2VzczE"></a> ` +
                 '<br> card template <br><br>Postfix'
         );
     });
 
-    it('Body of email should not contain header and footer when hideDefaultBodyPrefixAndPostfix is set to true', async function () {
+    it('Body of email should not contain header and footer when useOnlyTemplateForBodyRendering is set to true', async function () {
         const publishDate = Date.now();
         setup();
         realTimeCardsDiffusionControl.setShowCardUrls(false);
@@ -657,7 +656,7 @@ describe('Cards external diffusion', function () {
                 processState: {
                     email: {
                         bodyTemplate: 'testTemplateMail',
-                        hideDefaultBodyPrefixAndPostfix: true
+                        useOnlyTemplateForBodyRendering: true
                     }
                 }
             }
@@ -685,10 +684,10 @@ describe('Cards external diffusion', function () {
         await new Promise((resolve) => setTimeout(resolve, 1));
 
         expect(mailService.numberOfMailsSent).toEqual(1);
-        expect(mailService.sent[0].body).toEqual(`Title1 &amp; &lt;br&gt; ` + '<br> Title1 &amp; &lt;br&gt;');
+        expect(mailService.sent[0].body).toEqual(`Title1 &amp; &lt;br&gt;`);
     });
 
-    it('Body of email should contain header and footer when hideDefaultBodyPrefixAndPostfix is set to false', async function () {
+    it('Body of email should contain header and footer when useOnlyTemplateForBodyRendering is set to false', async function () {
         const publishDate = Date.now();
         setup();
         realTimeCardsDiffusionControl.setShowCardUrls(false);
@@ -712,7 +711,7 @@ describe('Cards external diffusion', function () {
                 processState: {
                     email: {
                         bodyTemplate: 'testTemplateMail',
-                        hideDefaultBodyPrefixAndPostfix: false
+                        useOnlyTemplateForBodyRendering: false
                     }
                 }
             }
@@ -745,7 +744,7 @@ describe('Cards external diffusion', function () {
         );
     });
 
-    it('Body of email should contain header and footer when hideDefaultBodyPrefixAndPostfix is not in the config', async function () {
+    it('Body of email should contain header and footer when useOnlyTemplateForBodyRendering is not in the config', async function () {
         const publishDate = Date.now();
         setup();
         realTimeCardsDiffusionControl.setShowCardUrls(false);
@@ -801,6 +800,58 @@ describe('Cards external diffusion', function () {
         );
     });
 
+    it('Body of email should be empty when useOnlyTemplateForBodyRendering is true and no template is provided', async function () {
+        const publishDate = Date.now();
+        setup();
+
+        opfabServicesInterfaceStub.allUsers = [{login: 'operator_1', entities: ['ENTITY1']}];
+
+        opfabServicesInterfaceStub.usersWithPerimeters = [
+            {
+                userData: {login: 'operator_1', entities: ['ENTITY1']},
+                sendCardsByEmail: true,
+                emailForCardSending: 'operator_1@opfab.com',
+                processesStatesNotifiedByEmail: {defaultProcess: ['processState']},
+                computedPerimeters: perimeters
+            }
+        ];
+
+        opfabBusinessConfigServicesInterfaceStub.config = {
+            id: 'defaultProcess',
+            name: 'Process example',
+            version: '1',
+            states: {
+                processState: {
+                    email: {
+                        useOnlyTemplateForBodyRendering: true
+                    }
+                }
+            }
+        };
+
+        databaseServiceStub.cards = [
+            {
+                uid: '1001',
+                id: 'defaultProcess.process1',
+                publisher: 'publisher1',
+                publishDate,
+                startDate: publishDate,
+                titleTranslated: 'Title1',
+                summaryTranslated: 'Summary1',
+                process: 'defaultProcess',
+                state: 'processState',
+                entityRecipients: ['ENTITY1'],
+                processVersion: '1'
+            }
+        ];
+
+        await realTimeCardsDiffusionControl.checkCardsNeedToBeSent();
+        await new Promise((resolve) => setTimeout(resolve, 1));
+
+        expect(mailService.numberOfMailsSent).toEqual(1);
+        expect(mailService.sent[0].body).toEqual('');
+    });
+
     it('Sender of email should be the one of the state when sender is defined in the state', async function () {
         const publishDate = Date.now();
         setup();
@@ -825,7 +876,7 @@ describe('Cards external diffusion', function () {
                 processState: {
                     email: {
                         bodyTemplate: 'testTemplateMail',
-                        hideDefaultBodyPrefixAndPostfix: true,
+                        useOnlyTemplateForBodyRendering: true,
                         sender: 'senderForTheState@test.com'
                     }
                 }
@@ -881,7 +932,7 @@ describe('Cards external diffusion', function () {
                 processState: {
                     email: {
                         bodyTemplate: 'testTemplateMail',
-                        hideDefaultBodyPrefixAndPostfix: true,
+                        useOnlyTemplateForBodyRendering: true,
                         sender: 'senderForTheState@test.com',
                         cardFieldUsedForSubject: 'titleTranslated'
                     }
@@ -938,7 +989,7 @@ describe('Cards external diffusion', function () {
                 processState: {
                     email: {
                         bodyTemplate: 'testTemplateMail',
-                        hideDefaultBodyPrefixAndPostfix: true,
+                        useOnlyTemplateForBodyRendering: true,
                         sender: 'senderForTheState@test.com',
                         cardFieldUsedForSubject: 'data.mailTitle'
                     }

--- a/backend/java-common/src/main/java/org/opfab/common/businessconfig/Email.java
+++ b/backend/java-common/src/main/java/org/opfab/common/businessconfig/Email.java
@@ -13,7 +13,7 @@ import org.springframework.validation.annotation.Validated;
 
 @Validated
 public record Email(String bodyTemplate,
-                    Boolean hideDefaultBodyPrefixAndPostfix,
+                    Boolean useOnlyTemplateForBodyRendering,
                     String sender,
                     String cardFieldUsedForSubject,
                     Boolean bodyInPlainText) {

--- a/docs/api/openapi.yml
+++ b/docs/api/openapi.yml
@@ -5628,7 +5628,7 @@
               "properties":
                 {
                   "bodyTemplate": { "type": "string" },
-                  "hideDefaultBodyPrefixAndPostfix": { "type": "boolean" },
+                  "useOnlyTemplateForBodyRendering": { "type": "boolean" },
                   "sender": { "type": "string" },
                   "cardFieldUsedForSubject": { "type": "string" },
                   "bodyInPlainText": { "type": "boolean" }

--- a/docs/asciidoc/reference_doc/mail_notification.adoc
+++ b/docs/asciidoc/reference_doc/mail_notification.adoc
@@ -30,8 +30,25 @@ The email body contains a link to the card details in OpFab. In the config.json 
 the `email.bodyTemplate` field allows defining a template specific to the email body content.
 This template can use handlebars helpers for formatting but can't run javascript. If no template is specified, the mail
 is sent with just the link to the card in the body. +
-In the state definition, you can also set `email.hideDefaultBodyPrefixAndPostfix` to true if you don't want to display the
-default body prefix and postfix. +
+
+In the state definition, you can control how the email body is rendered using the `email.useOnlyTemplateForBodyRendering` parameter.
+
+When set to `true`, only the content generated from the `email.bodyTemplate` is used as the email body.
+The default header (prefix), footer (postfix), and card title/link are not included.
+
+When set to `false` or not defined, the email body is composed of:
+- the default body prefix
+- the card title and/or link (depending on configuration)
+- the content generated from the `email.bodyTemplate`
+- the default body postfix
+
+Example:
+....
+email : {
+    bodyTemplate: "myTemplate",
+    useOnlyTemplateForBodyRendering: true
+}
+....
 
 You can override the default mail sender using `email.sender` in the state definition. +
 

--- a/docs/asciidoc/resources/migration_guide_to_4.12.adoc
+++ b/docs/asciidoc/resources/migration_guide_to_4.12.adoc
@@ -122,6 +122,40 @@ operatorfabric:
         # ... other email config
 ----
 
+=== Email body rendering parameter renamed
+
+The email body rendering parameter has been renamed in state configuration.
+
+Replace the deprecated parameter:
+----
+email: {
+  hideDefaultBodyPrefixAndPostfix: true
+}
+----
+
+With
+
+----
+email: {
+useOnlyTemplateForBodyRendering: true
+}
+----
+
+=== Behavior change
+
+The new parameter `useOnlyTemplateForBodyRendering` provides clearer behavior:
+
+* When set to `true`, only the content generated from `email.bodyTemplate` is used as the email body.
+  The default prefix, postfix, and card title/link are not included.
+
+* When set to `false` or not defined, the email body includes:
+  - the default prefix
+  - the card title and/or link
+  - the rendered template content
+  - the default postfix
+
+Make sure to update your state configurations accordingly, otherwise email content may differ from previous versions.
+
 === MongoDB collection name
 
 The MongoDB collection name has changed:

--- a/tests/api/karate/businessconfig/getABusinessconfig.feature
+++ b/tests/api/karate/businessconfig/getABusinessconfig.feature
@@ -31,7 +31,7 @@ Feature: Bundle
     And match response.states.questionState.showAcknowledgmentFooter == 'OnlyForUsersAllowedToEdit'
     And match response.states.messageState.type == 'CANCELED'
     And match response.states.messageState.email.bodyTemplate == 'email_template'
-    And match response.states.messageState.email.hideDefaultBodyPrefixAndPostfix == true
+    And match response.states.messageState.email.useOnlyTemplateForBodyRendering == true
     And match response.states.messageState.email.sender == 'senderOfMail@opfab.com'
     And match response.states.messageState.email.cardFieldUsedForSubject == 'data.mailTitle'
     And match response.states.messageState.email.bodyInPlainText == true

--- a/tests/api/karate/businessconfig/resources/bundle_api_test_v2/config.json
+++ b/tests/api/karate/businessconfig/resources/bundle_api_test_v2/config.json
@@ -12,7 +12,7 @@
 			"type" : "CANCELED",
 			"email" : {
 				"bodyTemplate" : "email_template",
-				"hideDefaultBodyPrefixAndPostfix" : true,
+				"useOnlyTemplateForBodyRendering" : true,
 				"sender" : "senderOfMail@opfab.com",
 				"cardFieldUsedForSubject" : "data.mailTitle",
 				"bodyInPlainText" : true


### PR DESCRIPTION
- In release notes :
  -  In chapter : Features
  -  Text : `#9736 : Email gateway : replace hideDefaultBodyPrefixAndPostfix config param by useOnlyTemplateForBodyRendering` 
