### PR TITLE
Solve issue : "Not all JDKs and JVMs use the same encoding standard s…

### DIFF
--- a/backend/users/src/main/java/org/opfab/users/configuration/jwt/groups/roles/RoleClaim.java
+++ b/backend/users/src/main/java/org/opfab/users/configuration/jwt/groups/roles/RoleClaim.java
@@ -15,6 +15,7 @@ import org.springframework.security.oauth2.jwt.Jwt;
 
 import jakarta.validation.constraints.NotBlank;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
@@ -88,7 +89,7 @@ public abstract class RoleClaim {
         int payloadIndexInJwt = 1;
         String base64EncodedBody = tokenSplit[payloadIndexInJwt];
 
-        return new String(Base64.getUrlDecoder().decode(base64EncodedBody));
+        return new String(Base64.getUrlDecoder().decode(base64EncodedBody), StandardCharsets.UTF_8);
     }
 
     /**


### PR DESCRIPTION
Solve issue : 

Not all JDKs and JVMs use the same encoding standard since it’s not enforced by the Java language specification, for example if a new server behind a loadbalancer is being used that has an automatic preference for UTF16LE instead of UTF8 this can cause bugs.

Nothing in release note
